### PR TITLE
Issue 178 healy

### DIFF
--- a/config.py
+++ b/config.py
@@ -97,3 +97,4 @@ OWNER_TYPE = "Organization"
 UNIQUE_ISSUE_ID = "O/gitautoai/test#1"
 USER_ID = -1
 USER_NAME = "username-test"
+EMAIL = "test@gitauto.com"

--- a/services/gitauto_handler.py
+++ b/services/gitauto_handler.py
@@ -156,6 +156,7 @@ async def handle_gitauto(payload: GitHubLabeledPayload, trigger_type: str) -> No
         user_id=sender_id,
         installation_id=installation_id,
         unique_issue_id=unique_issue_id,
+        email=email,
     )
     add_reaction_to_issue(
         issue_number=issue_number, content="eyes", base_args=base_args

--- a/services/gitauto_handler.py
+++ b/services/gitauto_handler.py
@@ -4,8 +4,6 @@ import logging
 import time
 from uuid import uuid4
 
-import requests
-
 # Local imports
 from config import (
     EXCEPTION_OWNERS,
@@ -29,6 +27,7 @@ from services.github.github_manager import (
     create_comment,
     update_comment,
     add_reaction_to_issue,
+    get_user_public_email,
 )
 from services.github.github_types import (
     BaseArgs,
@@ -50,20 +49,6 @@ from utils.text_copy import (
 )
 
 supabase_manager = SupabaseManager(url=SUPABASE_URL, key=SUPABASE_SERVICE_ROLE_KEY)
-
-def get_user_public_email(username: str):
-    url = f"https://api.github.com/users/{username}"
-    headers = {
-        "Accept": "application/vnd.github.v3+json"
-    }
-
-    response: requests.Response = requests.get(url, headers=headers)
-    response.raise_for_status()
-    user_data: dict = response.json()
-
-    email: str = user_data.get('email')
-    
-    return email
 
 async def handle_gitauto(payload: GitHubLabeledPayload, trigger_type: str) -> None:
     """Core functionality to create comments on issue, create PRs, and update progress."""

--- a/services/github/github_manager.py
+++ b/services/github/github_manager.py
@@ -829,3 +829,18 @@ def update_comment_for_raised_errors(
     update_comment(comment_url=comment_url, token=token, body=body)
 
     raise RuntimeError("Error occurred")
+
+@handle_exceptions(default_return_value=None, raise_on_error=False)
+def get_user_public_email(username: str):
+    url = f"https://api.github.com/users/{username}"
+    headers = {
+        "Accept": "application/vnd.github.v3+json"
+    }
+
+    response: requests.Response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    user_data: dict = response.json()
+
+    email: str = user_data.get('email')
+    
+    return email

--- a/services/supabase/gitauto_manager.py
+++ b/services/supabase/gitauto_manager.py
@@ -19,6 +19,8 @@ class GitAutoAgentManager:
         token_input: int,
         token_output: int,
         total_seconds: int,
+        user_id: int,
+        email: str,
         is_completed: bool = True,
     ) -> None:
         """Add agent information to usage record and set is_completed to True."""
@@ -30,6 +32,12 @@ class GitAutoAgentManager:
                 "total_seconds": total_seconds,
             }
         ).eq(column="id", value=usage_record_id).execute()
+        
+        self.client.table(table_name="users").update(
+            json={
+                "email": email,
+            },
+        ).eq(column="user_id", value=user_id).execute()
 
     @handle_exceptions(default_return_value=None, raise_on_error=True)
     def create_installation(

--- a/services/supabase/gitauto_manager.py
+++ b/services/supabase/gitauto_manager.py
@@ -49,6 +49,7 @@ class GitAutoAgentManager:
         owner_id: int,
         user_id: int,
         user_name: str,
+        email: str,
     ) -> None:
         """Create owners record with stripe customerId, subscribe to free plan, create installation record, create users record on Installation Webhook event"""
         # If owner doesn't exist in owners table, insert owner and stripe customer
@@ -92,6 +93,7 @@ class GitAutoAgentManager:
             json={
                 "user_id": user_id,
                 "user_name": user_name,
+                "email": email,
             },
             on_conflict="user_id",
         ).execute()

--- a/services/webhook_handler.py
+++ b/services/webhook_handler.py
@@ -14,6 +14,7 @@ from services.github.github_manager import (
     create_comment_on_issue_with_gitauto_button,
     get_installation_access_token,
     # turn_on_issue,
+    get_user_public_email
 )
 from services.github.github_types import (
     GitHubEventPayload,
@@ -38,6 +39,7 @@ async def handle_installation_created(payload: GitHubInstallationPayload) -> Non
     user_id: int = payload["sender"]["id"]
     user_name: str = payload["sender"]["login"]
     token: str = get_installation_access_token(installation_id=installation_id)
+    email: str = get_user_public_email(username=user_name)
 
     # Create installation record in Supabase
     supabase_manager.create_installation(
@@ -47,6 +49,7 @@ async def handle_installation_created(payload: GitHubInstallationPayload) -> Non
         owner_id=owner_id,
         user_id=user_id,
         user_name=user_name,
+        email=email,
     )
 
     # Add issue templates to the repositories

--- a/tests/services/supabase/test_gitauto_manager.py
+++ b/tests/services/supabase/test_gitauto_manager.py
@@ -1,6 +1,6 @@
 # run this file locally with: python -m tests.services.supabase.test_gitauto_manager
 import os
-from config import OWNER_TYPE
+from config import (EMAIL, OWNER_TYPE)
 from services.supabase import SupabaseManager
 from tests.services.supabase.wipe_data import (
     wipe_installation_owner_user_data,
@@ -29,6 +29,8 @@ def test_create_update_user_request_works() -> None:
         owner_id=-1,
         user_id=user_id,
         user_name="test",
+        email=EMAIL,
+        
     )
 
     usage_record_id = supabase_manager.create_user_request(
@@ -36,6 +38,7 @@ def test_create_update_user_request_works() -> None:
         installation_id=installation_id,
         # fake issue creation
         unique_issue_id="U/gitautoai/test#01",
+        email=EMAIL,
     )
     assert isinstance(
         usage_record_id,
@@ -77,6 +80,7 @@ def test_complete_and_update_usage_record_only_updates_one_record() -> None:
         owner_id=-1,
         user_id=user_id,
         user_name="test",
+        email=EMAIL,
     )
 
     # Creating multiple usage records where is_completed = false.
@@ -86,6 +90,7 @@ def test_complete_and_update_usage_record_only_updates_one_record() -> None:
             installation_id=installation_id,
             # fake issue creation
             unique_issue_id="U/gitautoai/test#01",
+            email=EMAIL,
         )
 
     usage_record_id = supabase_manager.create_user_request(
@@ -93,6 +98,7 @@ def test_complete_and_update_usage_record_only_updates_one_record() -> None:
         installation_id=installation_id,
         # fake issue creation
         unique_issue_id="U/gitautoai/test#01",
+        email=EMAIL,
     )
     assert isinstance(
         usage_record_id,

--- a/tests/services/supabase/test_users_manager.py
+++ b/tests/services/supabase/test_users_manager.py
@@ -14,6 +14,7 @@ from config import (
     INSTALLATION_ID,
     UNIQUE_ISSUE_ID,
     NEW_INSTALLATION_ID,
+    EMAIL,
 )
 from services.stripe.customer import get_subscription
 from services.supabase import SupabaseManager
@@ -47,12 +48,14 @@ def test_create_and_update_user_request_works() -> None:
         owner_id=OWNER_ID,
         user_id=USER_ID,
         user_name=USER_NAME,
+        email=EMAIL,
     )
 
     usage_record_id = supabase_manager.create_user_request(
         user_id=USER_ID,
         installation_id=INSTALLATION_ID,
         unique_issue_id="U/gitautoai/nextjs-website#52",
+        email=EMAIL,
     )
     assert isinstance(usage_record_id, int)
     assert (
@@ -83,6 +86,7 @@ def test_how_many_requests_left() -> None:
         owner_id=OWNER_ID,
         user_id=USER_ID,
         user_name=USER_NAME,
+        email=EMAIL,
     )
     # Testing 0 requests have been made on free tier
     requests_left, request_count, end_date = (
@@ -154,6 +158,7 @@ def test_is_users_first_issue() -> None:
         owner_id=OWNER_ID,
         user_id=USER_ID,
         user_name=USER_NAME,
+        email=EMAIL,
     )
     assert supabase_manager.is_users_first_issue(
         user_id=USER_ID, installation_id=INSTALLATION_ID
@@ -189,6 +194,7 @@ def test_parse_subscription_object() -> None:
         owner_id=OWNER_ID,
         user_id=USER_ID,
         user_name=USER_NAME,
+        email=EMAIL,
     )
 
     def assertion_test(customer_id: str, product_id: str):


### PR DESCRIPTION
## What does this PR do?

Makes API request to github API based on username to get email. If email is received, it upserts to users table on installation and updates on create_user_request

## PR checklist

- [X] This PR is related to the issue: [https://gitauto.atlassian.net/jira/software/c/projects/GITAUTO/list?selectedIssue=GITAUTO-178](url)
- [X] This PR includes only changes related to this PR.

## Test Cases

Here is the list of test cases:

- under line 87 in gitauto_handler.py, set the email equal to something else. Then run create create_user_request. Your email address should be updated in the Users table of supabase
- under line 42 in webhook_handler.py, set the email equal to something else. Then run create create_installation. Your email address should be updated in the Users table of supabase

## Evidence

Here is the list of Loom video URL(s):

- [https://www.loom.com/share/348f26f6366245948c71d69238f4f08a](url)
- [https://www.loom.com/share/585e4469134f4f4eb66b2b1fa2d60718](url)

## Environment Variables Setting

Here is the list of configurations and screenshots where we have changes other than code:

- GitHub Actions
- OpenAI Console
- Stripe Admin Console
- Stripe Webhook
- Supabase Admin Console
- Supabase Database
- AWS Lambda Console
- Vercel Hosting Console
- Sentry Console
