### PR TITLE
Kan 183 Add time to usage table

### DIFF
--- a/services/gitauto_handler.py
+++ b/services/gitauto_handler.py
@@ -231,6 +231,6 @@ async def handle_gitauto(payload: GitHubLabeledPayload, trigger_type: str) -> No
         usage_record_id=usage_record_id,
         token_input=token_input,
         token_output=token_output,
-        total_time=int(end_time - current_time),
+        total_seconds=int(end_time - current_time),
     )
     return

--- a/services/supabase/gitauto_manager.py
+++ b/services/supabase/gitauto_manager.py
@@ -17,7 +17,7 @@ class GitAutoAgentManager:
         usage_record_id: int,
         token_input: int,
         token_output: int,
-        total_time: int,
+        total_seconds: int,
     ) -> None:
         """Add agent information to usage record and set is_completed to True."""
         try:
@@ -26,7 +26,7 @@ class GitAutoAgentManager:
                     "is_completed": True,
                     "token_input": token_input,
                     "token_output": token_output,
-                    "total_time": total_time,
+                    "total_seconds": total_seconds,
                 }
             ).eq(column="id", value=usage_record_id).execute()
         except Exception as e:

--- a/tests/services/supabase/test_gitauto_manager.py
+++ b/tests/services/supabase/test_gitauto_manager.py
@@ -62,7 +62,7 @@ def test_create_update_user_request_works() -> None:
             usage_record_id=usage_record_id,
             token_input=1000,
             token_output=100,
-            total_time=100,
+            total_seconds=100,
         )
         is None
     )
@@ -119,7 +119,7 @@ def test_complete_and_update_usage_record_only_updates_one_record() -> None:
             usage_record_id=usage_record_id,
             token_input=1000,
             token_output=100,
-            total_time=100,
+            total_seconds=100,
         )
         is None
     )

--- a/tests/services/supabase/test_users_manager.py
+++ b/tests/services/supabase/test_users_manager.py
@@ -84,7 +84,7 @@ def test_create_and_update_user_request_works() -> None:
             usage_record_id=usage_record_id,
             token_input=1000,
             token_output=100,
-            total_time=100,
+            total_seconds=100,
         )
         is None
     )


### PR DESCRIPTION
https://www.loom.com/share/a26e10b82e284c4893927cd7f0d3228d


Yes, unit of time is seconds.
Db changes: https://github.com/gitautoai/db_changes/pull/6/files


## Testing: 
In the first image we see the record was created at 28 minutes into the hour. And that it has total_seconds. Second picture shows PR is successful and that it was triggered 4 minutes ago at the 18 minute mark.
![image](https://github.com/gitautoai/gitauto/assets/66699290/4253f7fb-7d0c-4f0c-8748-78c7baf8c3dc)
![image](https://github.com/gitautoai/gitauto/assets/66699290/92fc2b6a-ca59-438f-ba66-53a151028cf7)
