### PR TITLE
Replace o1-preview with o1-mini as o1-mini codes better than o1-preview

### DIFF
--- a/config.py
+++ b/config.py
@@ -57,7 +57,7 @@ OPENAI_MAX_RETRIES = 3
 OPENAI_MAX_TOOL_OUTPUTS_SIZE = 512 * 1024  # in bytes
 OPENAI_MAX_TOKENS = 4096
 OPENAI_MODEL_ID_O1_PREVIEW = "o1-preview"  # https://platform.openai.com/docs/models/o1
-# OPENAI_MODEL_ID_O1_MINI = "o1-mini"  # https://platform.openai.com/docs/models/o1
+OPENAI_MODEL_ID_O1_MINI = "o1-mini"  # https://platform.openai.com/docs/models/o1
 OPENAI_MODEL_ID_GPT_4O = "gpt-4o"  # https://platform.openai.com/docs/models/gpt-4o
 OPENAI_ORG_ID: str = get_env_var(name="OPENAI_ORG_ID")
 OPENAI_TEMPERATURE = 0.0

--- a/services/openai/chat.py
+++ b/services/openai/chat.py
@@ -3,7 +3,7 @@ from openai import OpenAI
 from openai.types.chat import ChatCompletion
 
 # Local imports
-from config import OPENAI_MODEL_ID_O1_PREVIEW
+from config import OPENAI_MODEL_ID_O1_MINI
 from services.openai.init import create_openai_client
 from services.openai.truncate import truncate_message
 from utils.handle_exceptions import handle_exceptions
@@ -25,7 +25,7 @@ def chat_with_ai(system_input: str, user_input: str) -> str:
                 "content": truncated_msg if truncated_msg else user_input,
             },
         ],
-        model=OPENAI_MODEL_ID_O1_PREVIEW,
+        model=OPENAI_MODEL_ID_O1_MINI,
         n=1,
         # temperature=OPENAI_TEMPERATURE,  # temperature should be 0 but it is not supported for 01-mini as of Oct 5 2024
     )


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Replace the 'o1-preview' model with the 'o1-mini' model in the configuration and chat service.