### PR TITLE
Implement repo-specific CloudWatch log groups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,6 +59,8 @@ MarkupSafe==3.0.2
 mccabe==0.7.0
 mdurl==0.1.2
 multidict==6.1.0
+mypy-boto3-lambda==1.40.7
+mypy-boto3-logs==1.40.0
 mypy-boto3-scheduler==1.40.0
 mypy-extensions==1.0.0
 nodeenv==1.9.1

--- a/services/aws/client.py
+++ b/services/aws/client.py
@@ -1,9 +1,0 @@
-# Third-party imports
-import boto3
-from mypy_boto3_scheduler import EventBridgeSchedulerClient
-
-AWS_REGION = "us-west-1"
-
-scheduler_client: EventBridgeSchedulerClient = boto3.client(
-    "scheduler", region_name=AWS_REGION
-)

--- a/services/aws/clients.py
+++ b/services/aws/clients.py
@@ -1,0 +1,15 @@
+# Third-party imports
+import boto3
+from mypy_boto3_lambda import LambdaClient
+from mypy_boto3_logs import CloudWatchLogsClient
+from mypy_boto3_scheduler import EventBridgeSchedulerClient
+
+AWS_REGION = "us-west-1"
+
+lambda_client: LambdaClient = boto3.client("lambda", region_name=AWS_REGION)
+
+logs_client: CloudWatchLogsClient = boto3.client("logs", region_name=AWS_REGION)
+
+scheduler_client: EventBridgeSchedulerClient = boto3.client(
+    "scheduler", region_name=AWS_REGION
+)

--- a/services/aws/create_log_group.py
+++ b/services/aws/create_log_group.py
@@ -1,0 +1,14 @@
+# Local imports
+from services.aws.clients import logs_client
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=None, raise_on_error=False)
+def create_log_group(owner_name: str, repo_name: str):
+    """Create CloudWatch log group."""
+    log_group_name = f"/aws/lambda/gitauto/{owner_name}/{repo_name}"
+    try:
+        logs_client.create_log_group(logGroupName=log_group_name)
+    except logs_client.exceptions.ResourceAlreadyExistsException:
+        # Skip error notification if log group already exists
+        pass

--- a/services/aws/delete_scheduler.py
+++ b/services/aws/delete_scheduler.py
@@ -2,7 +2,7 @@
 import logging
 
 # Local imports
-from services.aws.client import scheduler_client
+from services.aws.clients import scheduler_client
 from utils.error.handle_exceptions import handle_exceptions
 
 

--- a/services/aws/get_schedulers.py
+++ b/services/aws/get_schedulers.py
@@ -1,5 +1,5 @@
 # Local imports
-from services.aws.client import scheduler_client
+from services.aws.clients import scheduler_client
 from utils.error.handle_exceptions import handle_exceptions
 
 

--- a/services/aws/switch_log_group.py
+++ b/services/aws/switch_log_group.py
@@ -1,0 +1,17 @@
+# Standard imports
+import os
+
+# Local imports
+from services.aws.clients import lambda_client
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=None, raise_on_error=False)
+def switch_lambda_log_group(owner_name: str, repo_name: str):
+    """Switch Lambda function to use repo-specific log group."""
+    function_name = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "pr-agent-prod")
+    repo_log_group = f"/aws/lambda/gitauto/{owner_name}/{repo_name}"
+
+    lambda_client.update_function_configuration(
+        FunctionName=function_name, LoggingConfig={"LogGroup": repo_log_group}
+    )

--- a/services/webhook/screenshot_handler.py
+++ b/services/webhook/screenshot_handler.py
@@ -12,7 +12,7 @@ from playwright.async_api import async_playwright
 
 # Local imports
 from config import GITHUB_APP_USER_NAME
-from services.aws.client import AWS_REGION
+from services.aws.clients import AWS_REGION
 from services.git.clone_repo import clone_repo
 from services.git.git_manager import (
     fetch_branch,

--- a/services/webhook/webhook_handler.py
+++ b/services/webhook/webhook_handler.py
@@ -10,8 +10,10 @@ from config import (
 )
 
 # Local imports (AWS)
+from services.aws.create_log_group import create_log_group
 from services.aws.delete_scheduler import delete_scheduler
 from services.aws.get_schedulers import get_schedulers_by_owner_id
+from services.aws.switch_log_group import switch_lambda_log_group
 
 # Local imports (GitHub)
 from services.github.comments.create_gitauto_button_comment import (
@@ -61,6 +63,16 @@ async def handle_webhook_event(event_name: str, payload: dict[str, Any]):
     https://docs.github.com/en/apps/github-marketplace/using-the-github-marketplace-api-in-your-app/handling-new-purchases-and-free-trials
     https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=purchased#marketplace_purchase
     """
+    # Switch to repo-specific log group if we can extract owner/repo
+    repo = payload.get("repository")
+    if repo:
+        owner = repo.get("owner", {})
+        owner_name = owner.get("login")
+        repo_name = repo.get("name")
+        if owner_name and repo_name:
+            create_log_group(owner_name, repo_name)
+            switch_lambda_log_group(owner_name, repo_name)
+
     action: str | None = payload.get("action")
 
     # Handle push events from non-bot users


### PR DESCRIPTION
- Add error log content printing for better debugging
- Create dynamic Lambda log group switching by owner/repo
- Add proper AWS client typing with mypy-boto3
- Rename client.py to clients.py for multiple AWS services
- Separate create_log_group and switch_lambda_log_group functions
- Update all imports to use centralized AWS clients