### PR TITLE
Enable GitAuto to read all lines of a file if it's within 100 lines. For files exceeding this limit, read only the specified section along with 50 lines before and after when line numbers are provided.

### DIFF
--- a/services/github/github_manager.py
+++ b/services/github/github_manager.py
@@ -630,7 +630,7 @@ def get_remote_file_content(
     file_path_with_lines = file_path
 
     # If line_number is specified, show the lines around the line_number
-    buffer = 10
+    buffer = 50
     if line_number is not None and line_number > 1 and len(lines) > 100:
         start = max(line_number - buffer, 0)
         end = min(line_number + buffer, len(lines))

--- a/services/github/github_manager.py
+++ b/services/github/github_manager.py
@@ -631,7 +631,7 @@ def get_remote_file_content(
 
     # If line_number is specified, show the lines around the line_number
     buffer = 10
-    if line_number is not None:
+    if line_number is not None and line_number > 1 and len(lines) > 100:
         start = max(line_number - buffer, 0)
         end = min(line_number + buffer, len(lines))
         numbered_lines = numbered_lines[start : end + 1]  # noqa: E203


### PR DESCRIPTION
Background: When GitAuto rummages through files in a repository, it assumes the files are large and allows specifying line numbers to reduce noise. However, due to a quirk—possibly related to the o3-mini model GitAuto uses—it sometimes unnecessarily specifies the first line. In such cases, GitAuto should read all lines, just as it would when no line numbers are specified.