### PR TITLE
Add AWS EventBridge Scheduler deletion on installation uninstall/suspend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,9 @@ backoff==2.2.1
 beautifulsoup4==4.12.3
 black==24.8.0
 boto3==1.36.21
+boto3-stubs==1.40.2
 botocore==1.36.21
+botocore-stubs==1.38.46
 certifi==2024.7.4
 cffi==1.17.0
 cfgv==3.4.0
@@ -57,6 +59,7 @@ MarkupSafe==3.0.2
 mccabe==0.7.0
 mdurl==0.1.2
 multidict==6.1.0
+mypy-boto3-scheduler==1.40.0
 mypy-extensions==1.0.0
 nodeenv==1.9.1
 openai==1.60.2
@@ -115,7 +118,9 @@ toml==0.10.2
 tomlkit==0.13.0
 tqdm==4.66.5
 typer==0.12.3
+types-awscrt==0.27.5
 types-psycopg2==2.9.21.20250516
+types-s3transfer==0.13.0
 typing_extensions==4.12.2
 ujson==5.10.0
 urllib3==2.5.0

--- a/services/aws/client.py
+++ b/services/aws/client.py
@@ -1,0 +1,6 @@
+# Third-party imports
+import boto3
+from mypy_boto3_scheduler import EventBridgeSchedulerClient
+
+# When running on AWS Lambda, credentials and region are automatically provided by IAM role
+scheduler_client: EventBridgeSchedulerClient = boto3.client("scheduler")

--- a/services/aws/delete_scheduler.py
+++ b/services/aws/delete_scheduler.py
@@ -1,0 +1,14 @@
+# Standard imports
+import logging
+
+# Local imports
+from services.aws.client import scheduler_client
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=False, raise_on_error=False)
+def delete_scheduler(schedule_name: str):
+    scheduler_client.delete_schedule(Name=schedule_name)
+    logging.info("Deleted EventBridge Scheduler: %s", schedule_name)
+
+    return True

--- a/services/aws/get_schedulers.py
+++ b/services/aws/get_schedulers.py
@@ -1,0 +1,27 @@
+# Local imports
+from services.aws.client import scheduler_client
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=[], raise_on_error=False)
+def get_schedulers_by_owner_id(owner_id: int):
+    schedules = []
+    next_token = None
+
+    while True:
+        if next_token:
+            response = scheduler_client.list_schedules(NextToken=next_token)
+        else:
+            response = scheduler_client.list_schedules()
+
+        for schedule in response.get("Schedules", []):
+            schedule_name = schedule.get("Name", "")
+            # Match pattern: gitauto-repo-{ownerId}-{repoId} or gitauto-repo-{ownerId}-{repoId}-{index}
+            if schedule_name.startswith(f"gitauto-repo-{owner_id}-"):
+                schedules.append(schedule_name)
+
+        next_token = response.get("NextToken")
+        if not next_token:
+            break
+
+    return schedules

--- a/services/webhook/schedule_handler.py
+++ b/services/webhook/schedule_handler.py
@@ -2,11 +2,14 @@
 import logging
 from typing import cast
 
-# Local imports (AWS)
+# Local imports (Types)
 from payloads.aws.event_bridge_scheduler.event_types import EventBridgeSchedulerEvent
+from schemas.supabase.fastapi.schema_public_latest import Coverages
+
+# Local imports (AWS)
+from services.aws.delete_scheduler import delete_scheduler
 
 # Local imports (GitHub)
-from schemas.supabase.fastapi.schema_public_latest import Coverages
 from services.github.branches.get_default_branch import get_default_branch
 from services.github.issues.create_issue import create_issue
 from services.github.issues.is_issue_open import is_issue_open
@@ -57,6 +60,9 @@ def schedule_handler(event: EventBridgeSchedulerEvent):
     # Get installation access token - simplified since we already have installation_id
     token = get_installation_access_token(installation_id=installation_id)
     if token is None:
+        # Delete scheduler since installation is invalid
+        schedule_name = f"gitauto-repo-{owner_id}-{repo_id}"
+        delete_scheduler(schedule_name)
         raise ValueError(f"Token is None for installation_id: {installation_id}")
 
     # Get repository settings - check if trigger_on_schedule is enabled


### PR DESCRIPTION
- Create services/aws/client.py with typed EventBridge Scheduler client
- Create services/aws/get_schedulers.py to find schedulers by owner ID
- Create services/aws/delete_scheduler.py to delete individual schedulers
- Update webhook handler to delete schedulers after uninstall/suspend cleanup
- Update schedule handler to delete scheduler when installation token is invalid
- Add boto3-stubs[scheduler] for proper type annotations