### PR TITLE
Fix get_installation_permissions to use JWT authentication

### DIFF
--- a/services/github/installations/get_installation_permissions.py
+++ b/services/github/installations/get_installation_permissions.py
@@ -1,13 +1,19 @@
 from requests import get
 from config import GITHUB_API_URL, TIMEOUT
+from services.github.token.get_jwt import get_jwt
 from services.github.utils.create_headers import create_headers
 from utils.error.handle_exceptions import handle_exceptions
 
 
 @handle_exceptions(default_return_value={}, raise_on_error=False)
-def get_installation_permissions(installation_id: int, token: str):
+def get_installation_permissions(installation_id: int):
+    # This endpoint requires JWT authentication
+    # Generate a fresh JWT for this request
+    jwt_token = get_jwt()
+
+    # https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-installation-for-the-authenticated-app
     url = f"{GITHUB_API_URL}/app/installations/{installation_id}"
-    headers = create_headers(token=token)
+    headers = create_headers(token=jwt_token)
     response = get(url=url, headers=headers, timeout=TIMEOUT)
     response.raise_for_status()
     return response.json().get("permissions", {})

--- a/services/webhook/check_run_handler.py
+++ b/services/webhook/check_run_handler.py
@@ -196,7 +196,7 @@ def handle_check_run(payload: CheckRunCompletedPayload) -> None:
         update_comment(body="\n".join(log_messages), base_args=base_args)
 
         # Get installation permissions via API
-        permissions = get_installation_permissions(installation_id, token)
+        permissions = get_installation_permissions(installation_id)
 
         # Early return notification
         early_return_msg = f"workflow_path is 404. Permission denied for workflow run id `{workflow_id}` in `{owner_name}/{repo_name}` - Permissions: `{permissions}`"
@@ -230,7 +230,7 @@ def handle_check_run(payload: CheckRunCompletedPayload) -> None:
         update_comment(body="\n".join(log_messages), base_args=base_args)
 
         # Get installation permissions via API
-        permissions = get_installation_permissions(installation_id, token)
+        permissions = get_installation_permissions(installation_id)
 
         # Early return notification
         early_return_msg = f"error_log is 404. Permission denied for workflow run id `{workflow_id}` in `{owner_name}/{repo_name}` - Permissions: `{permissions}`"


### PR DESCRIPTION
- Remove token parameter from get_installation_permissions function
- Function now generates JWT internally for GitHub API authentication
- Update all callers to not pass token parameter
- Fix 401 'JWT could not be decoded' error for /app/installations endpoint
- Update tests to verify JWT usage