### PR TITLE
Show credit balance in GitHub comments instead of misleading request counts

### DIFF
--- a/services/github/comments/combine_and_create_comment.py
+++ b/services/github/comments/combine_and_create_comment.py
@@ -33,6 +33,8 @@ def combine_and_create_comment(
     requests_left = limit_result["requests_left"]
     request_limit = limit_result["request_limit"]
     end_date = limit_result["end_date"]
+    is_credit_user = limit_result["is_credit_user"]
+    credit_balance_usd = limit_result["credit_balance_usd"]
 
     # Build comment body
     body = base_comment
@@ -45,7 +47,11 @@ def combine_and_create_comment(
     # Add usage info if end_date is valid
     if end_date != datetime(year=1, month=1, day=1, hour=0, minute=0, second=0):
         body += request_issue_comment(
-            requests_left=requests_left, sender_name=sender_name, end_date=end_date
+            requests_left=requests_left,
+            sender_name=sender_name,
+            end_date=end_date,
+            is_credit_user=is_credit_user,
+            credit_balance_usd=credit_balance_usd,
         )
 
     # Override with limit reached message if needed

--- a/utils/text/text_copy.py
+++ b/utils/text/text_copy.py
@@ -3,6 +3,7 @@ from datetime import datetime
 # Local imports
 from config import EMAIL_LINK, PRODUCT_ID
 from constants.messages import COMPLETED_PR
+from constants.urls import DASHBOARD_CREDITS_URL
 
 
 def git_command(new_branch_name: str) -> str:
@@ -51,7 +52,16 @@ def pull_request_completed(
     return f"{user_part}{COMPLETED_PR} {pr_url} 🚀\n\nNote: I automatically create a pull request for an unassigned and open issue in order from oldest to newest once a day at 00:00 UTC, as long as you have remaining automation usage. Should you have any questions or wish to change settings or limits, please feel free to contact {EMAIL_LINK} or invite us to Slack Connect."
 
 
-def request_issue_comment(requests_left: int, sender_name: str, end_date: datetime):
+def request_issue_comment(
+    requests_left: int,
+    sender_name: str,
+    end_date: datetime,
+    is_credit_user: bool = False,
+    credit_balance_usd: int = 0,
+):
+    if is_credit_user:
+        return f"\n\n@{sender_name}, You have ${credit_balance_usd} in credits remaining. [View credits]({DASHBOARD_CREDITS_URL})\nIf you have any questions or concerns, please contact us at {EMAIL_LINK}."
+
     requests_left = 0 if requests_left < 0 else requests_left
     plural = "" if requests_left == 1 else "s"
     return f"\n\n@{sender_name}, You have {requests_left} request{plural} left in this cycle which refreshes on {end_date}.\nIf you have any questions or concerns, please contact us at {EMAIL_LINK}."


### PR DESCRIPTION
- Update is_request_limit_reached to return credit_balance_usd for all users
- Modify request_issue_comment to display actual credit amounts for credit users
- Add direct link to credits dashboard for credit users
- Remove unnecessary else clause to fix pylint warning
- Credit users now see: '@user, You have  in credits remaining. [View credits](link)'