### PR TITLE
Fix an 403 error: 'Repository access blocked. Reason is tos.' in get_oldest_unassigned_open_issue()

### DIFF
--- a/services/github/github_manager.py
+++ b/services/github/github_manager.py
@@ -509,6 +509,11 @@ def get_oldest_unassigned_open_issue(
             },
             timeout=TIMEOUT,
         )
+
+        # Return None if repository access is blocked (403 TOS error)
+        if response.status_code == 403 and "Repository access blocked" in response.text:
+            return None
+
         response.raise_for_status()
         issues: list[IssueInfo] = response.json()
 


### PR DESCRIPTION
https://gitauto-ai.sentry.io/issues/6018127222/?environment=prod&environment=production&project=4506865231200256&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=1