### PR TITLE
Stop Check RUn

### DIFF
--- a/services/check_run_handler.py
+++ b/services/check_run_handler.py
@@ -30,6 +30,7 @@ supabase_manager = SupabaseManager(url=SUPABASE_URL, key=SUPABASE_SERVICE_ROLE_K
 
 
 def handle_check_run(payload: CheckRunCompletedPayload) -> None:
+    return
     # Extract workflow run id
     check_run: CheckRun = payload["check_run"]
     details_url: str = check_run["details_url"]


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent the execution of the handle_check_run function by adding an early return statement.