### PR TITLE
1. Add another break point for while loop to avoid an infinite loop and 2. unify tool_choice to 'auto' from 'required' as 'required' tends to fall into an infinite loop

### DIFF
--- a/services/gitauto_handler.py
+++ b/services/gitauto_handler.py
@@ -217,6 +217,12 @@ async def handle_gitauto(payload: GitHubLabeledPayload, trigger_type: str) -> No
         if not is_explored and not is_committed:
             break
 
+        # If no files are found but changes are made, it might fall into an infinite loop (e.g., repeatedly making and reverting similar changes with slight variations)
+        if not is_explored and is_committed:
+            retry_count += 1
+            if retry_count > 10:
+                break
+
         # If files are found but no changes are made, it means that the agent found files but didn't think it's necessary to commit changes or fell into an infinite-like loop (e.g. slightly different searches)
         if is_explored and not is_committed:
             retry_count += 1

--- a/services/openai/commit_changes.py
+++ b/services/openai/commit_changes.py
@@ -45,15 +45,15 @@ def explore_repo_or_commit_changes(
     if mode == "commit":
         content = SYSTEM_INSTRUCTION_TO_COMMIT_CHANGES
         tools = TOOLS_TO_COMMIT_CHANGES
-        tool_choice = "required"
+        tool_choice = "auto"  # DO NOT USE "required" and allow GitAuto not to call any tools.
     elif mode == "explore":
         content = SYSTEM_INSTRUCTION_TO_EXPLORE_REPO
         tools = TOOLS_TO_EXPLORE_REPO
-        tool_choice = "auto"
+        tool_choice = "auto"  # DO NOT USE "required" and allow GitAuto not to call any tools.
     elif mode == "get":
         content = SYSTEM_INSTRUCTION_TO_EXPLORE_REPO
         tools = TOOLS_TO_GET_FILE
-        tool_choice = "auto"
+        tool_choice = "auto"  # DO NOT USE "required" and allow GitAuto not to call any tools.
     system_message: ChatCompletionMessageParam = {"role": "system", "content": content}
     all_messages = [system_message] + list(messages)
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add a break condition to the while loop to prevent an infinite loop when no files are found but changes are made.