### PR TITLE
Fix schedule handler to skip empty and whitespace-only files

### DIFF
--- a/services/webhook/schedule_handler.py
+++ b/services/webhook/schedule_handler.py
@@ -211,7 +211,12 @@ def schedule_handler(event: EventBridgeSchedulerEvent):
             ref=default_branch,
             token=token,
         )
-        if content and should_skip_test(item_path, content):
+        # Skip empty files or files with only whitespace
+        if not content or not content.strip():
+            continue
+
+        # Skip files that should be skipped based on content
+        if should_skip_test(item_path, content):
             continue
 
         # Skip files excluded from testing

--- a/utils/files/test_should_skip_python.py
+++ b/utils/files/test_should_skip_python.py
@@ -130,3 +130,19 @@ def test_whitespace_only():
 
     """
     assert should_skip_python(content) is True
+
+
+def test_init_file_with_imports():
+    # Typical __init__.py file with only imports and __all__
+    content = """from .module1 import Class1, function1
+from .module2 import Class2
+from .utils import helper_function
+
+__all__ = ['Class1', 'Class2', 'function1', 'helper_function']"""
+    assert should_skip_python(content) is True
+
+
+def test_empty_init_file():
+    # Empty __init__.py file
+    content = ""
+    assert should_skip_python(content) is True


### PR DESCRIPTION
- Add separate check for empty files or files with only whitespace
- Ensure should_skip_test is called for files with content
- Fix bug where empty __init__.py files were not being skipped
- Add tests for __init__.py file handling

🤖 Generated with [Claude Code](https://claude.ai/code)