### PR TITLE
Add code quality requirements to commit mode prompts

### DIFF
--- a/utils/prompts/modes/commit_changes.xml
+++ b/utils/prompts/modes/commit_changes.xml
@@ -16,4 +16,14 @@
   <coding_rules>
     <rule>NEVER EVER place import statements in the body of the function</rule>
   </coding_rules>
+
+  <code_quality_requirement>
+    <instruction>Before committing, review your code as if you ran standard linting/formatting tools for that language and fix any issues they would detect.</instruction>
+    <examples>
+      <typescript>Issues that tsc --noEmit or eslint --fix would catch (unused imports, syntax errors, type issues)</typescript>
+      <python>Issues that pylint, pyright, black, or ruff check --fix would catch (unused imports, formatting, style violations)</python>
+      <other_languages>Apply the same principle - fix issues that standard linters/formatters for that language would detect</other_languages>
+    </examples>
+    <rationale>We cannot run these tools in our environment, but you have the knowledge to identify and fix these common issues manually. This prevents CI/CD failures and expensive fix cycles.</rationale>
+  </code_quality_requirement>
 </mode_instruction> 


### PR DESCRIPTION
- Instruct AI to review code for standard linting/formatting issues before committing
- Include examples for TypeScript (tsc --noEmit, eslint --fix) and Python (pylint, black, ruff)
- Apply same principle to all languages - fix issues that standard linters would detect
- Prevent CI/CD failures and expensive fix cycles by catching common issues early

This should reduce test_failure webhook costs by having AI self-review code quality before committing, similar to running linting tools manually.

🤖 Generated with [Claude Code](https://claude.ai/code)