### PR TITLE
Fix an error: Invalid 'messages[1].content': string too long. Expected a string with maximum length 1048576, but got a string with length 4446485 instead. in chat_with_agent()

### DIFF
--- a/config.py
+++ b/config.py
@@ -51,7 +51,7 @@ OPENAI_ASSISTANT_NAME = (
 )
 OPENAI_FINAL_STATUSES = ["cancelled", "completed", "expired", "failed"]
 OPENAI_MAX_ARRAY_LENGTH = 32  # https://community.openai.com/t/assistant-threads-create-400-messages-array-too-long/754574/1
-OPENAI_MAX_STRING_LENGTH = 256000  # https://community.openai.com/t/assistant-threads-create-400-messages-array-too-long/754574/5
+OPENAI_MAX_STRING_LENGTH = 1000000  # Secured 48576 as a buffer. https://gitauto-ai.sentry.io/issues/5582421505/?notification_uuid=016fc393-8f5d-45cf-8296-4ec6e264adcb&project=4506865231200256&referrer=regression_activity-slack and https://community.openai.com/t/assistant-threads-create-400-messages-array-too-long/754574/5
 OPENAI_MAX_CONTEXT_TOKENS = 120000  # Secured 8,000 as a buffer. https://gitauto-ai.sentry.io/issues/5582421515/events/9a09416e714c4a66bf1bd86916702be2/?project=4506865231200256&referrer=issue_details.related_trace_issue
 OPENAI_MAX_RETRIES = 3
 OPENAI_MAX_TOOL_OUTPUTS_SIZE = 512 * 1024  # in bytes

--- a/services/openai/truncate.py
+++ b/services/openai/truncate.py
@@ -1,15 +1,22 @@
 import tiktoken
-from config import OPENAI_MAX_CONTEXT_TOKENS, OPENAI_MODEL_ID_GPT_4O
+from config import (
+    OPENAI_MAX_CONTEXT_TOKENS,
+    OPENAI_MODEL_ID_GPT_4O,
+    OPENAI_MAX_STRING_LENGTH,
+)
 from utils.handle_exceptions import handle_exceptions
 
 
 @handle_exceptions(default_return_value="", raise_on_error=False)
 def truncate_message(input_message: str) -> str:
-    truncated_message: str = input_message
+    # First truncate by string length if needed
+    truncated_message: str = input_message[:OPENAI_MAX_STRING_LENGTH]
+
+    # Then handle token truncation
     encoding: tiktoken.Encoding = tiktoken.encoding_for_model(
         model_name=OPENAI_MODEL_ID_GPT_4O
     )
-    tokens: list[int] = encoding.encode(text=input_message)
+    tokens: list[int] = encoding.encode(text=truncated_message)
     if len(tokens) > OPENAI_MAX_CONTEXT_TOKENS:
         tokens = tokens[:OPENAI_MAX_CONTEXT_TOKENS]
         truncated_message: str = encoding.decode(tokens=tokens)


### PR DESCRIPTION
https://gitauto-ai.sentry.io/issues/5582421505/?notification_uuid=016fc393-8f5d-45cf-8296-4ec6e264adcb&project=4506865231200256&referrer=regression_activity-slack