### PR TITLE
Fix token limit issue in review comments by using file lists instead …

### DIFF
--- a/services/github/pulls/test_get_pull_request_files.py
+++ b/services/github/pulls/test_get_pull_request_files.py
@@ -1,0 +1,143 @@
+from unittest.mock import Mock, patch
+import pytest
+import requests
+from services.github.pulls.get_pull_request_files import get_pull_request_files
+
+
+@pytest.fixture
+def mock_requests():
+    with patch("services.github.pulls.get_pull_request_files.requests") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_create_headers():
+    with patch("services.github.pulls.get_pull_request_files.create_headers") as mock:
+        mock.return_value = {"Authorization": "token test_token"}
+        yield mock
+
+
+def test_get_pull_request_files_success(mock_requests, mock_create_headers):
+    """Test successful retrieval of pull request files"""
+    mock_response_data = [
+        {"filename": "file1.py", "status": "modified"},
+        {"filename": "file2.js", "status": "added"},
+        {"filename": "file3.txt", "status": "removed"},
+    ]
+    # Setup mock response
+    mock_response = Mock()
+    mock_response.json.return_value = mock_response_data
+    mock_response.raise_for_status.return_value = None
+
+    # Mock for empty second page (pagination)
+    empty_response = Mock()
+    empty_response.json.return_value = []
+
+    mock_requests.get.side_effect = [mock_response, empty_response]
+
+    # Call function
+    result = get_pull_request_files(
+        "https://api.github.com/repos/test/test/pulls/1/files", "token123"
+    )
+
+    # Verify result
+    expected = [
+        {"filename": "file1.py", "status": "modified"},
+        {"filename": "file2.js", "status": "added"},
+        {"filename": "file3.txt", "status": "removed"},
+    ]
+
+    assert result == expected
+    mock_create_headers.assert_called_once_with(token="token123")
+    assert mock_requests.get.call_count == 2
+
+
+def test_get_pull_request_files_pagination():
+    """Test pagination handling"""
+    page1_data = [{"filename": "file1.py", "status": "modified"}]
+    page2_data = [{"filename": "file2.js", "status": "added"}]
+
+    with patch("services.github.pulls.get_pull_request_files.requests.get") as mock_get:
+        mock_response1 = Mock()
+        mock_response1.json.return_value = page1_data
+        mock_response1.raise_for_status.return_value = None
+
+        mock_response2 = Mock()
+        mock_response2.json.return_value = page2_data
+        mock_response2.raise_for_status.return_value = None
+
+        mock_response3 = Mock()
+        mock_response3.json.return_value = []  # Empty page ends pagination
+        mock_response3.raise_for_status.return_value = None
+
+        mock_get.side_effect = [mock_response1, mock_response2, mock_response3]
+
+        result = get_pull_request_files(
+            "https://api.github.com/repos/test/test/pulls/1/files", "token123"
+        )
+
+        expected = [
+            {"filename": "file1.py", "status": "modified"},
+            {"filename": "file2.js", "status": "added"},
+        ]
+
+        assert result == expected
+        assert mock_get.call_count == 3
+
+
+def test_get_pull_request_files_missing_fields():
+    """Test handling of files with missing filename or status fields"""
+    mock_response_data = [
+        {"filename": "file1.py", "status": "modified"},
+        {"filename": "file2.js"},  # Missing status
+        {"status": "added"},  # Missing filename
+        {"filename": "file3.txt", "status": "removed"},
+    ]
+
+    with patch("services.github.pulls.get_pull_request_files.requests.get") as mock_get:
+        mock_response = Mock()
+        mock_response.json.return_value = mock_response_data
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = get_pull_request_files(
+            "https://api.github.com/repos/test/test/pulls/1/files", "token123"
+        )
+
+        expected = [
+            {"filename": "file1.py", "status": "modified"},
+            {"filename": "file3.txt", "status": "removed"},
+        ]
+
+        assert result == expected
+
+
+def test_get_pull_request_files_http_error():
+    """Test handling of HTTP errors"""
+    with patch("services.github.pulls.get_pull_request_files.requests.get") as mock_get:
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "404 Not Found"
+        )
+        mock_get.return_value = mock_response
+
+        result = get_pull_request_files(
+            "https://api.github.com/repos/test/test/pulls/1/files", "token123"
+        )
+
+        assert result == []
+
+
+def test_get_pull_request_files_empty_response():
+    """Test handling of empty response"""
+    with patch("services.github.pulls.get_pull_request_files.requests.get") as mock_get:
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = get_pull_request_files(
+            "https://api.github.com/repos/test/test/pulls/1/files", "token123"
+        )
+
+        assert result == []

--- a/services/webhook/issue_handler.py
+++ b/services/webhook/issue_handler.py
@@ -74,16 +74,25 @@ def create_pr_from_issue(
     current_time: float = time.time()
 
     # Extract label and validate it
-    if trigger == "issue_label" and input_from == "github" and "label" in payload and payload["label"]["name"] != PRODUCT_ID:
+    if (
+        trigger == "issue_label"
+        and input_from == "github"
+        and "label" in payload
+        and payload["label"]["name"] != PRODUCT_ID
+    ):
         return
 
     # Deconstruct payload based on input_from
     base_args = None
     repo_settings = None
     if input_from == "github":
-        base_args, repo_settings = deconstruct_github_payload(payload=cast(GitHubLabeledPayload, payload))
+        base_args, repo_settings = deconstruct_github_payload(
+            payload=cast(GitHubLabeledPayload, payload)
+        )
     elif input_from == "jira":
-        base_args, repo_settings = deconstruct_jira_payload(payload=cast(JiraPayload, payload))
+        base_args, repo_settings = deconstruct_jira_payload(
+            payload=cast(JiraPayload, payload)
+        )
 
     # Ensure skip_ci is set to True for development commits
     base_args["skip_ci"] = True

--- a/services/webhook/review_run_handler.py
+++ b/services/webhook/review_run_handler.py
@@ -13,9 +13,7 @@ from services.github.comments.reply_to_comment import reply_to_comment
 from services.github.comments.update_comment import update_comment
 from services.github.commits.create_empty_commit import create_empty_commit
 from services.github.files.get_remote_file_content import get_remote_file_content
-from services.github.pulls.get_pull_request_file_contents import (
-    get_pull_request_file_contents,
-)
+from services.github.pulls.get_pull_request_files import get_pull_request_files
 from services.github.pulls.get_review_thread_comments import get_review_thread_comments
 from services.github.pulls.is_pull_request_open import is_pull_request_open
 from services.github.token.get_installation_token import get_installation_access_token
@@ -181,10 +179,10 @@ def handle_review_run(payload: dict[str, Any]):
     comment_body = create_progress_bar(p=p, msg="\n".join(log_messages))
     update_comment(body=comment_body, base_args=base_args)
 
-    # Get changed files in the PR
-    pull_files = get_pull_request_file_contents(url=pull_file_url, base_args=base_args)
+    # Get list of changed files in the PR (filenames only, not contents)
+    pull_files = get_pull_request_files(url=pull_file_url, token=token)
     p += 5
-    log_messages.append(f"Read {len(pull_files)} changed files in the PR.")
+    log_messages.append(f"Found {len(pull_files)} changed files in the PR.")
     comment_body = create_progress_bar(p=p, msg="\n".join(log_messages))
     update_comment(body=comment_body, base_args=base_args)
 


### PR DESCRIPTION
…of contents

- Change review_run_handler to use get_pull_request_files (filenames only) instead of get_pull_request_file_contents (full file contents)
- This prevents 191,402+ token errors when PRs have many files
- Add comprehensive tests for get_pull_request_files function
- Fix test hanging issue by using proper pytest fixture pattern for mocking requests
- Include formatting changes to issue_handler.py