### PR TITLE
Fix year 0 ValueError in is_request_limit_reached

### DIFF
--- a/config.py
+++ b/config.py
@@ -86,7 +86,9 @@ STRIPE_PRODUCT_ID_FREE: str = get_env_var(name="STRIPE_PRODUCT_ID_FREE")
 STRIPE_PRODUCT_ID_STANDARD: str = get_env_var(name="STRIPE_PRODUCT_ID_STANDARD")
 
 # General
-DEFAULT_TIME = datetime(year=1, month=1, day=1, hour=0, minute=0, second=0)
+ONE_YEAR_FROM_NOW = datetime.now(timezone.utc).replace(
+    year=datetime.now().year + 1, microsecond=0
+)
 EMAIL_LINK = "[info@gitauto.ai](mailto:info@gitauto.ai)"
 ENV: str = get_env_var(name="ENV")
 EXCEPTION_OWNERS = ["gitautoai", "Suchica", "hiroshinishio"]

--- a/services/supabase/usage/is_request_limit_reached.py
+++ b/services/supabase/usage/is_request_limit_reached.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import TypedDict
 
 # Local imports
-from config import DEFAULT_TIME, EXCEPTION_OWNERS, TZ
+from config import ONE_YEAR_FROM_NOW, EXCEPTION_OWNERS, TZ
 from services.supabase.installations.get_stripe_customer_id import (
     get_stripe_customer_id,
 )
@@ -30,7 +30,7 @@ DEFAULT = {
     "is_limit_reached": False,
     "requests_left": 0,
     "request_limit": 1,
-    "end_date": DEFAULT_TIME,
+    "end_date": ONE_YEAR_FROM_NOW,
     "is_credit_user": False,
 }
 
@@ -50,7 +50,7 @@ def is_request_limit_reached(
             "is_limit_reached": False,
             "requests_left": 999999,
             "request_limit": 999999,
-            "end_date": DEFAULT_TIME,
+            "end_date": ONE_YEAR_FROM_NOW,
             "is_credit_user": False,
         }
 
@@ -75,7 +75,7 @@ def is_request_limit_reached(
                 "is_limit_reached": True,
                 "requests_left": 0,
                 "request_limit": 0,
-                "end_date": DEFAULT_TIME,
+                "end_date": ONE_YEAR_FROM_NOW,
                 "is_credit_user": False,
             }
 
@@ -109,14 +109,14 @@ def is_request_limit_reached(
                 "is_limit_reached": True,
                 "requests_left": 0,
                 "request_limit": 0,
-                "end_date": DEFAULT_TIME,
+                "end_date": ONE_YEAR_FROM_NOW,
                 "is_credit_user": True,
             }
 
         # For credits, we don't have a monthly limit - just check if they have balance
         request_limit = 999999  # Effectively unlimited as long as they have credits
-        start_date_seconds = int(DEFAULT_TIME.timestamp())
-        end_date_seconds = int(DEFAULT_TIME.timestamp())
+        start_date_seconds = int(ONE_YEAR_FROM_NOW.timestamp())
+        end_date_seconds = int(ONE_YEAR_FROM_NOW.timestamp())
 
     # Set credit user flag
     is_credit_user = not has_paid_subscription


### PR DESCRIPTION
Replace DEFAULT_TIME (year 1) with ONE_YEAR_FROM_NOW to prevent timestamp conversion errors that result in invalid year 0 dates.

🤖 Generated with [Claude Code](https://claude.ai/code)