### PR TITLE
Remove FREE_TIER_REQUEST_AMOUNT and implement auto-customer creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,13 @@ pre-commit run --all-files
 uvicorn main:app --reload --port 8000 --log-level warning
 ```
 
+### Database Access
+
+```bash
+# Connect to Supabase PostgreSQL database
+source .env && psql "postgresql://postgres.dkrxtcbaqzrodvsagwwn:$SUPABASE_DB_PASSWORD@aws-0-us-west-1.pooler.supabase.com:6543/postgres"
+```
+
 ## Architecture Overview
 
 ### Core Application Structure

--- a/config.py
+++ b/config.py
@@ -91,7 +91,6 @@ EMAIL_LINK = "[info@gitauto.ai](mailto:info@gitauto.ai)"
 ENV: str = get_env_var(name="ENV")
 EXCEPTION_OWNERS = ["gitautoai", "Suchica", "hiroshinishio"]
 # Update here too: https://dashboard.stripe.com/test/products/prod_PokLGIxiVUwCi6
-FREE_TIER_REQUEST_AMOUNT = 3
 CREDIT_AMOUNTS_USD = {
     "usage": -2,
     "grant": 10,
@@ -110,7 +109,6 @@ UTF8 = "utf-8"
 TEST_APP_ID = 123456
 TEST_INSTALLATION_ID = 12345678
 TEST_NEW_INSTALLATION_ID = 87654321
-PRODUCT_ID_FOR_FREE = "prod_PokLGIxiVUwCi6"  # https://dashboard.stripe.com/test/products/prod_PokLGIxiVUwCi6
 PRODUCT_ID_FOR_STANDARD = "prod_PqZFpCs1Jq6X4E"  # https://dashboard.stripe.com/test/products/prod_PqZFpCs1Jq6X4E
 TEST_OWNER_ID = 123456789
 TEST_OWNER_TYPE = "Organization"

--- a/services/stripe/get_base_request_limit.py
+++ b/services/stripe/get_base_request_limit.py
@@ -1,9 +1,8 @@
-from config import FREE_TIER_REQUEST_AMOUNT
 from services.stripe.client import stripe
 from utils.error.handle_exceptions import handle_exceptions
 
 
-@handle_exceptions(default_return_value=FREE_TIER_REQUEST_AMOUNT, raise_on_error=False)
+@handle_exceptions(default_return_value=0, raise_on_error=False)
 def get_base_request_limit(product_id: str):
     """
     https://docs.stripe.com/api/products/retrieve?lang=python

--- a/services/stripe/test_get_base_request_limit.py
+++ b/services/stripe/test_get_base_request_limit.py
@@ -1,10 +1,6 @@
 from unittest.mock import patch
 import pytest
-from config import (
-    FREE_TIER_REQUEST_AMOUNT,
-    PRODUCT_ID_FOR_FREE,
-    PRODUCT_ID_FOR_STANDARD,
-)
+from config import PRODUCT_ID_FOR_STANDARD
 from services.stripe.get_base_request_limit import get_base_request_limit
 
 
@@ -28,17 +24,6 @@ def sample_product_response():
     }
 
 
-@pytest.fixture
-def free_tier_product_response():
-    """Fixture providing a free tier product response."""
-    return {
-        "id": PRODUCT_ID_FOR_FREE,
-        "object": "product",
-        "name": "Free Tier",
-        "metadata": {"request_count": str(FREE_TIER_REQUEST_AMOUNT)},
-    }
-
-
 def test_get_base_request_limit_returns_correct_value(
     mock_stripe_product, sample_product_response
 ):
@@ -49,18 +34,6 @@ def test_get_base_request_limit_returns_correct_value(
 
     assert result == 100
     mock_stripe_product.assert_called_once_with("prod_test123")
-
-
-def test_get_base_request_limit_with_free_tier_product(
-    mock_stripe_product, free_tier_product_response
-):
-    """Test get_base_request_limit with free tier product."""
-    mock_stripe_product.return_value = free_tier_product_response
-
-    result = get_base_request_limit(PRODUCT_ID_FOR_FREE)
-
-    assert result == FREE_TIER_REQUEST_AMOUNT
-    mock_stripe_product.assert_called_once_with(PRODUCT_ID_FOR_FREE)
 
 
 def test_get_base_request_limit_with_standard_product(mock_stripe_product):
@@ -100,7 +73,7 @@ def test_get_base_request_limit_handles_stripe_exception(mock_stripe_product):
 
     result = get_base_request_limit("invalid_product_id")
 
-    assert result == FREE_TIER_REQUEST_AMOUNT
+    assert result == 0
 
 
 def test_get_base_request_limit_handles_missing_metadata(mock_stripe_product):
@@ -114,7 +87,7 @@ def test_get_base_request_limit_handles_missing_metadata(mock_stripe_product):
 
     result = get_base_request_limit("prod_no_metadata")
 
-    assert result == FREE_TIER_REQUEST_AMOUNT
+    assert result == 0
 
 
 def test_get_base_request_limit_handles_missing_request_count(mock_stripe_product):
@@ -128,7 +101,7 @@ def test_get_base_request_limit_handles_missing_request_count(mock_stripe_produc
 
     result = get_base_request_limit("prod_no_request_count")
 
-    assert result == FREE_TIER_REQUEST_AMOUNT
+    assert result == 0
 
 
 def test_get_base_request_limit_handles_invalid_request_count_format(
@@ -144,7 +117,7 @@ def test_get_base_request_limit_handles_invalid_request_count_format(
 
     result = get_base_request_limit("prod_invalid_count")
 
-    assert result == FREE_TIER_REQUEST_AMOUNT
+    assert result == 0
 
 
 @pytest.mark.parametrize(
@@ -178,7 +151,7 @@ def test_get_base_request_limit_with_empty_product_id(mock_stripe_product):
 
     result = get_base_request_limit("")
 
-    assert result == FREE_TIER_REQUEST_AMOUNT
+    assert result == 0
 
 
 def test_get_base_request_limit_with_none_product_id(mock_stripe_product):
@@ -187,4 +160,4 @@ def test_get_base_request_limit_with_none_product_id(mock_stripe_product):
 
     result = get_base_request_limit(None)
 
-    assert result == FREE_TIER_REQUEST_AMOUNT
+    assert result == 0

--- a/services/supabase/owners/update_stripe_customer_id.py
+++ b/services/supabase/owners/update_stripe_customer_id.py
@@ -1,0 +1,9 @@
+from services.supabase.client import supabase
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=None, raise_on_error=False)
+def update_stripe_customer_id(owner_id: int, stripe_customer_id: str):
+    supabase.table("owners").update({"stripe_customer_id": stripe_customer_id}).eq(
+        "owner_id", owner_id
+    ).execute()


### PR DESCRIPTION
- Removed FREE_TIER_REQUEST_AMOUNT constant from config.py
- Removed PRODUCT_ID_FOR_FREE constant from config.py
- Updated get_base_request_limit.py to return 0 as default instead of free tier amount
- Updated is_request_limit_reached.py to auto-create Stripe customers for users without one
- Added update_stripe_customer_id.py helper function
- Updated all test files to use hardcoded values instead of removed constants
- Now users without Stripe customers get one created automatically instead of being blocked

🤖 Generated with [Claude Code](https://claude.ai/code)