### PR TITLE
Fix AttributeError in is_request_limit_reached function

### DIFF
--- a/services/supabase/usage/is_request_limit_reached.py
+++ b/services/supabase/usage/is_request_limit_reached.py
@@ -104,7 +104,7 @@ def is_request_limit_reached(
     else:
         # User doesn't have paid subscription, check credit balance
         owner = get_owner(owner_id)
-        if not owner or owner.credit_balance_usd <= 0:
+        if not owner or owner["credit_balance_usd"] <= 0:
             return {
                 "is_limit_reached": True,
                 "requests_left": 0,


### PR DESCRIPTION
Changed owner.credit_balance_usd to owner["credit_balance_usd"] to properly access dictionary value since get_owner returns a dict, not an object with attributes.

🤖 Generated with [Claude Code](https://claude.ai/code)