### PR TITLE
Fix async mock issues in test files

### DIFF
--- a/services/webhook/test_webhook_handler.py
+++ b/services/webhook/test_webhook_handler.py
@@ -26,24 +26,30 @@ def mock_unsuspend_installation():
 
 @pytest.fixture
 def mock_handle_installation_created():
-    with patch("services.webhook.webhook_handler.handle_installation_created") as mock:
-        mock.return_value = AsyncMock()
+    with patch(
+        "services.webhook.webhook_handler.handle_installation_created",
+        new_callable=AsyncMock,
+    ) as mock:
+        mock.return_value = None
         yield mock
 
 
 @pytest.fixture
 def mock_handle_installation_repos_added():
     with patch(
-        "services.webhook.webhook_handler.handle_installation_repos_added"
+        "services.webhook.webhook_handler.handle_installation_repos_added",
+        new_callable=AsyncMock,
     ) as mock:
-        mock.return_value = AsyncMock()
+        mock.return_value = None
         yield mock
 
 
 @pytest.fixture
 def mock_create_pr_from_issue():
-    with patch("services.webhook.webhook_handler.create_pr_from_issue") as mock:
-        mock.return_value = AsyncMock()
+    with patch(
+        "services.webhook.webhook_handler.create_pr_from_issue", new_callable=AsyncMock
+    ) as mock:
+        mock.return_value = None
         yield mock
 
 
@@ -57,8 +63,11 @@ def mock_create_gitauto_button_comment():
 
 @pytest.fixture
 def mock_handle_pr_checkbox_trigger():
-    with patch("services.webhook.webhook_handler.handle_pr_checkbox_trigger") as mock:
-        mock.return_value = AsyncMock()
+    with patch(
+        "services.webhook.webhook_handler.handle_pr_checkbox_trigger",
+        new_callable=AsyncMock,
+    ) as mock:
+        mock.return_value = None
         yield mock
 
 
@@ -82,8 +91,11 @@ def mock_write_pr_description():
 
 @pytest.fixture
 def mock_handle_screenshot_comparison():
-    with patch("services.webhook.webhook_handler.handle_screenshot_comparison") as mock:
-        mock.return_value = AsyncMock()
+    with patch(
+        "services.webhook.webhook_handler.handle_screenshot_comparison",
+        new_callable=AsyncMock,
+    ) as mock:
+        mock.return_value = None
         yield mock
 
 
@@ -107,18 +119,23 @@ def mock_handle_review_run():
 
 @pytest.fixture
 def mock_handle_coverage_report():
-    with patch("services.webhook.webhook_handler.handle_coverage_report") as mock:
-        mock.return_value = AsyncMock()
+    with patch(
+        "services.webhook.webhook_handler.handle_coverage_report",
+        new_callable=AsyncMock,
+    ) as mock:
+        mock.return_value = None
         yield mock
 
 
 class TestHandleWebhookEvent:
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_no_action(self):
         """Test that the function returns early when no action is provided."""
         payload = {"key": "value"}
         result = await handle_webhook_event(event_name="push", payload=payload)
         assert result is None
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_installation_created(
         self, mock_slack_notify, mock_handle_installation_created
     ):
@@ -136,13 +153,17 @@ class TestHandleWebhookEvent:
         )
         mock_handle_installation_created.assert_called_once_with(payload=payload)
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_installation_deleted(
         self, mock_slack_notify, mock_delete_installation
     ):
         """Test handling of installation deleted event."""
         payload = {
             "action": "deleted",
-            "installation": {"account": {"login": "test-owner"}, "id": 12345},
+            "installation": {
+                "account": {"login": "test-owner", "id": 11111},
+                "id": 12345,
+            },
             "sender": {"login": "test-sender", "id": 67890},
         }
 
@@ -157,13 +178,17 @@ class TestHandleWebhookEvent:
             user_name="test-sender",
         )
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_installation_suspended(
         self, mock_slack_notify, mock_delete_installation
     ):
         """Test handling of installation suspended event."""
         payload = {
             "action": "suspend",
-            "installation": {"account": {"login": "test-owner"}, "id": 12345},
+            "installation": {
+                "account": {"login": "test-owner", "id": 11111},
+                "id": 12345,
+            },
             "sender": {"login": "test-sender", "id": 67890},
         }
 
@@ -178,6 +203,7 @@ class TestHandleWebhookEvent:
             user_name="test-sender",
         )
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_installation_unsuspended(
         self, mock_slack_notify, mock_unsuspend_installation
     ):
@@ -195,6 +221,7 @@ class TestHandleWebhookEvent:
         )
         mock_unsuspend_installation.assert_called_once_with(installation_id=12345)
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_installation_repos_added(
         self, mock_slack_notify, mock_handle_installation_repos_added
     ):
@@ -212,6 +239,7 @@ class TestHandleWebhookEvent:
         mock_slack_notify.assert_not_called()
         mock_handle_installation_repos_added.assert_called_once_with(payload=payload)
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_issues_labeled(self, mock_create_pr_from_issue):
         """Test handling of issues labeled event."""
         payload = {"action": "labeled"}
@@ -222,6 +250,7 @@ class TestHandleWebhookEvent:
             payload=payload, trigger="issue_label", input_from="github"
         )
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_issues_opened(
         self, mock_create_gitauto_button_comment
     ):
@@ -232,6 +261,7 @@ class TestHandleWebhookEvent:
 
         mock_create_gitauto_button_comment.assert_called_once_with(payload=payload)
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_issue_comment_edited_dev_env(
         self, mock_handle_pr_checkbox_trigger, mock_create_pr_from_issue
     ):
@@ -249,6 +279,7 @@ class TestHandleWebhookEvent:
                 payload=payload, trigger="issue_comment", input_from="github"
             )
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_issue_comment_edited_prod_env(
         self, mock_handle_pr_checkbox_trigger, mock_create_pr_from_issue
     ):
@@ -266,6 +297,7 @@ class TestHandleWebhookEvent:
                 payload=payload, trigger="issue_comment", input_from="github"
             )
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_issue_comment_edited_no_trigger(
         self, mock_handle_pr_checkbox_trigger, mock_create_pr_from_issue
     ):
@@ -280,6 +312,7 @@ class TestHandleWebhookEvent:
         mock_handle_pr_checkbox_trigger.assert_called_once_with(payload=payload)
         mock_create_pr_from_issue.assert_not_called()
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_check_run_completed_failure(
         self, mock_handle_check_run
     ):
@@ -296,6 +329,7 @@ class TestHandleWebhookEvent:
 
             mock_handle_check_run.assert_called_once_with(payload=payload)
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_check_run_completed_success(
         self, mock_handle_check_run
     ):
@@ -309,6 +343,7 @@ class TestHandleWebhookEvent:
 
         mock_handle_check_run.assert_not_called()
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_pull_request_opened(
         self,
         mock_create_pr_checkbox_comment,
@@ -324,6 +359,7 @@ class TestHandleWebhookEvent:
         mock_write_pr_description.assert_called_once_with(payload=payload)
         mock_handle_screenshot_comparison.assert_called_once_with(payload=payload)
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_pull_request_synchronize(
         self, mock_create_pr_checkbox_comment, mock_handle_screenshot_comparison
     ):
@@ -335,6 +371,7 @@ class TestHandleWebhookEvent:
         mock_create_pr_checkbox_comment.assert_called_once_with(payload=payload)
         mock_handle_screenshot_comparison.assert_called_once_with(payload=payload)
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_pull_request_closed_no_pull_request(self):
         """Test handling of pull request closed event with no pull_request."""
         payload = {"action": "closed"}
@@ -343,6 +380,7 @@ class TestHandleWebhookEvent:
 
         # Should return early with no errors
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_pull_request_closed_not_merged(self):
         """Test handling of pull request closed event that wasn't merged."""
         payload = {
@@ -354,6 +392,7 @@ class TestHandleWebhookEvent:
 
         # Should return early with no errors
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_pull_request_closed_non_gitauto_branch(
         self, mock_handle_pr_merged
     ):
@@ -374,6 +413,7 @@ class TestHandleWebhookEvent:
 
                 mock_handle_pr_merged.assert_called_once_with(payload=payload)
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_pull_request_closed_gitauto_branch_no_body(
         self, mock_update_issue_merged, mock_slack_notify
     ):
@@ -396,6 +436,7 @@ class TestHandleWebhookEvent:
                 mock_update_issue_merged.assert_not_called()
                 mock_slack_notify.assert_not_called()
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_pull_request_closed_gitauto_branch_wrong_body_format(
         self, mock_update_issue_merged, mock_slack_notify
     ):
@@ -423,6 +464,7 @@ class TestHandleWebhookEvent:
                     mock_update_issue_merged.assert_not_called()
                     mock_slack_notify.assert_not_called()
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_pull_request_closed_gitauto_branch_success(
         self, mock_update_issue_merged, mock_slack_notify
     ):
@@ -464,6 +506,7 @@ class TestHandleWebhookEvent:
                         "🎉 PR created by `author-name` was merged by `sender-name` for `owner-name/repo-name`"
                     )
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_pull_request_review_comment_created(
         self, mock_handle_review_run
     ):
@@ -476,6 +519,7 @@ class TestHandleWebhookEvent:
 
         mock_handle_review_run.assert_called_once_with(payload=payload)
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_pull_request_review_comment_edited(
         self, mock_handle_review_run
     ):
@@ -488,6 +532,7 @@ class TestHandleWebhookEvent:
 
         mock_handle_review_run.assert_called_once_with(payload=payload)
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_pull_request_review_comment_deleted(
         self, mock_handle_review_run
     ):
@@ -500,6 +545,7 @@ class TestHandleWebhookEvent:
 
         mock_handle_review_run.assert_not_called()
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_workflow_run_completed_success(
         self, mock_handle_coverage_report
     ):
@@ -533,6 +579,7 @@ class TestHandleWebhookEvent:
             user_name="sender-name",
         )
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_workflow_run_completed_failure(
         self, mock_handle_coverage_report
     ):
@@ -543,6 +590,7 @@ class TestHandleWebhookEvent:
 
         mock_handle_coverage_report.assert_not_called()
 
+    @pytest.mark.asyncio
     async def test_handle_webhook_event_unknown_event(self):
         """Test handling of unknown event."""
         payload = {"action": "some_action"}

--- a/test_main.py
+++ b/test_main.py
@@ -140,8 +140,9 @@ class TestHandler:
 
 
 class TestHandleWebhook:
-    @patch("main.verify_webhook_signature")
-    @patch("main.handle_webhook_event")
+    @patch("main.verify_webhook_signature", new_callable=AsyncMock)
+    @patch("main.handle_webhook_event", new_callable=AsyncMock)
+    @pytest.mark.asyncio
     async def test_handle_webhook_success(
         self, mock_handle_webhook_event, mock_verify_signature, mock_github_request
     ):
@@ -162,8 +163,9 @@ class TestHandleWebhook:
         )
         assert response == {"message": "Webhook processed successfully"}
 
-    @patch("main.verify_webhook_signature")
-    @patch("main.handle_webhook_event")
+    @patch("main.verify_webhook_signature", new_callable=AsyncMock)
+    @patch("main.handle_webhook_event", new_callable=AsyncMock)
+    @pytest.mark.asyncio
     async def test_handle_webhook_body_error(
         self, mock_handle_webhook_event, mock_verify_signature, mock_github_request
     ):
@@ -182,8 +184,9 @@ class TestHandleWebhook:
         mock_handle_webhook_event.assert_called_once_with(event_name="push", payload={})
         assert response == {"message": "Webhook processed successfully"}
 
-    @patch("main.verify_webhook_signature")
-    @patch("main.handle_webhook_event")
+    @patch("main.verify_webhook_signature", new_callable=AsyncMock)
+    @patch("main.handle_webhook_event", new_callable=AsyncMock)
+    @pytest.mark.asyncio
     async def test_handle_webhook_json_decode_error(
         self, mock_handle_webhook_event, mock_verify_signature, mock_github_request
     ):
@@ -202,8 +205,9 @@ class TestHandleWebhook:
         mock_handle_webhook_event.assert_called_once_with(event_name="push", payload={})
         assert response == {"message": "Webhook processed successfully"}
 
-    @patch("main.verify_webhook_signature")
-    @patch("main.handle_webhook_event")
+    @patch("main.verify_webhook_signature", new_callable=AsyncMock)
+    @patch("main.handle_webhook_event", new_callable=AsyncMock)
+    @pytest.mark.asyncio
     async def test_handle_webhook_url_encoded_payload(
         self,
         mock_handle_webhook_event,
@@ -230,8 +234,9 @@ class TestHandleWebhook:
         )
         assert response == {"message": "Webhook processed successfully"}
 
-    @patch("main.verify_webhook_signature")
-    @patch("main.handle_webhook_event")
+    @patch("main.verify_webhook_signature", new_callable=AsyncMock)
+    @patch("main.handle_webhook_event", new_callable=AsyncMock)
+    @pytest.mark.asyncio
     async def test_handle_webhook_with_custom_event_name(
         self, mock_handle_webhook_event, mock_verify_signature, mock_github_request
     ):
@@ -254,8 +259,9 @@ class TestHandleWebhook:
         assert response == {"message": "Webhook processed successfully"}
 
 
-@patch("main.verify_jira_webhook")
-@patch("main.create_pr_from_issue")
+@patch("main.verify_jira_webhook", new_callable=AsyncMock)
+@patch("main.create_pr_from_issue", new_callable=AsyncMock)
+@pytest.mark.asyncio
 async def test_handle_jira_webhook_success(
     mock_create_pr, mock_verify_jira, mock_jira_request
 ):
@@ -277,6 +283,7 @@ async def test_handle_jira_webhook_success(
     assert response == {"message": "Jira webhook processed successfully"}
 
 
+@pytest.mark.asyncio
 async def test_root_endpoint():
     """Test root endpoint returns correct product name."""
     response = await root()


### PR DESCRIPTION
- Update test_main.py: Use new_callable=AsyncMock for async function mocks
- Update test_webhook_handler.py: Use new_callable=AsyncMock for async function mocks
- Add missing @pytest.mark.asyncio decorators to async test methods

🤖 Generated with [Claude Code](https://claude.ai/code)