### PR TITLE
Fix duplicate webhook handling for usage records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,11 @@ uvicorn main:app --reload --port 8000 --log-level warning
 ### Database Access
 
 ```bash
-# Connect to Supabase PostgreSQL database
+# Connect to Supabase PostgreSQL database (Development)
 source .env && psql "postgresql://postgres.dkrxtcbaqzrodvsagwwn:$SUPABASE_DB_PASSWORD@aws-0-us-west-1.pooler.supabase.com:6543/postgres"
+
+# Connect to Supabase PostgreSQL database (Production)
+source .env && psql "postgresql://postgres.awegqusxzsmlgxaxyyrq:$SUPABASE_DB_PASSWORD@aws-0-us-west-1.pooler.supabase.com:6543/postgres"
 ```
 
 ### AWS CLI
@@ -65,6 +68,7 @@ AWS CLI is available and configured for us-west-1 region.
 # Search production Lambda logs
 # Log group: /aws/lambda/pr-agent-prod
 
+# IMPORTANT: First check today's date with 'date' command to ensure correct timestamp calculation
 # Convert date to epoch milliseconds for AWS logs
 python3 -c "import datetime; print(int(datetime.datetime(2025, 8, 19, 19, 0, 0).timestamp() * 1000))"
 

--- a/services/supabase/create_user_request.py
+++ b/services/supabase/create_user_request.py
@@ -19,6 +19,7 @@ def create_user_request(
     source: str,
     trigger: Trigger,
     email: str | None,
+    pr_number: int | None = None,
 ):
     existing_issue = get_issue(
         owner_type=owner_type,
@@ -49,6 +50,7 @@ def create_user_request(
         installation_id=installation_id,
         source=source,
         trigger=trigger,
+        pr_number=pr_number,
     )
 
     upsert_user(user_id=user_id, user_name=user_name, email=email)

--- a/services/supabase/usage/insert_usage.py
+++ b/services/supabase/usage/insert_usage.py
@@ -28,6 +28,7 @@ def insert_usage(
     installation_id: int,
     source: str,
     trigger: Trigger,
+    pr_number: int | None = None,
 ):
     usage_data = UsageInsert(
         owner_id=owner_id,
@@ -40,6 +41,7 @@ def insert_usage(
         installation_id=installation_id,
         source=source,
         trigger=trigger,
+        pr_number=pr_number,
     )
     usage_data_dict = usage_data.model_dump(exclude_none=True)
     data, _ = supabase.table(table_name="usage").insert(json=usage_data_dict).execute()

--- a/services/supabase/usage/update_usage.py
+++ b/services/supabase/usage/update_usage.py
@@ -10,14 +10,20 @@ def update_usage(
     total_seconds: int,
     is_completed: bool = True,
     pr_number: int | None = None,
+    retry_workflow_id_hash_pairs: list[str] | None = None,
 ):
     """Add agent information to usage record and set is_completed to True."""
-    supabase.table(table_name="usage").update(
-        json={
-            "is_completed": is_completed,
-            "pr_number": pr_number,
-            "token_input": token_input,
-            "token_output": token_output,
-            "total_seconds": total_seconds,
-        }
-    ).eq(column="id", value=usage_id).execute()
+    update_data = {
+        "is_completed": is_completed,
+        "pr_number": pr_number,
+        "token_input": token_input,
+        "token_output": token_output,
+        "total_seconds": total_seconds,
+    }
+
+    if retry_workflow_id_hash_pairs is not None:
+        update_data["retry_workflow_id_hash_pairs"] = retry_workflow_id_hash_pairs
+
+    supabase.table(table_name="usage").update(json=update_data).eq(
+        column="id", value=usage_id
+    ).execute()

--- a/services/webhook/check_run_handler.py
+++ b/services/webhook/check_run_handler.py
@@ -191,6 +191,7 @@ def handle_check_run(payload: CheckRunCompletedPayload):
         source="github",
         trigger="test_failure",
         email=None,
+        pr_number=pull_number,
     )
 
     # Cancel other in_progress check runs before proceeding with the fix
@@ -329,6 +330,17 @@ def handle_check_run(payload: CheckRunCompletedPayload):
         msg = f"Skipping `{check_run_name}` because GitAuto has already tried to fix this exact error before `{current_pair}`."
         log_messages.append(msg)
         update_comment(body="\n".join(log_messages), base_args=base_args)
+
+        # Update usage record for skipped duplicate
+        update_usage(
+            usage_id=usage_id,
+            token_input=0,
+            token_output=0,
+            total_seconds=int(time.time() - current_time),
+            is_completed=True,
+            pr_number=pull_number,
+            retry_workflow_id_hash_pairs=existing_pairs,
+        )
 
         # Early return notification
         early_return_msg = (
@@ -478,6 +490,7 @@ def handle_check_run(payload: CheckRunCompletedPayload):
         total_seconds=int(end_time - current_time),
         pr_number=pull_number,
         is_completed=True,
+        retry_workflow_id_hash_pairs=existing_pairs,
     )
 
     # End notification


### PR DESCRIPTION
- Enhanced insert_usage to accept optional pr_number parameter
- Enhanced create_user_request to pass pr_number when available
- Enhanced update_usage to handle retry_workflow_id_hash_pairs
- Fixed check_run_handler to properly handle skipped duplicates
- Ensure usage records have pr_number set immediately in check_run scenarios
- Mark skipped duplicate requests as completed with proper data

This prevents orphaned incomplete usage records when GitHub sends duplicate webhooks for the same test failure event.

🤖 Generated with [Claude Code](https://claude.ai/code)