### PR TITLE
Enable GitAuto to read the parent issue number, title, body too in addition to an issue when working on the issue.

### DIFF
--- a/services/gitauto_handler.py
+++ b/services/gitauto_handler.py
@@ -77,6 +77,9 @@ async def handle_gitauto(
     issue_body = base_args["issue_body"]
     issue_body_rendered = render_text(base_args=base_args, text=issue_body)
     issuer_name = base_args["issuer_name"]
+    parent_issue_number = base_args["parent_issue_number"]
+    parent_issue_title = base_args["parent_issue_title"]
+    parent_issue_body = base_args["parent_issue_body"]
     new_branch_name = base_args["new_branch"]
     sender_id = base_args["sender_id"]
     sender_name = base_args["sender_name"]
@@ -182,9 +185,11 @@ async def handle_gitauto(
             "issue_body": issue_body,
             "reference_contents": reference_contents,
             "issue_comments": issue_comments,
+            "parent_issue_number": parent_issue_number,
+            "parent_issue_title": parent_issue_title,
+            "parent_issue_body": parent_issue_body,
             "file_tree": file_tree,
             "config_contents": config_contents,
-            # "pr_body": pr_body,
         }
     )
     messages = [{"role": "user", "content": user_input}]

--- a/services/github/github_utils.py
+++ b/services/github/github_utils.py
@@ -14,6 +14,7 @@ from services.github.github_manager import (
     get_installation_access_token,
     get_user_public_email,
 )
+from services.github.issues_manager import get_parent_issue
 from utils.extract_urls import extract_urls
 from utils.handle_exceptions import handle_exceptions
 
@@ -69,6 +70,19 @@ def deconstruct_github_payload(payload: GitHubLabeledPayload):
     token: str = get_installation_access_token(installation_id=installation_id)
     sender_email: str = get_user_public_email(username=sender_name, token=token)
 
+    # Extract its parent issue
+    parent_issue = get_parent_issue(
+        owner=owner_name,
+        repo=repo_name,
+        issue_number=issue_number,
+        token=token,
+    )
+    parent_issue_number: int | None = (
+        parent_issue.get("number") if parent_issue else None
+    )
+    parent_issue_title: str | None = parent_issue.get("title") if parent_issue else None
+    parent_issue_body: str | None = parent_issue.get("body") if parent_issue else None
+
     base_args: BaseArgs = {
         "input_from": "github",
         "owner_type": owner_type,
@@ -81,6 +95,9 @@ def deconstruct_github_payload(payload: GitHubLabeledPayload):
         "issue_title": issue_title,
         "issue_body": issue_body,
         "issuer_name": issuer_name,
+        "parent_issue_number": parent_issue_number,
+        "parent_issue_title": parent_issue_title,
+        "parent_issue_body": parent_issue_body,
         "base_branch": base_branch_name,
         "new_branch": new_branch_name,
         "installation_id": installation_id,

--- a/services/github/issues_manager.py
+++ b/services/github/issues_manager.py
@@ -26,3 +26,38 @@ def get_issue_body(owner: str, repo: str, issue_number: int, token: str):
     return body
 
 
+@handle_exceptions(default_return_value=None, raise_on_error=False)
+def get_parent_issue(owner: str, repo: str, issue_number: int, token: str):
+    """Get parent issue information (number, title, body) using GraphQL API
+
+    https://docs.github.com/en/graphql/reference/objects#issue
+    """
+    client = get_graphql_client(token)
+    query = gql(
+        """
+        query GetParentIssue($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            issue(number: $number) {
+              parent {
+                number
+                title
+                body
+              }
+            }
+          }
+        }
+    """
+    )
+
+    variables = {"owner": owner, "repo": repo, "number": issue_number}
+    result = client.execute(query, variable_values=variables)
+
+    parent = result.get("repository", {}).get("issue", {}).get("parent", {})
+    if not parent:
+        return None
+    output = {
+        "number": parent.get("number"),
+        "title": parent.get("title"),
+        "body": parent.get("body"),
+    }
+    return output


### PR DESCRIPTION
GitAuto can now reference the parent issue’s number, title, and body (description) when triggered from a sub-issue. GitHub introduced issue parent-child relationships in October 2024 (beta). Since the REST API does not yet support this feature, GraphQL is used instead.

With this update, users can create a main issue for tasks like unit test creation, integration test creation, or external specification writing, and then create sub-issues for specific files or functions. Common requirements—such as using functions instead of classes, using Jest for JavaScript, or specifying a test constants file—can be documented in the parent issue’s body. This eliminates the need to repeatedly open requirement documents when writing sub-issues, allowing sub-issue bodies to focus only on sub-issue specific details, making the process more efficient.