### PR TITLE
Enable 'Check Run Retry' again

### DIFF
--- a/services/check_run_handler.py
+++ b/services/check_run_handler.py
@@ -31,7 +31,6 @@ supabase_manager = SupabaseManager(url=SUPABASE_URL, key=SUPABASE_SERVICE_ROLE_K
 
 
 def handle_check_run(payload: CheckRunCompletedPayload) -> None:
-    return
     # Extract workflow run id
     check_run: CheckRun = payload["check_run"]
     details_url: str = check_run["details_url"]


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the issue where the 'Check Run Retry' functionality was disabled by removing an early return statement in the check run handler.