### PR TITLE
Fix webhook handler test async mock warnings

### DIFF
--- a/services/webhook/test_webhook_handler.py
+++ b/services/webhook/test_webhook_handler.py
@@ -26,9 +26,7 @@ def mock_unsuspend_installation():
 
 @pytest.fixture
 def mock_handle_installation_created():
-    with patch(
-        "services.webhook.webhook_handler.handle_installation_created"
-    ) as mock:
+    with patch("services.webhook.webhook_handler.handle_installation_created") as mock:
         mock.return_value = None
         yield mock
 
@@ -44,9 +42,7 @@ def mock_handle_installation_repos_added():
 
 @pytest.fixture
 def mock_create_pr_from_issue():
-    with patch(
-        "services.webhook.webhook_handler.create_pr_from_issue"
-    ) as mock:
+    with patch("services.webhook.webhook_handler.create_pr_from_issue") as mock:
         mock.return_value = None
         yield mock
 

--- a/services/webhook/test_webhook_handler.py
+++ b/services/webhook/test_webhook_handler.py
@@ -1,5 +1,5 @@
 # Standard imports
-from unittest.mock import patch, Mock, AsyncMock
+from unittest.mock import patch, AsyncMock
 import pytest
 
 # Local imports

--- a/services/webhook/test_webhook_handler.py
+++ b/services/webhook/test_webhook_handler.py
@@ -1,5 +1,5 @@
 # Standard imports
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, Mock, AsyncMock
 import pytest
 
 # Local imports
@@ -27,8 +27,7 @@ def mock_unsuspend_installation():
 @pytest.fixture
 def mock_handle_installation_created():
     with patch(
-        "services.webhook.webhook_handler.handle_installation_created",
-        new_callable=AsyncMock,
+        "services.webhook.webhook_handler.handle_installation_created"
     ) as mock:
         mock.return_value = None
         yield mock
@@ -37,8 +36,7 @@ def mock_handle_installation_created():
 @pytest.fixture
 def mock_handle_installation_repos_added():
     with patch(
-        "services.webhook.webhook_handler.handle_installation_repos_added",
-        new_callable=AsyncMock,
+        "services.webhook.webhook_handler.handle_installation_repos_added"
     ) as mock:
         mock.return_value = None
         yield mock
@@ -47,7 +45,7 @@ def mock_handle_installation_repos_added():
 @pytest.fixture
 def mock_create_pr_from_issue():
     with patch(
-        "services.webhook.webhook_handler.create_pr_from_issue", new_callable=AsyncMock
+        "services.webhook.webhook_handler.create_pr_from_issue"
     ) as mock:
         mock.return_value = None
         yield mock


### PR DESCRIPTION
- Change AsyncMock to Mock for synchronous functions (handle_installation_created, handle_installation_repos_added, create_pr_from_issue)
- Keep AsyncMock for actual async functions
- Eliminates RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited