### PR TITLE
Fix KeyError: 'pull_requests' and IndexError: list index out of range in handle_check_run()

### DIFF
--- a/services/check_run_handler.py
+++ b/services/check_run_handler.py
@@ -70,8 +70,13 @@ def handle_check_run(payload: CheckRunCompletedPayload) -> None:
         print(colorize(text=msg, color="yellow"))
         return
 
-    # Extract PR related variables
-    pull_request: PullRequest = check_run["pull_requests"][0]
+    # Extract PR related variables and return if no PR is associated with this check run
+    pull_requests: list[PullRequest] = check_run.get("pull_requests", [])
+    if not pull_requests:
+        msg = "Skipping because no pull request is associated with this check run"
+        print(colorize(text=msg, color="yellow"))
+        return
+    pull_request: PullRequest = pull_requests[0]
     pull_number: int = pull_request["number"]
     pull_url: str = pull_request["url"]
 


### PR DESCRIPTION
## Summary by Sourcery

Fix errors in handle_check_run by checking for the presence and non-emptiness of 'pull_requests' in the payload before accessing it.

Bug Fixes:
- Fix KeyError by checking for the presence of 'pull_requests' in the check_run payload before accessing it.
- Fix IndexError by ensuring the 'pull_requests' list is not empty before accessing its first element.