### PR TITLE
Implement log deduplication to fix Claude API token overflow

### DIFF
--- a/services/anthropic/test_message_to_dict.py
+++ b/services/anthropic/test_message_to_dict.py
@@ -3,6 +3,7 @@ from services.anthropic.message_to_dict import message_to_dict
 
 def create_mock_message(**kwargs):
     from types import SimpleNamespace
+
     return SimpleNamespace(**kwargs)
 
 

--- a/services/github/workflow_runs/get_workflow_run_logs_deduplicated.txt
+++ b/services/github/workflow_runs/get_workflow_run_logs_deduplicated.txt
@@ -1,0 +1,279 @@
+```GitHub Check Run Log: build/6_Run pytest.txt
+##[group]Run python -m pytest -r fE -x --cov-branch --cov=./ --cov-report=lcov:coverage/lcov.info
+[36;1mpython -m pytest -r fE -x --cov-branch --cov=./ --cov-report=lcov:coverage/lcov.info[0m
+shell: /usr/bin/bash -e {0}
+env:
+  pythonLocation: /opt/hostedtoolcache/Python/3.12.11/x64
+  PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.12.11/x64/lib/pkgconfig
+  Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.11/x64
+  Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.11/x64
+  Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.11/x64
+  LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.12.11/x64/lib
+  PYTHONPATH: /home/runner/work/gitauto/gitauto
+  GH_APP_ID: ***
+  GH_APP_NAME: ***
+  GH_APP_USER_ID: ***
+  GH_APP_USER_NAME: ***
+  GH_PRIVATE_KEY: ***
+  GH_WEBHOOK_SECRET: ***
+  ANTHROPIC_API_KEY: ***
+  OPENAI_API_KEY: ***
+  OPENAI_ORG_ID: ***
+
+  RESEND_API_KEY: ***
+  SENTRY_DSN: ***
+  SUPABASE_SERVICE_ROLE_KEY: ***
+  SUPABASE_URL: ***
+  STRIPE_API_KEY: ***
+  STRIPE_FREE_TIER_PRICE_ID: ***
+  STRIPE_PRODUCT_ID_FREE: ***
+  STRIPE_PRODUCT_ID_STANDARD: ***
+  ENV: ***
+  PRODUCT_ID: ***
+##[endgroup]
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
+The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
+
+  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
+============================= test session starts ==============================
+platform linux -- Python 3.12.11, pytest-8.3.3, pluggy-1.5.0
+rootdir: /home/runner/work/gitauto/gitauto
+plugins: cov-6.0.0, anyio-4.4.0, asyncio-0.26.0, Faker-24.14.1
+asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 2276 items
+
+services/anthropic/test_client.py ..................                     [  0%]
+services/anthropic/test_client_integration.py ..                         [  0%]
+services/anthropic/test_exceptions.py ................                   [  1%]
+services/anthropic/test_message_to_dict.py ........                      [  1%]
+services/anthropic/test_trim_messages.py .........                       [  2%]
+services/aws/test_delete_scheduler.py ....................               [  3%]
+services/aws/test_get_schedulers.py ................                     [  3%]
+services/circleci/test_get_build_logs.py ....                            [  4%]
+services/circleci/test_get_workflow_jobs.py ...                          [  4%]
+services/coverages/test_create_coverage_report.py ...........            [  4%]
+services/coverages/test_create_empty_stats.py .........                  [  5%]
+services/git/test_clone_repo.py ...                                      [  5%]
+services/github/artifacts/test_download_artifact.py ..................   [  6%]
+services/github/artifacts/test_get_workflow_artifacts.py .............   [  6%]
+services/github/branches/test_check_branch_exists.py ................... [  7%]
+..............                                                           [  8%]
+services/github/branches/test_create_remote_branch.py .................. [  8%]
+....                                                                     [  9%]
+services/github/branches/test_get_default_branch.py .................... [  9%]
+..                                                                       [  9%]
+services/github/collaborators/test_check_user_is_collaborator.py ....... [ 10%]
+....                                                                     [ 10%]
+services/github/comments/test_create_comment.py .....                    [ 10%]
+services/github/comments/test_delete_comment.py .............            [ 11%]
+services/github/comments/test_delete_comments_by_identifiers.py ........ [ 11%]
+.............                                                            [ 12%]
+services/github/comments/test_filter_comments_by_identifiers.py ........ [ 12%]
+...                                                                      [ 12%]
+services/github/comments/test_get_all_comments.py ...................... [ 13%]
+....                                                                     [ 13%]
+services/github/comments/test_get_comments.py ....                       [ 13%]
+services/github/comments/test_has_comment_with_text.py ............      [ 14%]
+services/github/comments/test_reply_to_comment.py ...................... [ 15%]
+                                                                         [ 15%]
+services/github/comments/test_update_comment.py ..........               [ 15%]
+services/github/commits/test_create_commit.py .....................      [ 16%]
+services/github/commits/test_create_empty_commit.py ...................  [ 17%]
+services/github/commits/test_get_commit.py ....................          [ 18%]
+services/github/commits/test_get_commit_diff.py ............             [ 19%]
+services/github/installations/test_get_installation_permissions.py ..... [ 19%]
+...                                                                      [ 19%]
+services/github/issues/test_create_issue.py .........                    [ 19%]
+services/github/issues/test_get_issue_body.py ........................   [ 20%]
+services/github/issues/test_get_parent_issue.py ...................      [ 21%]
+services/github/issues/test_is_issue_open.py ..................          [ 22%]
+services/github/markdown/test_render_text.py ........................... [ 23%]
+..........                                                               [ 24%]
+services/github/pulls/test_create_pull_request.py ..........             [ 24%]
+services/github/pulls/test_find_pull_request_by_branch.py .............. [ 25%]
+........                                                                 [ 25%]
+services/github/pulls/test_get_pull_request.py ..........                [ 25%]
+services/github/pulls/test_is_pull_request_open.py .........             [ 26%]
+services/github/pulls/test_update_pull_request_body.py ................. [ 27%]
+......                                                                   [ 27%]
+services/github/reactions/test_add_reaction_to_issue.py ssssssss         [ 27%]
+services/github/refs/test_get_reference.py .....................         [ 28%]
+services/github/refs/test_update_reference.py .......................... [ 29%]
+..........................                                               [ 30%]
+services/github/repositories/test_get_repository_languages.py .......... [ 31%]
+....                                                                     [ 31%]
+services/github/repositories/test_get_repository_stats.py .............. [ 32%]
+.............                                                            [ 32%]
+services/github/repositories/test_is_repo_forked.py ......               [ 32%]
+services/github/repositories/test_is_repo_forked_integration.py ....     [ 33%]
+services/github/repositories/test_turn_on_issue.py ..........            [ 33%]
+services/github/test_graphql_client.py ..                                [ 33%]
+services/github/trees/test_create_tree.py .........F
+
+=================================== FAILURES ===================================
+______________________ test_create_tree_rate_limit_error _______________________
+
+args = ({'base_branch': 'main', 'clone_url': 'https://github.com/gitautoai/gitauto.git', 'github_urls': [], 'input_from': 'gi..._file.py', 'type': 'blob'}, {'content': '# Test README', 'mode': '100644', 'path': 'another_file.md', 'type': 'blob'}])
+kwargs = {}
+truncated_args = [{'base_branch': 'main', 'clone_url': 'https://github.com/gitautoai/g...', 'github_urls': [], 'input_from': 'github', ..._file.py', 'type': 'blob'}, {'content': '# Test README', 'mode': '100644', 'path': 'another_file.md', 'type': 'blob'}]]
+truncated_kwargs = {}, status_code = 403, reason = 'Forbidden'
+text = 'API rate limit exceeded', limit = 5000
+
+    @wraps(wrapped=func)
+    def wrapper(*args: Tuple[Any, ...], **kwargs: Any):
+        # Create truncated args and kwargs at the beginning
+        truncated_args = [truncate_value(arg) for arg in args]
+        truncated_kwargs = {
+            key: truncate_value(value) for key, value in kwargs.items()
+        }
+    
+        try:
+>           return func(*args, **kwargs)
+
+utils/error/handle_exceptions.py:36: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <Mock name='post().raise_for_status' id='140461186535488'>, args = ()
+kwargs = {}, effect = HTTPError()
+
+    def _execute_mock_call(self, /, *args, **kwargs):
+        # separate from _increment_mock_call so that awaited functions are
+        # executed separately from their call, also AsyncMock overrides this method
+    
+        effect = self.side_effect
+        if effect is not None:
+            if _is_exception(effect):
+>               raise effect
+E               requests.exceptions.HTTPError
+
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: HTTPError
+
+During handling of the above exception, another exception occurred:
+
+base_args = {'base_branch': 'main', 'clone_url': 'https://github.com/gitautoai/gitauto.git', 'github_urls': [], 'input_from': 'github', ...}
+tree_items = [{'content': "print('Hello, World!')", 'mode': '100644', 'path': 'test_file.py', 'type': 'blob'}, {'content': '# Test README', 'mode': '100644', 'path': 'another_file.md', 'type': 'blob'}]
+mock_headers = {'Accept': 'application/vnd.github.v3+json', 'Authorization': '***', 'User-Agent': 'test-app', 'X-GitHub-Api-Version': '2022-11-28'}
+
+    def test_create_tree_rate_limit_error(base_args, tree_items, mock_headers):
+        base_tree_sha = "base_tree_sha_123"
+    
+        mock_response = Mock()
+        mock_response.status_code = 403
+        mock_response.reason = "Forbidden"
+        mock_response.text = "API rate limit exceeded"
+        mock_response.headers = {
+            "X-RateLimit-Limit": "5000",
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Used": "5000",
+            "X-RateLimit-Reset": "1234567890"
+        }
+        http_error = requests.exceptions.HTTPError()
+        http_error.response = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+    
+        with patch("services.github.trees.create_tree.requests.post") as mock_post, patch(
+            "services.github.trees.create_tree.create_headers"
+        ) as mock_create_headers, patch("time.time") as mock_time, patch("time.sleep") as mock_sleep:
+    
+            mock_post.return_value = mock_response
+            mock_create_headers.return_value = mock_headers
+            mock_time.return_value = 1234567880  # 10 seconds before reset
+    
+>           result = create_tree(base_args, base_tree_sha, tree_items)
+
+services/github/trees/test_create_tree.py:323: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+utils/error/handle_exceptions.py:64: in wrapper
+    return wrapper(*args, **kwargs)
+utils/error/handle_exceptions.py:64: in wrapper
+    return wrapper(*args, **kwargs)
+E   RecursionError: maximum recursion depth exceeded
+!!! Recursion detected (same locals & position)
+----------------------------- Captured stdout call -----------------------------
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+------------------------------ Captured log call -------------------------------
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+=============================== warnings summary ===============================
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_success
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_different_reactions
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_different_repositories
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_http_error_handled
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_request_exception_handled
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_json_decode_error_handled
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_edge_case_values
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_response_json_called
+  /opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/_pytest/python.py:148: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.
+  You need to install a suitable plugin for your async framework, for example:
+    - anyio
+    - pytest-asyncio
+    - pytest-tornasync
+    - pytest-trio
+    - pytest-twisted
+    warnings.warn(PytestUnhandledCoroutineWarning(msg.format(nodeid)))
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+
+---------- coverage: platform linux, python 3.12.11-final-0 ----------
+Coverage LCOV written to file coverage/lcov.info
+
+=========================== short test summary info ============================
+FAILED services/github/trees/test_create_tree.py::test_create_tree_rate_limit_error - RecursionError: maximum recursion depth exceeded
+!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
+======= 1 failed, 768 passed, 8 skipped, 8 warnings in 138.76s (0:02:18) =======
+##[error]Process completed with exit code 1.
+##[group]Run actions/upload-artifact@v4
+with:
+  name: coverage-report
+  path: coverage/lcov.info
+  if-no-files-found: warn
+  compression-level: 6
+  overwrite: false
+  include-hidden-files: false
+env:
+  pythonLocation: /opt/hostedtoolcache/Python/3.12.11/x64
+  PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.12.11/x64/lib/pkgconfig
+  Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.11/x64
+  Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.11/x64
+  Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.11/x64
+  LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.12.11/x64/lib
+  PYTHONPATH: /home/runner/work/gitauto/gitauto
+##[endgroup]
+With the provided path, there will be 1 file uploaded
+Artifact name is valid!
+Root directory input is valid!
+Beginning upload of artifact content to blob storage
+Uploaded bytes 88726
+Finished uploading artifact content to blob storage!
+SHA256 digest of uploaded artifact zip is 23e2fb7961a0f9e22b8352feba0688007fabbcbf69a8fad4cb91f64e8a38afe3
+Finalizing artifact upload
+Artifact coverage-report.zip successfully finalized. Artifact ID 3836046657
+Artifact coverage-report has been successfully uploaded! Final size is 88726 bytes. Artifact ID is 3836046657
+Artifact download URL: https://github.com/gitautoai/gitauto/actions/runs/17181772238/artifacts/3836046657
+Post job cleanup.
+[command]/usr/bin/git version
+git version 2.51.0
+Temporarily overriding HOME='/home/runner/work/_temp/645f6149-ccdf-45c8-a81b-710c860579c0' before making global git config changes
+Adding repository directory to the temporary git global config as a safe directory
+[command]/usr/bin/git config --global --add safe.directory /home/runner/work/gitauto/gitauto
+[command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+[command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+[command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+http.https://github.com/.extraheader
+[command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+[command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Cleaning up orphan processes
+```

--- a/services/github/workflow_runs/get_workflow_run_logs_duplicated.txt
+++ b/services/github/workflow_runs/get_workflow_run_logs_duplicated.txt
@@ -1,0 +1,14580 @@
+```GitHub Check Run Log: build/6_Run pytest.txt
+##[group]Run python -m pytest -r fE -x --cov-branch --cov=./ --cov-report=lcov:coverage/lcov.info
+[36;1mpython -m pytest -r fE -x --cov-branch --cov=./ --cov-report=lcov:coverage/lcov.info[0m
+shell: /usr/bin/bash -e {0}
+env:
+  pythonLocation: /opt/hostedtoolcache/Python/3.12.11/x64
+  PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.12.11/x64/lib/pkgconfig
+  Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.11/x64
+  Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.11/x64
+  Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.11/x64
+  LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.12.11/x64/lib
+  PYTHONPATH: /home/runner/work/gitauto/gitauto
+  GH_APP_ID: ***
+  GH_APP_NAME: ***
+  GH_APP_USER_ID: ***
+  GH_APP_USER_NAME: ***
+  GH_PRIVATE_KEY: ***
+  GH_WEBHOOK_SECRET: ***
+  ANTHROPIC_API_KEY: ***
+  OPENAI_API_KEY: ***
+  OPENAI_ORG_ID: ***
+
+  RESEND_API_KEY: ***
+  SENTRY_DSN: ***
+  SUPABASE_SERVICE_ROLE_KEY: ***
+  SUPABASE_URL: ***
+  STRIPE_API_KEY: ***
+  STRIPE_FREE_TIER_PRICE_ID: ***
+  STRIPE_PRODUCT_ID_FREE: ***
+  STRIPE_PRODUCT_ID_STANDARD: ***
+  ENV: ***
+  PRODUCT_ID: ***
+##[endgroup]
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
+The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
+
+  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
+============================= test session starts ==============================
+platform linux -- Python 3.12.11, pytest-8.3.3, pluggy-1.5.0
+rootdir: /home/runner/work/gitauto/gitauto
+plugins: cov-6.0.0, anyio-4.4.0, asyncio-0.26.0, Faker-24.14.1
+asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 2276 items
+
+services/anthropic/test_client.py ..................                     [  0%]
+services/anthropic/test_client_integration.py ..                         [  0%]
+services/anthropic/test_exceptions.py ................                   [  1%]
+services/anthropic/test_message_to_dict.py ........                      [  1%]
+services/anthropic/test_trim_messages.py .........                       [  2%]
+services/aws/test_delete_scheduler.py ....................               [  3%]
+services/aws/test_get_schedulers.py ................                     [  3%]
+services/circleci/test_get_build_logs.py ....                            [  4%]
+services/circleci/test_get_workflow_jobs.py ...                          [  4%]
+services/coverages/test_create_coverage_report.py ...........            [  4%]
+services/coverages/test_create_empty_stats.py .........                  [  5%]
+services/git/test_clone_repo.py ...                                      [  5%]
+services/github/artifacts/test_download_artifact.py ..................   [  6%]
+services/github/artifacts/test_get_workflow_artifacts.py .............   [  6%]
+services/github/branches/test_check_branch_exists.py ................... [  7%]
+..............                                                           [  8%]
+services/github/branches/test_create_remote_branch.py .................. [  8%]
+....                                                                     [  9%]
+services/github/branches/test_get_default_branch.py .................... [  9%]
+..                                                                       [  9%]
+services/github/collaborators/test_check_user_is_collaborator.py ....... [ 10%]
+....                                                                     [ 10%]
+services/github/comments/test_create_comment.py .....                    [ 10%]
+services/github/comments/test_delete_comment.py .............            [ 11%]
+services/github/comments/test_delete_comments_by_identifiers.py ........ [ 11%]
+.............                                                            [ 12%]
+services/github/comments/test_filter_comments_by_identifiers.py ........ [ 12%]
+...                                                                      [ 12%]
+services/github/comments/test_get_all_comments.py ...................... [ 13%]
+....                                                                     [ 13%]
+services/github/comments/test_get_comments.py ....                       [ 13%]
+services/github/comments/test_has_comment_with_text.py ............      [ 14%]
+services/github/comments/test_reply_to_comment.py ...................... [ 15%]
+                                                                         [ 15%]
+services/github/comments/test_update_comment.py ..........               [ 15%]
+services/github/commits/test_create_commit.py .....................      [ 16%]
+services/github/commits/test_create_empty_commit.py ...................  [ 17%]
+services/github/commits/test_get_commit.py ....................          [ 18%]
+services/github/commits/test_get_commit_diff.py ............             [ 19%]
+services/github/installations/test_get_installation_permissions.py ..... [ 19%]
+...                                                                      [ 19%]
+services/github/issues/test_create_issue.py .........                    [ 19%]
+services/github/issues/test_get_issue_body.py ........................   [ 20%]
+services/github/issues/test_get_parent_issue.py ...................      [ 21%]
+services/github/issues/test_is_issue_open.py ..................          [ 22%]
+services/github/markdown/test_render_text.py ........................... [ 23%]
+..........                                                               [ 24%]
+services/github/pulls/test_create_pull_request.py ..........             [ 24%]
+services/github/pulls/test_find_pull_request_by_branch.py .............. [ 25%]
+........                                                                 [ 25%]
+services/github/pulls/test_get_pull_request.py ..........                [ 25%]
+services/github/pulls/test_is_pull_request_open.py .........             [ 26%]
+services/github/pulls/test_update_pull_request_body.py ................. [ 27%]
+......                                                                   [ 27%]
+services/github/reactions/test_add_reaction_to_issue.py ssssssss         [ 27%]
+services/github/refs/test_get_reference.py .....................         [ 28%]
+services/github/refs/test_update_reference.py .......................... [ 29%]
+..........................                                               [ 30%]
+services/github/repositories/test_get_repository_languages.py .......... [ 31%]
+....                                                                     [ 31%]
+services/github/repositories/test_get_repository_stats.py .............. [ 32%]
+.............                                                            [ 32%]
+services/github/repositories/test_is_repo_forked.py ......               [ 32%]
+services/github/repositories/test_is_repo_forked_integration.py ....     [ 33%]
+services/github/repositories/test_turn_on_issue.py ..........            [ 33%]
+services/github/test_graphql_client.py ..                                [ 33%]
+services/github/trees/test_create_tree.py .........F
+
+=================================== FAILURES ===================================
+______________________ test_create_tree_rate_limit_error _______________________
+
+args = ({'base_branch': 'main', 'clone_url': 'https://github.com/gitautoai/gitauto.git', 'github_urls': [], 'input_from': 'gi..._file.py', 'type': 'blob'}, {'content': '# Test README', 'mode': '100644', 'path': 'another_file.md', 'type': 'blob'}])
+kwargs = {}
+truncated_args = [{'base_branch': 'main', 'clone_url': 'https://github.com/gitautoai/g...', 'github_urls': [], 'input_from': 'github', ..._file.py', 'type': 'blob'}, {'content': '# Test README', 'mode': '100644', 'path': 'another_file.md', 'type': 'blob'}]]
+truncated_kwargs = {}, status_code = 403, reason = 'Forbidden'
+text = 'API rate limit exceeded', limit = 5000
+
+    @wraps(wrapped=func)
+    def wrapper(*args: Tuple[Any, ...], **kwargs: Any):
+        # Create truncated args and kwargs at the beginning
+        truncated_args = [truncate_value(arg) for arg in args]
+        truncated_kwargs = {
+            key: truncate_value(value) for key, value in kwargs.items()
+        }
+    
+        try:
+>           return func(*args, **kwargs)
+
+utils/error/handle_exceptions.py:36: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: in _execute_mock_call
+    raise effect
+utils/error/handle_exceptions.py:36: in wrapper
+    return func(*args, **kwargs)
+services/github/trees/create_tree.py:24: in create_tree
+    response.raise_for_status()
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1139: in __call__
+    return self._mock_call(*args, **kwargs)
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1143: in _mock_call
+    return self._execute_mock_call(*args, **kwargs)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <Mock name='post().raise_for_status' id='140461186535488'>, args = ()
+kwargs = {}, effect = HTTPError()
+
+    def _execute_mock_call(self, /, *args, **kwargs):
+        # separate from _increment_mock_call so that awaited functions are
+        # executed separately from their call, also AsyncMock overrides this method
+    
+        effect = self.side_effect
+        if effect is not None:
+            if _is_exception(effect):
+>               raise effect
+E               requests.exceptions.HTTPError
+
+/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/unittest/mock.py:1198: HTTPError
+
+During handling of the above exception, another exception occurred:
+
+base_args = {'base_branch': 'main', 'clone_url': 'https://github.com/gitautoai/gitauto.git', 'github_urls': [], 'input_from': 'github', ...}
+tree_items = [{'content': "print('Hello, World!')", 'mode': '100644', 'path': 'test_file.py', 'type': 'blob'}, {'content': '# Test README', 'mode': '100644', 'path': 'another_file.md', 'type': 'blob'}]
+mock_headers = {'Accept': 'application/vnd.github.v3+json', 'Authorization': '***', 'User-Agent': 'test-app', 'X-GitHub-Api-Version': '2022-11-28'}
+
+    def test_create_tree_rate_limit_error(base_args, tree_items, mock_headers):
+        base_tree_sha = "base_tree_sha_123"
+    
+        mock_response = Mock()
+        mock_response.status_code = 403
+        mock_response.reason = "Forbidden"
+        mock_response.text = "API rate limit exceeded"
+        mock_response.headers = {
+            "X-RateLimit-Limit": "5000",
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Used": "5000",
+            "X-RateLimit-Reset": "1234567890"
+        }
+        http_error = requests.exceptions.HTTPError()
+        http_error.response = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+    
+        with patch("services.github.trees.create_tree.requests.post") as mock_post, patch(
+            "services.github.trees.create_tree.create_headers"
+        ) as mock_create_headers, patch("time.time") as mock_time, patch("time.sleep") as mock_sleep:
+    
+            mock_post.return_value = mock_response
+            mock_create_headers.return_value = mock_headers
+            mock_time.return_value = 1234567880  # 10 seconds before reset
+    
+>           result = create_tree(base_args, base_tree_sha, tree_items)
+
+services/github/trees/test_create_tree.py:323: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+utils/error/handle_exceptions.py:64: in wrapper
+    return wrapper(*args, **kwargs)
+utils/error/handle_exceptions.py:64: in wrapper
+    return wrapper(*args, **kwargs)
+E   RecursionError: maximum recursion depth exceeded
+!!! Recursion detected (same locals & position)
+----------------------------- Captured stdout call -----------------------------
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+reason: Forbidden, text: API rate limit exceeded, status_code: 403
+err.response.headers: {'X-RateLimit-Limit': '5000', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Used': '5000', 'X-RateLimit-Reset': '1234567890'}
+------------------------------ Captured log call -------------------------------
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+
+
+WARNING  root:handle_exceptions.py:62 create_tree encountered a GitHubPrimaryRateLimitError: . Retrying after 10 seconds. Limit: 5000, Remaining: 0, Used: 5000. Reason: Forbidden. Text: API rate limit exceeded
+=============================== warnings summary ===============================
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_success
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_different_reactions
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_different_repositories
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_http_error_handled
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_request_exception_handled
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_json_decode_error_handled
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_edge_case_values
+services/github/reactions/test_add_reaction_to_issue.py::test_add_reaction_to_issue_response_json_called
+  /opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/_pytest/python.py:148: PytestUnhandledCoroutineWarning: async def functions are not natively supported and have been skipped.
+  You need to install a suitable plugin for your async framework, for example:
+    - anyio
+    - pytest-asyncio
+    - pytest-tornasync
+    - pytest-trio
+    - pytest-twisted
+    warnings.warn(PytestUnhandledCoroutineWarning(msg.format(nodeid)))
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+
+---------- coverage: platform linux, python 3.12.11-final-0 ----------
+Coverage LCOV written to file coverage/lcov.info
+
+=========================== short test summary info ============================
+FAILED services/github/trees/test_create_tree.py::test_create_tree_rate_limit_error - RecursionError: maximum recursion depth exceeded
+!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
+======= 1 failed, 768 passed, 8 skipped, 8 warnings in 138.76s (0:02:18) =======
+##[error]Process completed with exit code 1.
+##[group]Run actions/upload-artifact@v4
+with:
+  name: coverage-report
+  path: coverage/lcov.info
+  if-no-files-found: warn
+  compression-level: 6
+  overwrite: false
+  include-hidden-files: false
+env:
+  pythonLocation: /opt/hostedtoolcache/Python/3.12.11/x64
+  PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.12.11/x64/lib/pkgconfig
+  Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.11/x64
+  Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.11/x64
+  Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.11/x64
+  LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.12.11/x64/lib
+  PYTHONPATH: /home/runner/work/gitauto/gitauto
+##[endgroup]
+With the provided path, there will be 1 file uploaded
+Artifact name is valid!
+Root directory input is valid!
+Beginning upload of artifact content to blob storage
+Uploaded bytes 88726
+Finished uploading artifact content to blob storage!
+SHA256 digest of uploaded artifact zip is 23e2fb7961a0f9e22b8352feba0688007fabbcbf69a8fad4cb91f64e8a38afe3
+Finalizing artifact upload
+Artifact coverage-report.zip successfully finalized. Artifact ID 3836046657
+Artifact coverage-report has been successfully uploaded! Final size is 88726 bytes. Artifact ID is 3836046657
+Artifact download URL: https://github.com/gitautoai/gitauto/actions/runs/17181772238/artifacts/3836046657
+Post job cleanup.
+[command]/usr/bin/git version
+git version 2.51.0
+Temporarily overriding HOME='/home/runner/work/_temp/645f6149-ccdf-45c8-a81b-710c860579c0' before making global git config changes
+Adding repository directory to the temporary git global config as a safe directory
+[command]/usr/bin/git config --global --add safe.directory /home/runner/work/gitauto/gitauto
+[command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+[command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+[command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+http.https://github.com/.extraheader
+[command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+[command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Cleaning up orphan processes
+```

--- a/services/github/workflow_runs/test_get_workflow_runs.py
+++ b/services/github/workflow_runs/test_get_workflow_runs.py
@@ -46,7 +46,7 @@ def mock_workflow_runs_response():
                 "workflow_url": "https://api.github.com/repos/owner/repo/actions/workflows/123",
                 "head_commit": {"id": "abc123def456", "message": "Test commit"},
                 "repository": {"id": 123, "name": "repo"},
-                "head_repository": {"id": 123, "name": "repo"}
+                "head_repository": {"id": 123, "name": "repo"},
             }
         ]
     }
@@ -67,7 +67,9 @@ def mock_headers():
     return {"Authorization": f"Bearer {TOKEN}"}
 
 
-def test_get_workflow_runs_success_with_commit_sha(mock_successful_response, mock_headers, mock_workflow_runs_response):
+def test_get_workflow_runs_success_with_commit_sha(
+    mock_successful_response, mock_headers, mock_workflow_runs_response
+):
     """Test successful retrieval of workflow runs with commit_sha."""
     # Arrange
     commit_sha = "abc123def456"
@@ -97,7 +99,9 @@ def test_get_workflow_runs_success_with_commit_sha(mock_successful_response, moc
     assert result == expected_workflow_runs
 
 
-def test_get_workflow_runs_success_with_branch(mock_successful_response, mock_headers, mock_workflow_runs_response):
+def test_get_workflow_runs_success_with_branch(
+    mock_successful_response, mock_headers, mock_workflow_runs_response
+):
     """Test successful retrieval of workflow runs with branch."""
     # Arrange
     branch = "feature-branch"
@@ -127,7 +131,9 @@ def test_get_workflow_runs_success_with_branch(mock_successful_response, mock_he
     assert result == expected_workflow_runs
 
 
-def test_get_workflow_runs_both_commit_sha_and_branch_prefers_commit_sha(mock_successful_response, mock_headers):
+def test_get_workflow_runs_both_commit_sha_and_branch_prefers_commit_sha(
+    mock_successful_response, mock_headers
+):
     """Test that commit_sha takes precedence when both commit_sha and branch are provided."""
     # Arrange
     commit_sha = "abc123def456"
@@ -335,7 +341,9 @@ def test_get_workflow_runs_missing_workflow_runs_key():
     branch = "main"
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"other_field": "value"}  # Missing 'workflow_runs' key
+    mock_response.json.return_value = {
+        "other_field": "value"
+    }  # Missing 'workflow_runs' key
 
     # Act
     with patch(

--- a/services/supabase/usage/test_count_completed_unique_requests.py
+++ b/services/supabase/usage/test_count_completed_unique_requests.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from unittest.mock import Mock, patch
 import requests
 
-from services.supabase.usage.count_completed_unique_requests import count_completed_unique_requests
+from services.supabase.usage.count_completed_unique_requests import (
+    count_completed_unique_requests,
+)
 
 
 def test_count_completed_unique_requests_with_valid_data():
@@ -13,17 +15,19 @@ def test_count_completed_unique_requests_with_valid_data():
             "owner_type": "Organization",
             "owner_name": "gitautoai",
             "repo_name": "gitauto",
-            "issue_number": 123
+            "issue_number": 123,
         },
         {
             "owner_type": "User",
             "owner_name": "john_doe",
             "repo_name": "my_repo",
-            "issue_number": 456
-        }
+            "issue_number": 456,
+        },
     ]
-    
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table
         mock_table.select.return_value = mock_table
@@ -31,23 +35,24 @@ def test_count_completed_unique_requests_with_valid_data():
         mock_table.eq.return_value = mock_table
         mock_table.in_.return_value = mock_table
         mock_table.execute.return_value = ((None, mock_data), None)
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
-        expected = {
-            "Organization/gitautoai/gitauto#123",
-            "User/john_doe/my_repo#456"
-        }
+
+        expected = {"Organization/gitautoai/gitauto#123", "User/john_doe/my_repo#456"}
         assert result == expected
-        
+
         # Verify the query was built correctly
         mock_supabase.table.assert_called_once_with("usage")
-        mock_table.select.assert_called_once_with("owner_type, owner_name, repo_name, issue_number")
+        mock_table.select.assert_called_once_with(
+            "owner_type, owner_name, repo_name, issue_number"
+        )
         mock_table.gt.assert_called_once_with("created_at", start_date)
         mock_table.eq.assert_any_call("installation_id", 123)
         mock_table.eq.assert_any_call("is_completed", True)
-        mock_table.in_.assert_called_once_with("trigger", ["issue_comment", "issue_label", "pull_request"])
+        mock_table.in_.assert_called_once_with(
+            "trigger", ["issue_comment", "issue_label", "pull_request"]
+        )
         mock_table.execute.assert_called_once()
 
 
@@ -58,23 +63,25 @@ def test_count_completed_unique_requests_with_duplicate_data():
             "owner_type": "Organization",
             "owner_name": "gitautoai",
             "repo_name": "gitauto",
-            "issue_number": 123
+            "issue_number": 123,
         },
         {
             "owner_type": "Organization",
             "owner_name": "gitautoai",
             "repo_name": "gitauto",
-            "issue_number": 123
+            "issue_number": 123,
         },
         {
             "owner_type": "User",
             "owner_name": "john_doe",
             "repo_name": "my_repo",
-            "issue_number": 456
-        }
+            "issue_number": 456,
+        },
     ]
-    
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table
         mock_table.select.return_value = mock_table
@@ -82,22 +89,21 @@ def test_count_completed_unique_requests_with_duplicate_data():
         mock_table.eq.return_value = mock_table
         mock_table.in_.return_value = mock_table
         mock_table.execute.return_value = ((None, mock_data), None)
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         # Should only have 2 unique requests despite 3 records
-        expected = {
-            "Organization/gitautoai/gitauto#123",
-            "User/john_doe/my_repo#456"
-        }
+        expected = {"Organization/gitautoai/gitauto#123", "User/john_doe/my_repo#456"}
         assert result == expected
         assert len(result) == 2
 
 
 def test_count_completed_unique_requests_with_empty_data():
     """Test with empty data response"""
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table
         mock_table.select.return_value = mock_table
@@ -105,16 +111,18 @@ def test_count_completed_unique_requests_with_empty_data():
         mock_table.eq.return_value = mock_table
         mock_table.in_.return_value = mock_table
         mock_table.execute.return_value = ((None, []), None)
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         assert result == set()
 
 
 def test_count_completed_unique_requests_with_none_data():
     """Test with None data response"""
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table
         mock_table.select.return_value = mock_table
@@ -122,10 +130,10 @@ def test_count_completed_unique_requests_with_none_data():
         mock_table.eq.return_value = mock_table
         mock_table.in_.return_value = mock_table
         mock_table.execute.return_value = ((None, None), None)
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         assert result == set()
 
 
@@ -136,11 +144,13 @@ def test_count_completed_unique_requests_with_zero_installation_id():
             "owner_type": "Organization",
             "owner_name": "test_org",
             "repo_name": "test_repo",
-            "issue_number": 1
+            "issue_number": 1,
         }
     ]
-    
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table
         mock_table.select.return_value = mock_table
@@ -148,10 +158,10 @@ def test_count_completed_unique_requests_with_zero_installation_id():
         mock_table.eq.return_value = mock_table
         mock_table.in_.return_value = mock_table
         mock_table.execute.return_value = ((None, mock_data), None)
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(0, start_date)
-        
+
         expected = {"Organization/test_org/test_repo#1"}
         assert result == expected
         mock_table.eq.assert_any_call("installation_id", 0)
@@ -164,11 +174,13 @@ def test_count_completed_unique_requests_with_negative_installation_id():
             "owner_type": "User",
             "owner_name": "negative_user",
             "repo_name": "negative_repo",
-            "issue_number": 999
+            "issue_number": 999,
         }
     ]
-    
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table
         mock_table.select.return_value = mock_table
@@ -176,10 +188,10 @@ def test_count_completed_unique_requests_with_negative_installation_id():
         mock_table.eq.return_value = mock_table
         mock_table.in_.return_value = mock_table
         mock_table.execute.return_value = ((None, mock_data), None)
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(-1, start_date)
-        
+
         expected = {"User/negative_user/negative_repo#999"}
         assert result == expected
         mock_table.eq.assert_any_call("installation_id", -1)
@@ -192,11 +204,13 @@ def test_count_completed_unique_requests_with_large_installation_id():
             "owner_type": "Organization",
             "owner_name": "large_org",
             "repo_name": "large_repo",
-            "issue_number": 888888
+            "issue_number": 888888,
         }
     ]
-    
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table
         mock_table.select.return_value = mock_table
@@ -204,10 +218,10 @@ def test_count_completed_unique_requests_with_large_installation_id():
         mock_table.eq.return_value = mock_table
         mock_table.in_.return_value = mock_table
         mock_table.execute.return_value = ((None, mock_data), None)
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(999999999, start_date)
-        
+
         expected = {"Organization/large_org/large_repo#888888"}
         assert result == expected
         mock_table.eq.assert_any_call("installation_id", 999999999)
@@ -220,17 +234,19 @@ def test_count_completed_unique_requests_with_special_characters():
             "owner_type": "Organization",
             "owner_name": "org-with-dashes",
             "repo_name": "repo_with_underscores",
-            "issue_number": 123
+            "issue_number": 123,
         },
         {
             "owner_type": "User",
             "owner_name": "user.with.dots",
             "repo_name": "repo-with-dashes",
-            "issue_number": 456
-        }
+            "issue_number": 456,
+        },
     ]
-    
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table
         mock_table.select.return_value = mock_table
@@ -238,70 +254,80 @@ def test_count_completed_unique_requests_with_special_characters():
         mock_table.eq.return_value = mock_table
         mock_table.in_.return_value = mock_table
         mock_table.execute.return_value = ((None, mock_data), None)
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         expected = {
             "Organization/org-with-dashes/repo_with_underscores#123",
-            "User/user.with.dots/repo-with-dashes#456"
+            "User/user.with.dots/repo-with-dashes#456",
         }
         assert result == expected
 
 
 def test_count_completed_unique_requests_with_exception():
     """Test when supabase raises an exception"""
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_supabase.table.side_effect = Exception("Database error")
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         # Should return default value (empty set) due to handle_exceptions decorator
         assert result == set()
 
 
 def test_count_completed_unique_requests_with_attribute_error():
     """Test when AttributeError is raised"""
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_supabase.table.side_effect = AttributeError("Attribute error")
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         assert result == set()
 
 
 def test_count_completed_unique_requests_with_key_error():
     """Test when KeyError is raised"""
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_supabase.table.side_effect = KeyError("Key error")
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         assert result == set()
 
 
 def test_count_completed_unique_requests_with_type_error():
     """Test when TypeError is raised"""
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_supabase.table.side_effect = TypeError("Type error")
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         assert result == set()
 
 
 def test_count_completed_unique_requests_with_json_decode_error():
     """Test when JSONDecodeError is raised"""
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_supabase.table.side_effect = json.JSONDecodeError("JSON error", "", 0)
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         assert result == set()
 
 
@@ -311,15 +337,17 @@ def test_count_completed_unique_requests_with_http_error_500():
     mock_response.status_code = 500
     mock_response.reason = "Internal Server Error"
     mock_response.text = "Server error"
-    
+
     http_error = requests.exceptions.HTTPError(response=mock_response)
-    
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_supabase.table.side_effect = http_error
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         assert result == set()
 
 
@@ -329,21 +357,25 @@ def test_count_completed_unique_requests_with_http_error_409():
     mock_response.status_code = 409
     mock_response.reason = "Conflict"
     mock_response.text = "Conflict error"
-    
+
     http_error = requests.exceptions.HTTPError(response=mock_response)
-    
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_supabase.table.side_effect = http_error
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         assert result == set()
 
 
 def test_count_completed_unique_requests_execute_exception():
     """Test when execute method raises an exception"""
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table
         mock_table.select.return_value = mock_table
@@ -351,10 +383,10 @@ def test_count_completed_unique_requests_execute_exception():
         mock_table.eq.return_value = mock_table
         mock_table.in_.return_value = mock_table
         mock_table.execute.side_effect = Exception("Execute error")
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         assert result == set()
 
 
@@ -369,12 +401,14 @@ def test_count_completed_unique_requests_with_malformed_data():
         {
             "owner_type": "User",
             "repo_name": "my_repo",
-            "issue_number": 456
+            "issue_number": 456,
             # Missing owner_name
-        }
+        },
     ]
-    
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table
         mock_table.select.return_value = mock_table
@@ -382,10 +416,10 @@ def test_count_completed_unique_requests_with_malformed_data():
         mock_table.eq.return_value = mock_table
         mock_table.in_.return_value = mock_table
         mock_table.execute.return_value = ((None, mock_data), None)
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         # Should return empty set due to KeyError in processing
         assert result == set()
 
@@ -397,11 +431,13 @@ def test_count_completed_unique_requests_with_different_start_dates():
             "owner_type": "Organization",
             "owner_name": "test_org",
             "repo_name": "test_repo",
-            "issue_number": 1
+            "issue_number": 1,
         }
     ]
-    
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table
         mock_table.select.return_value = mock_table
@@ -409,14 +445,14 @@ def test_count_completed_unique_requests_with_different_start_dates():
         mock_table.eq.return_value = mock_table
         mock_table.in_.return_value = mock_table
         mock_table.execute.return_value = ((None, mock_data), None)
-        
+
         # Test with different datetime formats
         start_dates = [
             datetime(2023, 1, 1, 0, 0, 0),
             datetime(2023, 12, 31, 23, 59, 59),
-            datetime(2024, 6, 15, 12, 30, 45)
+            datetime(2024, 6, 15, 12, 30, 45),
         ]
-        
+
         for start_date in start_dates:
             result = count_completed_unique_requests(123, start_date)
             expected = {"Organization/test_org/test_repo#1"}
@@ -431,11 +467,13 @@ def test_count_completed_unique_requests_with_single_record():
             "owner_type": "Organization",
             "owner_name": "single_org",
             "repo_name": "single_repo",
-            "issue_number": 42
+            "issue_number": 42,
         }
     ]
-    
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table
         mock_table.select.return_value = mock_table
@@ -443,10 +481,10 @@ def test_count_completed_unique_requests_with_single_record():
         mock_table.eq.return_value = mock_table
         mock_table.in_.return_value = mock_table
         mock_table.execute.return_value = ((None, mock_data), None)
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
+
         expected = {"Organization/single_org/single_repo#42"}
         assert result == expected
         assert len(result) == 1
@@ -459,17 +497,19 @@ def test_count_completed_unique_requests_with_numeric_strings():
             "owner_type": "Organization",
             "owner_name": "org123",
             "repo_name": "repo456",
-            "issue_number": 789
+            "issue_number": 789,
         },
         {
             "owner_type": "User",
             "owner_name": "user999",
             "repo_name": "project2023",
-            "issue_number": 1
-        }
+            "issue_number": 1,
+        },
     ]
-    
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table
         mock_table.select.return_value = mock_table
@@ -477,20 +517,19 @@ def test_count_completed_unique_requests_with_numeric_strings():
         mock_table.eq.return_value = mock_table
         mock_table.in_.return_value = mock_table
         mock_table.execute.return_value = ((None, mock_data), None)
-        
+
         start_date = datetime(2023, 1, 1)
         result = count_completed_unique_requests(123, start_date)
-        
-        expected = {
-            "Organization/org123/repo456#789",
-            "User/user999/project2023#1"
-        }
+
+        expected = {"Organization/org123/repo456#789", "User/user999/project2023#1"}
         assert result == expected
         assert len(result) == 2
 
 
 def test_count_completed_unique_requests_query_parameters():
     """Test that all query parameters are correctly passed"""
-    with patch("services.supabase.usage.count_completed_unique_requests.supabase") as mock_supabase:
+    with patch(
+        "services.supabase.usage.count_completed_unique_requests.supabase"
+    ) as mock_supabase:
         mock_table = Mock()
         mock_supabase.table.return_value = mock_table

--- a/utils/issue_templates/test_merge.py
+++ b/utils/issue_templates/test_merge.py
@@ -120,9 +120,7 @@ class TestGetIssueBodyForPrMerged:
         expected = "\n".join(expected_lines)
         assert result == expected
 
-    def test_get_issue_body_for_pr_merged_files_with_special_characters(
-        self, _
-    ):
+    def test_get_issue_body_for_pr_merged_files_with_special_characters(self, _):
         """Test generating issue body with files containing special characters."""
         pr_number = 101
         file_list = [
@@ -173,9 +171,7 @@ class TestGetIssueBodyForPrMerged:
         result = get_issue_body_for_pr_merged(pr_number, file_list)
         assert isinstance(result, str)
 
-    def test_get_issue_body_for_pr_merged_structure_consistency(
-        self, _
-    ):
+    def test_get_issue_body_for_pr_merged_structure_consistency(self, _):
         """Test that the body structure is consistent across different inputs."""
         test_cases = [
             (1, ["file1.py"]),

--- a/utils/logs/deduplicate_repetitive_logs.py
+++ b/utils/logs/deduplicate_repetitive_logs.py
@@ -1,0 +1,48 @@
+def deduplicate_repetitive_logs(log_content: str) -> str:
+    lines = log_content.split("\n")
+
+    # Find all repetitive patterns using rolling hash
+    pattern_occurrences = {}
+
+    # Check patterns of different sizes
+    for size in range(1, min(20, len(lines) // 3)):
+        for i in range(len(lines) - size + 1):
+            pattern = tuple(lines[i : i + size])
+            if pattern not in pattern_occurrences:
+                pattern_occurrences[pattern] = []
+            pattern_occurrences[pattern].append(i)
+
+    # Find patterns that repeat consecutively 3+ times
+    to_remove = set()
+    for pattern, positions in pattern_occurrences.items():
+        if len(positions) < 3:
+            continue
+
+        size = len(pattern)
+        consecutive_groups = []
+        current_group = [positions[0]]
+
+        for pos in positions[1:]:
+            if pos == current_group[-1] + size:
+                current_group.append(pos)
+            else:
+                if len(current_group) >= 3:
+                    consecutive_groups.append(current_group)
+                current_group = [pos]
+
+        if len(current_group) >= 3:
+            consecutive_groups.append(current_group)
+
+        # Mark positions for removal (keep first occurrence)
+        for group in consecutive_groups:
+            for pos in group[1:]:  # Skip first occurrence
+                for j in range(size):
+                    to_remove.add(pos + j)
+
+    # Build result excluding removed positions
+    result = []
+    for i, line in enumerate(lines):
+        if i not in to_remove:
+            result.append(line)
+
+    return "\n".join(result)

--- a/utils/logs/test_deduplicate_logs.py
+++ b/utils/logs/test_deduplicate_logs.py
@@ -1,0 +1,40 @@
+from config import UTF8
+from utils.logs.deduplicate_repetitive_logs import deduplicate_repetitive_logs
+
+
+def test_deduplicate_repetitive_logs_with_real_sample():
+    with open(
+        "services/github/workflow_runs/get_workflow_run_logs_duplicated.txt",
+        "r",
+        encoding=UTF8,
+    ) as f:
+        original_log = f.read()
+
+    with open(
+        "services/github/workflow_runs/get_workflow_run_logs_deduplicated.txt",
+        "r",
+        encoding=UTF8,
+    ) as f:
+        expected_content = f.read()
+
+    deduplicated = deduplicate_repetitive_logs(original_log)
+
+    original_lines = original_log.split("\n")
+    deduplicated_lines = deduplicated.split("\n")
+    expected_lines = expected_content.split("\n")
+
+    # Check exact line count matches expected
+    assert (
+        len(original_lines) == 14581
+    ), f"Expected 14581 original lines, got {len(original_lines)}"
+    assert (
+        len(deduplicated_lines) == 280
+    ), f"Expected 280 deduplicated lines, got {len(deduplicated_lines)}"
+    assert (
+        len(expected_lines) == 280
+    ), f"Expected file should have 280 lines, got {len(expected_lines)}"
+
+    # Check content matches exactly
+    assert (
+        deduplicated == expected_content
+    ), "Deduplicated content should match expected file exactly"

--- a/utils/number/test_is_valid_line_number.py
+++ b/utils/number/test_is_valid_line_number.py
@@ -56,28 +56,28 @@ def test_invalid_types_trigger_exception_handler():
 
 def test_complex_objects_trigger_exception_handler():
     from unittest.mock import MagicMock
-    
+
     mock_obj = MagicMock()
     mock_obj.__str__ = lambda: "complex"
-    
+
     assert is_valid_line_number(mock_obj) is False
 
 
 def test_super_strict_failure_case():
     from unittest.mock import MagicMock
-    
+
     mock_obj = MagicMock()
     mock_obj.__str__.side_effect = ValueError("String conversion failed")
-    
+
     assert is_valid_line_number(mock_obj) is False
 
 
 def test_exception_during_processing():
     from unittest.mock import MagicMock
-    
+
     mock_obj = MagicMock()
     mock_obj.__int__.side_effect = ValueError("Cannot convert to int")
-    
+
     assert is_valid_line_number(mock_obj) is False
 
 


### PR DESCRIPTION
- Add deduplicate_repetitive_logs function with O(n²) pattern detection
- Integrate deduplication into check_run_handler to prevent 200k+ token errors
- Add comprehensive test with real 14,581 line GitHub Actions log sample
- Reduces repetitive pytest stack traces from 14,581 lines to 280 lines
- Fixes Sentry issue 6422354674 caused by massive log repetition