### PR TITLE
Fix: Handle single-line empty classes in should_skip functions

### DIFF
--- a/utils/files/should_skip_javascript.py
+++ b/utils/files/should_skip_javascript.py
@@ -91,6 +91,10 @@ def should_skip_javascript(content: str) -> bool:
             return False
 
         # Skip empty class definitions (class Name {} or class Name extends Base {})
+        # Handle single-line empty classes like: class Name {}
+        if re.match(r"^class\s+\w+(\s+extends\s+\w+)?\s*\{\s*\}$", line):
+            continue
+        # Handle multi-line empty classes
         if re.match(r"^class\s+\w+(\s+extends\s+\w+)?\s*\{$", line):
             in_class_definition = True
             continue

--- a/utils/files/should_skip_python.py
+++ b/utils/files/should_skip_python.py
@@ -80,6 +80,10 @@ def should_skip_python(content: str) -> bool:
             in_class_definition = True
             continue
 
+        # Handle single-line empty classes like: class Name: pass
+        if re.match(r"^class\s+\w+\s*:\s*pass$", line):
+            continue
+
         # Handle simple empty classes without inheritance
         if re.match(r"^class\s+\w+\s*:\s*$", line):
             in_class_definition = True

--- a/utils/files/test_should_skip_cpp.py
+++ b/utils/files/test_should_skip_cpp.py
@@ -172,3 +172,12 @@ Base class for application components
 class BaseComponent {
 };"""
     assert should_skip_cpp(content) is True
+
+
+def test_empty_class_single_line_braces():
+    # Empty class with braces on same line should be skipped
+    content = """// Base class for components
+class MyComponent {};
+
+struct MyStruct {};"""
+    assert should_skip_cpp(content) is True

--- a/utils/files/test_should_skip_csharp.py
+++ b/utils/files/test_should_skip_csharp.py
@@ -174,3 +174,12 @@ public class BaseComponent
 {
 }"""
     assert should_skip_csharp(content) is True
+
+
+def test_empty_class_single_line_braces():
+    # Empty class with braces on same line should be skipped
+    content = """// Base class for components
+public class MyComponent {}
+
+interface IMyInterface {}"""
+    assert should_skip_csharp(content) is True

--- a/utils/files/test_should_skip_go.py
+++ b/utils/files/test_should_skip_go.py
@@ -200,3 +200,12 @@ type BaseComponent struct {
 
 var _ = BaseComponent{}"""
     assert should_skip_go(content) is True
+
+
+def test_empty_class_single_line_braces():
+    # Empty struct with braces on same line should be skipped
+    content = """// Base struct for components
+type MyComponent struct{}
+
+var _ = MyComponent{}"""
+    assert should_skip_go(content) is True

--- a/utils/files/test_should_skip_java.py
+++ b/utils/files/test_should_skip_java.py
@@ -183,3 +183,12 @@ def test_comment_with_simple_class():
 public class BaseComponent {
 }"""
     assert should_skip_java(content) is True
+
+
+def test_empty_class_single_line_braces():
+    # Empty class with braces on same line should be skipped
+    content = """// Base class for components
+public class MyComponent {}
+
+class AnotherComponent {}"""
+    assert should_skip_java(content) is True

--- a/utils/files/test_should_skip_javascript.py
+++ b/utils/files/test_should_skip_javascript.py
@@ -162,3 +162,14 @@ class BaseComponent {
 
 export default BaseComponent;"""
     assert should_skip_javascript(content) is True
+
+
+def test_empty_class_single_line_braces():
+    # Empty class with braces on same line should be skipped
+    content = """/**
+ * Base class for components
+ */
+class MyComponent {}
+
+export default MyComponent;"""
+    assert should_skip_javascript(content) is True

--- a/utils/files/test_should_skip_php.py
+++ b/utils/files/test_should_skip_php.py
@@ -180,3 +180,13 @@ class BaseComponent
 {
 }"""
     assert should_skip_php(content) is True
+
+
+def test_empty_class_single_line_braces():
+    # Empty class with braces on same line should be skipped
+    content = """<?php
+// Base class for components
+class MyComponent {}
+
+interface MyInterface {}"""
+    assert should_skip_php(content) is True

--- a/utils/files/test_should_skip_python.py
+++ b/utils/files/test_should_skip_python.py
@@ -158,3 +158,12 @@ class BaseComponent:
 
 __all__ = ["BaseComponent"]'''
     assert should_skip_python(content) is True
+
+
+def test_empty_class_single_line_braces():
+    # Empty class with pass on same line should be skipped
+    content = """# Base class for components
+class MyComponent: pass
+
+__all__ = ['MyComponent']"""
+    assert should_skip_python(content) is True

--- a/utils/files/test_should_skip_ruby.py
+++ b/utils/files/test_should_skip_ruby.py
@@ -158,3 +158,12 @@ Base class for application components
 class BaseComponent
 end"""
     assert should_skip_ruby(content) is True
+
+
+def test_empty_class_single_line_braces():
+    # Empty class on single line should be skipped
+    content = """# Base class for components
+class MyComponent; end
+
+module MyModule; end"""
+    assert should_skip_ruby(content) is True

--- a/utils/files/test_should_skip_rust.py
+++ b/utils/files/test_should_skip_rust.py
@@ -166,3 +166,12 @@ struct BaseComponent {}
 
 const _: BaseComponent = BaseComponent {};"""
     assert should_skip_rust(content) is True
+
+
+def test_empty_class_single_line_braces():
+    # Empty struct with braces on same line should be skipped
+    content = """// Base struct for components
+struct MyComponent {}
+
+const _: MyComponent = MyComponent {};"""
+    assert should_skip_rust(content) is True


### PR DESCRIPTION
- JavaScript: Added regex to handle 'class Name {}' format
- Python: Added regex to handle 'class Name: pass' format
- Added test_empty_class_single_line_braces test to all 9 languages
- Other languages (Go, Java, Rust, Ruby, PHP, C#, C++) already handled correctly