### PR TITLE
Fix AGENT-Z7: Prevent apply_diff_to_file from handling file deletions

### DIFF
--- a/services/git/test_git_manager.py
+++ b/services/git/test_git_manager.py
@@ -232,27 +232,34 @@ class TestStartLocalServer:
             start_local_server("/path/to/repo")
 
     @patch("subprocess.Popen")
-    def test_start_local_server_with_npm_command(self, mock_popen, mock_subprocess_popen):
+    def test_start_local_server_with_npm_command(
+        self, mock_popen, mock_subprocess_popen
+    ):
         """Test server start with npm command (commented out in the code)"""
         # Create a modified version of the start_local_server function with npm command
         from services.git.git_manager import start_local_server
-        
+
         # Store original function to restore later
         original_function = start_local_server
-        
+
         # Create a patched version of the function
         def patched_start_local_server(repo_dir):
             command = "npm run dev"
             return subprocess.Popen(
-                args=command, shell=True, cwd=repo_dir, 
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                args=command,
+                shell=True,
+                cwd=repo_dir,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
             )
-        
+
         mock_popen.return_value = mock_subprocess_popen
         repo_dir = "/path/to/repo"
 
         # Skip this test as it's testing an implementation detail (commented code)
-        pytest.skip("This test is for a commented-out code path that isn't currently used")
+        pytest.skip(
+            "This test is for a commented-out code path that isn't currently used"
+        )
 
 
 class TestSwitchToBranch:
@@ -323,7 +330,9 @@ class TestSwitchToBranch:
         )
 
     @patch("subprocess.run")
-    def test_switch_to_branch_with_non_ascii_characters(self, mock_run, mock_subprocess_run):
+    def test_switch_to_branch_with_non_ascii_characters(
+        self, mock_run, mock_subprocess_run
+    ):
         """Test branch switch with non-ASCII characters in branch name"""
         mock_run.return_value = mock_subprocess_run
 
@@ -442,7 +451,9 @@ class TestEdgeCases:
         )
 
     @patch("subprocess.run")
-    def test_fetch_branch_with_very_large_pull_number(self, mock_run, mock_subprocess_run):
+    def test_fetch_branch_with_very_large_pull_number(
+        self, mock_run, mock_subprocess_run
+    ):
         """Test fetch_branch with a very large pull number"""
         mock_run.return_value = mock_subprocess_run
 

--- a/services/github/comments/test_create_gitauto_button_comment.py
+++ b/services/github/comments/test_create_gitauto_button_comment.py
@@ -37,7 +37,7 @@ def mock_dependencies():
     ) as mock_combine_comment:
         mock_get_token.return_value = "test-token"
         mock_get_email.return_value = "test@example.com"
-        
+
         yield {
             "get_token": mock_get_token,
             "get_email": mock_get_email,
@@ -55,34 +55,36 @@ def test_create_gitauto_button_comment_success(
 
     # Assert
     assert result is None  # Function returns None on success
-    
+
     # Verify token retrieval
     mock_dependencies["get_token"].assert_called_once_with(installation_id=12345)
-    
+
     # Verify email retrieval
     mock_dependencies["get_email"].assert_called_once_with(
         username="test-user", token="test-token"
     )
-    
+
     # Verify user upsert
     mock_dependencies["upsert_user"].assert_called_once_with(
         user_id=11111, user_name="test-user", email="test@example.com"
     )
-    
+
     # Verify comment creation with correct parameters
     mock_dependencies["combine_comment"].assert_called_once()
     call_args = mock_dependencies["combine_comment"].call_args
-    
+
     # Check base_comment format
-    assert "Click the checkbox below to generate a PR!" in call_args.kwargs["base_comment"]
+    assert (
+        "Click the checkbox below to generate a PR!" in call_args.kwargs["base_comment"]
+    )
     assert "- [ ] Generate PR" in call_args.kwargs["base_comment"]
-    
+
     # Check other parameters
     assert call_args.kwargs["installation_id"] == 12345
     assert call_args.kwargs["owner_id"] == 67890
     assert call_args.kwargs["owner_name"] == "test-owner"
     assert call_args.kwargs["sender_name"] == "test-user"
-    
+
     # Check base_args structure
     base_args = call_args.kwargs["base_args"]
     assert base_args["owner"] == "test-owner"
@@ -97,18 +99,18 @@ def test_create_gitauto_button_comment_with_null_email(
     """Test comment creation when user email is None"""
     # Arrange
     mock_dependencies["get_email"].return_value = None
-    
+
     # Act
     result = create_gitauto_button_comment(mock_github_labeled_payload)
-    
+
     # Assert
     assert result is None
-    
+
     # Verify user upsert with None email
     mock_dependencies["upsert_user"].assert_called_once_with(
         user_id=11111, user_name="test-user", email=None
     )
-    
+
     # Verify other functions were still called
     mock_dependencies["get_token"].assert_called_once()
     mock_dependencies["combine_comment"].assert_called_once()
@@ -120,16 +122,16 @@ def test_create_gitauto_button_comment_token_error(
     """Test behavior when token retrieval fails"""
     # Arrange
     mock_dependencies["get_token"].side_effect = Exception("Token error")
-    
+
     # Act
     result = create_gitauto_button_comment(mock_github_labeled_payload)
-    
+
     # Assert - handle_exceptions decorator should return None on error
     assert result is None
-    
+
     # Verify token retrieval was attempted
     mock_dependencies["get_token"].assert_called_once_with(installation_id=12345)
-    
+
     # Verify subsequent functions were not called due to exception
     mock_dependencies["get_email"].assert_not_called()
     mock_dependencies["upsert_user"].assert_not_called()
@@ -142,17 +144,17 @@ def test_create_gitauto_button_comment_email_error(
     """Test behavior when email retrieval fails"""
     # Arrange
     mock_dependencies["get_email"].side_effect = Exception("Email error")
-    
+
     # Act
     result = create_gitauto_button_comment(mock_github_labeled_payload)
-    
+
     # Assert - handle_exceptions decorator should return None on error
     assert result is None
-    
+
     # Verify functions called before error
     mock_dependencies["get_token"].assert_called_once()
     mock_dependencies["get_email"].assert_called_once()
-    
+
     # Verify subsequent functions were not called due to exception
     mock_dependencies["upsert_user"].assert_not_called()
     mock_dependencies["combine_comment"].assert_not_called()
@@ -164,18 +166,18 @@ def test_create_gitauto_button_comment_upsert_user_error(
     """Test behavior when user upsert fails"""
     # Arrange
     mock_dependencies["upsert_user"].side_effect = Exception("Upsert error")
-    
+
     # Act
     result = create_gitauto_button_comment(mock_github_labeled_payload)
-    
+
     # Assert - handle_exceptions decorator should return None on error
     assert result is None
-    
+
     # Verify functions called before error
     mock_dependencies["get_token"].assert_called_once()
     mock_dependencies["get_email"].assert_called_once()
     mock_dependencies["upsert_user"].assert_called_once()
-    
+
     # Verify subsequent function was not called due to exception
     mock_dependencies["combine_comment"].assert_not_called()
 
@@ -186,13 +188,13 @@ def test_create_gitauto_button_comment_combine_comment_error(
     """Test behavior when combine_and_create_comment fails"""
     # Arrange
     mock_dependencies["combine_comment"].side_effect = Exception("Comment error")
-    
+
     # Act
     result = create_gitauto_button_comment(mock_github_labeled_payload)
-    
+
     # Assert - handle_exceptions decorator should return None on error
     assert result is None
-    
+
     # Verify all functions were called
     mock_dependencies["get_token"].assert_called_once()
     mock_dependencies["get_email"].assert_called_once()
@@ -215,7 +217,7 @@ def test_create_gitauto_button_comment_different_payload_values():
         "label": {"name": "gitauto"},
         "organization": {"id": 66666, "login": "different-org"},
     }
-    
+
     with patch(
         "services.github.comments.create_gitauto_button_comment.get_installation_access_token"
     ) as mock_get_token, patch(
@@ -227,13 +229,13 @@ def test_create_gitauto_button_comment_different_payload_values():
     ) as mock_combine_comment:
         mock_get_token.return_value = "different-token"
         mock_get_email.return_value = "different@example.com"
-        
+
         # Act
         result = create_gitauto_button_comment(payload)
-        
+
         # Assert
         assert result is None
-        
+
         # Verify correct values were extracted and used
         mock_get_token.assert_called_once_with(installation_id=99999)
         mock_get_email.assert_called_once_with(
@@ -242,14 +244,14 @@ def test_create_gitauto_button_comment_different_payload_values():
         mock_upsert_user.assert_called_once_with(
             user_id=77777, user_name="different-user", email="different@example.com"
         )
-        
+
         # Verify combine_and_create_comment called with correct values
         call_args = mock_combine_comment.call_args
         assert call_args.kwargs["installation_id"] == 99999
         assert call_args.kwargs["owner_id"] == 88888
         assert call_args.kwargs["owner_name"] == "different-owner"
         assert call_args.kwargs["sender_name"] == "different-user"
-        
+
         base_args = call_args.kwargs["base_args"]
         assert base_args["owner"] == "different-owner"
         assert base_args["repo"] == "different-repo"
@@ -271,7 +273,7 @@ def test_create_gitauto_button_comment_base_comment_format():
         "label": {"name": "gitauto"},
         "organization": {"id": 22222, "login": "test-org"},
     }
-    
+
     with patch(
         "services.github.comments.create_gitauto_button_comment.get_installation_access_token",
         return_value="test-token",
@@ -283,21 +285,23 @@ def test_create_gitauto_button_comment_base_comment_format():
     ) as mock_upsert_user, patch(
         "services.github.comments.create_gitauto_button_comment.combine_and_create_comment"
     ) as mock_combine_comment:
-        
+
         # Act
         result = create_gitauto_button_comment(payload)
-        
+
         # Assert
         assert result is None
-        
+
         # Verify the base comment format
         call_args = mock_combine_comment.call_args
         base_comment = call_args.kwargs["base_comment"]
-        
+
         # Check that the comment contains the expected elements
         assert "Click the checkbox below to generate a PR!" in base_comment
         assert "- [ ] Generate PR" in base_comment
-        
+
         # Verify the exact format
-        expected_comment = "Click the checkbox below to generate a PR!\n- [ ] Generate PR"
+        expected_comment = (
+            "Click the checkbox below to generate a PR!\n- [ ] Generate PR"
+        )
         assert base_comment == expected_comment

--- a/services/github/commits/test_apply_diff_to_file.py
+++ b/services/github/commits/test_apply_diff_to_file.py
@@ -1,0 +1,54 @@
+from typing import cast
+from unittest.mock import patch
+
+from services.github.commits.apply_diff_to_file import apply_diff_to_file
+from services.github.types.github_types import BaseArgs
+
+
+@patch("services.github.commits.apply_diff_to_file.requests.get")
+def test_deletion_diff_rejected(mock_get):
+    """Test that deletion diffs are rejected with proper error message."""
+    base_args = cast(BaseArgs, {
+        "owner": "test_owner",
+        "repo": "test_repo",
+        "token": "test_token",
+        "new_branch": "test_branch",
+    })
+
+    deletion_diff = """--- utils/files/test_file.py
++++ /dev/null
+@@ -1 +0,0 @@
+-# Temporary file to check existing content"""
+
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "content": "IyBUZW1wb3JhcnkgZmlsZSB0byBjaGVjayBleGlzdGluZyBjb250ZW50",
+        "sha": "test_sha",
+    }
+
+    result = apply_diff_to_file(
+        diff=deletion_diff, file_path="utils/files/test_file.py", base_args=base_args
+    )
+
+    assert isinstance(result, str)
+    assert "Cannot delete files using apply_diff_to_file" in result
+    assert "Use the delete_file tool instead" in result
+    assert "utils/files/test_file.py" in result
+
+
+def test_missing_new_branch_error():
+    """Test that missing new_branch returns False due to handle_exceptions."""
+    base_args = cast(BaseArgs, {
+        "owner": "test_owner",
+        "repo": "test_repo",
+        "token": "test_token",
+        "new_branch": None,
+    })
+
+    result = apply_diff_to_file(
+        diff="--- test\n+++ test\n@@ -1,1 +1,1 @@\n-old\n+new",
+        file_path="test.py",
+        base_args=base_args,
+    )
+
+    assert result is False

--- a/services/github/files/test_get_remote_file_content_by_url.py
+++ b/services/github/files/test_get_remote_file_content_by_url.py
@@ -8,7 +8,9 @@ import pytest
 import requests
 
 # Local imports
-from services.github.files.get_remote_file_content_by_url import get_remote_file_content_by_url
+from services.github.files.get_remote_file_content_by_url import (
+    get_remote_file_content_by_url,
+)
 
 
 class TestGetRemoteFileContentByUrl:
@@ -80,8 +82,12 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_successful_file_retrieval_full_content(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_parse_github_url, mock_github_response
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_parse_github_url,
+        mock_github_response,
     ):
         """Test successful retrieval of full file content without line filtering."""
         mock_parse_url.return_value = mock_parse_github_url
@@ -115,8 +121,12 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_successful_file_retrieval_with_line_range(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_parse_github_url_with_lines, mock_github_response
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_parse_github_url_with_lines,
+        mock_github_response,
     ):
         """Test successful retrieval with line range filtering."""
         mock_parse_url.return_value = mock_parse_github_url_with_lines
@@ -146,8 +156,12 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_successful_file_retrieval_single_line(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_parse_github_url_single_line, mock_github_response
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_parse_github_url_single_line,
+        mock_github_response,
     ):
         """Test successful retrieval with single line filtering."""
         mock_parse_url.return_value = mock_parse_github_url_single_line
@@ -172,13 +186,16 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_http_error_handled_by_decorator(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_parse_github_url
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_parse_github_url,
     ):
         """Test that HTTP errors are handled by the decorator."""
         mock_parse_url.return_value = mock_parse_github_url
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
-        
+
         mock_response = MagicMock()
         mock_response.status_code = 404
         mock_response.reason = "Not Found"
@@ -201,13 +218,16 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_json_decode_error_handled_by_decorator(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_parse_github_url
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_parse_github_url,
     ):
         """Test that JSON decode errors are handled by the decorator."""
         mock_parse_url.return_value = mock_parse_github_url
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
-        
+
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
@@ -227,13 +247,16 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_base64_decode_error_handled_by_decorator(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_parse_github_url
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_parse_github_url,
     ):
         """Test that base64 decode errors are handled by the decorator."""
         mock_parse_url.return_value = mock_parse_github_url
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
-        
+
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
@@ -256,13 +279,18 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_requests_exception_handled_by_decorator(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_parse_github_url
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_parse_github_url,
     ):
         """Test that requests exceptions are handled by the decorator."""
         mock_parse_url.return_value = mock_parse_github_url
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
-        mock_requests_get.side_effect = requests.exceptions.ConnectionError("Connection failed")
+        mock_requests_get.side_effect = requests.exceptions.ConnectionError(
+            "Connection failed"
+        )
 
         url = "https://github.com/test-owner/test-repo/blob/main/src/test.py"
         result = get_remote_file_content_by_url(url, "test-token")
@@ -296,8 +324,11 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_create_headers_exception_handled_by_decorator(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_parse_github_url
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_parse_github_url,
     ):
         """Test that create_headers exceptions are handled by the decorator."""
         mock_parse_url.return_value = mock_parse_github_url
@@ -316,16 +347,21 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_empty_file_content(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_parse_github_url
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_parse_github_url,
     ):
         """Test handling of empty file content."""
         mock_parse_url.return_value = mock_parse_github_url
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
-        
+
         empty_content = ""
-        encoded_content = base64.b64encode(empty_content.encode("utf-8")).decode("utf-8")
-        
+        encoded_content = base64.b64encode(empty_content.encode("utf-8")).decode(
+            "utf-8"
+        )
+
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
@@ -345,16 +381,21 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_unicode_content_handling(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_parse_github_url
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_parse_github_url,
     ):
         """Test proper handling of Unicode content."""
         mock_parse_url.return_value = mock_parse_github_url
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
-        
+
         unicode_content = "# 测试文件\nprint('Hello, 世界!')\n# 这是一个测试"
-        encoded_content = base64.b64encode(unicode_content.encode("utf-8")).decode("utf-8")
-        
+        encoded_content = base64.b64encode(unicode_content.encode("utf-8")).decode(
+            "utf-8"
+        )
+
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
@@ -379,8 +420,11 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_different_branch_and_commit_sha(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_github_response
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_github_response,
     ):
         """Test retrieval with different branch and commit SHA."""
         mock_parse_url.return_value = {
@@ -408,8 +452,11 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_nested_file_path(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_github_response
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_github_response,
     ):
         """Test retrieval of nested file path."""
         mock_parse_url.return_value = {
@@ -437,8 +484,11 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_line_range_edge_cases(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_github_response
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_github_response,
     ):
         """Test line range edge cases."""
         # Test line range that exceeds file length
@@ -467,8 +517,11 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_single_line_edge_case(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_github_response
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_github_response,
     ):
         """Test single line edge case that exceeds file length."""
         mock_parse_url.return_value = {
@@ -497,18 +550,22 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_various_http_error_codes(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_parse_github_url, status_code
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_parse_github_url,
+        status_code,
     ):
         """Test handling of various HTTP error status codes."""
         mock_parse_url.return_value = mock_parse_github_url
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
-        
+
         mock_response = MagicMock()
         mock_response.status_code = status_code
         mock_response.reason = f"HTTP {status_code} Error"
         mock_response.text = f"Error {status_code}"
-        
+
         http_error = requests.exceptions.HTTPError(f"{status_code} Error")
         http_error.response = mock_response
         mock_response.raise_for_status.side_effect = http_error
@@ -534,8 +591,15 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_various_parameter_combinations(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_github_response, owner, repo, ref, file_path
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_github_response,
+        owner,
+        repo,
+        ref,
+        file_path,
     ):
         """Test that the function handles various parameter combinations correctly."""
         mock_parse_url.return_value = {
@@ -564,17 +628,22 @@ class TestGetRemoteFileContentByUrl:
     @patch("services.github.files.get_remote_file_content_by_url.create_headers")
     @patch("services.github.files.get_remote_file_content_by_url.parse_github_url")
     def test_large_file_content(
-        self, mock_parse_url, mock_create_headers, mock_requests_get,
-        mock_parse_github_url
+        self,
+        mock_parse_url,
+        mock_create_headers,
+        mock_requests_get,
+        mock_parse_github_url,
     ):
         """Test handling of large file content."""
         mock_parse_url.return_value = mock_parse_github_url
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
-        
+
         # Create large content (simulating a large file)
         large_content = "# Large file\n" + "print('line')\n" * 100
-        encoded_content = base64.b64encode(large_content.encode("utf-8")).decode("utf-8")
-        
+        encoded_content = base64.b64encode(large_content.encode("utf-8")).decode(
+            "utf-8"
+        )
+
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None

--- a/services/github/pulls/test_add_reviewers.py
+++ b/services/github/pulls/test_add_reviewers.py
@@ -42,10 +42,7 @@ def mock_success_response():
     response = Mock(spec=requests.Response)
     response.status_code = 200
     response.json.return_value = {
-        "requested_reviewers": [
-            {"login": "reviewer1"},
-            {"login": "reviewer2"}
-        ]
+        "requested_reviewers": [{"login": "reviewer1"}, {"login": "reviewer2"}]
     }
     return response
 
@@ -82,7 +79,7 @@ def test_add_reviewers_success_all_valid(
     result = add_reviewers(base_args)
 
     assert result is None  # Function returns None on success
-    
+
     # Verify collaborator checks were called for each reviewer
     assert mock_check_collaborator.call_count == 3
     mock_check_collaborator.assert_any_call(
@@ -94,10 +91,12 @@ def test_add_reviewers_success_all_valid(
     mock_check_collaborator.assert_any_call(
         owner="gitautoai", repo="gitauto", user="reviewer3", token="test-token-mock"
     )
-    
+
     # Verify print was called with valid reviewers
-    mock_print.assert_called_once_with("Adding reviewers: ['reviewer1', 'reviewer2', 'reviewer3']")
-    
+    mock_print.assert_called_once_with(
+        "Adding reviewers: ['reviewer1', 'reviewer2', 'reviewer3']"
+    )
+
     # Verify API call was made
     mock_create_headers.assert_called_once_with(token="test-token-mock")
     mock_post.assert_called_once_with(
@@ -124,7 +123,7 @@ def test_add_reviewers_success_partial_valid(
     # Only some reviewers are collaborators
     def collaborator_side_effect(owner, repo, user, token):
         return user in ["reviewer1", "reviewer3"]
-    
+
     mock_check_collaborator.side_effect = collaborator_side_effect
     mock_post.return_value = mock_success_response
     mock_create_headers.return_value = {"Authorization": "Bearer token"}
@@ -132,13 +131,13 @@ def test_add_reviewers_success_partial_valid(
     result = add_reviewers(base_args)
 
     assert result is None
-    
+
     # Verify collaborator checks were called for each reviewer
     assert mock_check_collaborator.call_count == 3
-    
+
     # Verify print was called with only valid reviewers
     mock_print.assert_called_once_with("Adding reviewers: ['reviewer1', 'reviewer3']")
-    
+
     # Verify API call was made with only valid reviewers
     mock_post.assert_called_once_with(
         url="https://api.github.com/repos/gitautoai/gitauto/pulls/123/requested_reviewers",
@@ -159,7 +158,7 @@ def test_add_reviewers_no_valid_reviewers(
     result = add_reviewers(base_args)
 
     assert result is None
-    
+
     # Verify collaborator checks were called for each reviewer
     assert mock_check_collaborator.call_count == 3
 
@@ -172,7 +171,7 @@ def test_add_reviewers_empty_reviewers_list(
     result = add_reviewers(base_args_empty_reviewers)
 
     assert result is None
-    
+
     # No collaborator checks should be made for empty list
     mock_check_collaborator.assert_not_called()
 
@@ -191,7 +190,7 @@ def test_add_reviewers_pr_number_none(test_owner, test_repo):
         "token": "test-token-mock",
         "reviewers": ["reviewer1"],
     }
-    
+
     result = add_reviewers(base_args)
 
     assert result is None  # handle_exceptions decorator returns None on error
@@ -216,7 +215,7 @@ def test_add_reviewers_http_error(
     result = add_reviewers(base_args)
 
     assert result is None  # handle_exceptions decorator returns None on error
-    
+
     # Verify the API call was attempted
     mock_post.assert_called_once()
     mock_error_response.raise_for_status.assert_called_once()
@@ -290,7 +289,7 @@ def test_add_reviewers_single_reviewer(
         "token": "test-token-mock",
         "reviewers": ["single_reviewer"],
     }
-    
+
     mock_check_collaborator.return_value = True
     mock_post.return_value = mock_success_response
     mock_create_headers.return_value = {"Authorization": "Bearer token"}
@@ -307,7 +306,6 @@ def test_add_reviewers_single_reviewer(
     )
 
 
-
 @patch("services.github.pulls.add_reviewers.create_headers")
 @patch("services.github.pulls.add_reviewers.requests.post")
 @patch("services.github.pulls.add_reviewers.check_user_is_collaborator")
@@ -319,7 +317,7 @@ def test_add_reviewers_422_unprocessable_entity(
 ):
     mock_check_collaborator.return_value = True
     mock_create_headers.return_value = {"Authorization": "Bearer token"}
-    
+
     # Create a 422 response (e.g., reviewer already requested)
     response = Mock(spec=requests.Response)
     response.status_code = 422
@@ -344,7 +342,7 @@ def test_add_reviewers_missing_required_fields():
         "token": "test-token",
         "reviewers": ["reviewer1"],
     }
-    
+
     result = add_reviewers(incomplete_args)
     assert result is None  # handle_exceptions decorator returns None on error
 
@@ -369,7 +367,7 @@ def test_add_reviewers_mixed_collaborator_results(
             raise Exception("API error")  # This should be handled by handle_exceptions
         else:  # reviewer3
             return False
-    
+
     mock_check_collaborator.side_effect = collaborator_side_effect
     mock_post.return_value = mock_success_response
     mock_create_headers.return_value = {"Authorization": "Bearer token"}
@@ -378,7 +376,9 @@ def test_add_reviewers_mixed_collaborator_results(
 
     # Should still work with the valid reviewer despite the exception
     assert result is None
-    assert mock_check_collaborator.call_count == 2  # Should stop after exception on reviewer2
+    assert (
+        mock_check_collaborator.call_count == 2
+    )  # Should stop after exception on reviewer2
 
 
 @patch("services.github.pulls.add_reviewers.create_headers")
@@ -438,7 +438,7 @@ def test_add_reviewers_url_construction(
         "token": "different-token",
         "reviewers": ["test-reviewer"],
     }
-    
+
     mock_check_collaborator.return_value = True
     mock_post.return_value = mock_success_response
     mock_create_headers.return_value = {"Authorization": "Bearer token"}

--- a/services/github/pulls/test_get_review_thread_comments.py
+++ b/services/github/pulls/test_get_review_thread_comments.py
@@ -9,7 +9,9 @@ from services.github.pulls.get_review_thread_comments import get_review_thread_c
 @pytest.fixture
 def mock_graphql_client():
     """Fixture to provide a mocked GraphQL client."""
-    with patch("services.github.pulls.get_review_thread_comments.get_graphql_client") as mock:
+    with patch(
+        "services.github.pulls.get_review_thread_comments.get_graphql_client"
+    ) as mock:
         mock_client = MagicMock()
         mock.return_value = mock_client
         yield mock_client
@@ -122,15 +124,7 @@ def test_get_review_thread_comments_no_review_threads_returns_empty_list(
 ):
     """Test that function returns empty list when there are no review threads."""
     # Arrange
-    response = {
-        "repository": {
-            "pullRequest": {
-                "reviewThreads": {
-                    "nodes": []
-                }
-            }
-        }
-    }
+    response = {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}
     mock_graphql_client.execute.return_value = response
 
     # Act
@@ -148,17 +142,7 @@ def test_get_review_thread_comments_empty_thread_comments_returns_empty_list(
     # Arrange
     response = {
         "repository": {
-            "pullRequest": {
-                "reviewThreads": {
-                    "nodes": [
-                        {
-                            "comments": {
-                                "nodes": []
-                            }
-                        }
-                    ]
-                }
-            }
+            "pullRequest": {"reviewThreads": {"nodes": [{"comments": {"nodes": []}}]}}
         }
     }
     mock_graphql_client.execute.return_value = response
@@ -231,7 +215,11 @@ def test_get_review_thread_comments_calls_graphql_with_correct_parameters(
     # Assert
     call_args = mock_graphql_client.execute.call_args
     query_arg = call_args[0][0] if call_args[0] else call_args.kwargs["document"]
-    variables_arg = call_args[1]["variable_values"] if call_args[0] else call_args.kwargs["variable_values"]
+    variables_arg = (
+        call_args[1]["variable_values"]
+        if call_args[0]
+        else call_args.kwargs["variable_values"]
+    )
 
     # Verify the query structure (checking if it's a gql object with the right content)
     assert str(type(query_arg).__name__) == "DocumentNode"
@@ -263,7 +251,9 @@ def test_get_review_thread_comments_creates_graphql_client_with_token(sample_par
         mock_get_client.assert_called_once_with("test-token")
 
 
-def test_get_review_thread_comments_handles_graphql_exception_returns_empty_list(sample_params):
+def test_get_review_thread_comments_handles_graphql_exception_returns_empty_list(
+    sample_params,
+):
     """Test that function returns empty list when GraphQL exception occurs (due to @handle_exceptions decorator)."""
     with patch(
         "services.github.pulls.get_review_thread_comments.get_graphql_client"
@@ -277,7 +267,9 @@ def test_get_review_thread_comments_handles_graphql_exception_returns_empty_list
         assert result == []
 
 
-def test_get_review_thread_comments_handles_client_execute_exception_returns_empty_list(sample_params):
+def test_get_review_thread_comments_handles_client_execute_exception_returns_empty_list(
+    sample_params,
+):
     """Test that function returns empty list when client.execute raises exception (due to @handle_exceptions decorator)."""
     with patch(
         "services.github.pulls.get_review_thread_comments.get_graphql_client"
@@ -326,7 +318,7 @@ def test_get_review_thread_comments_with_different_parameters(mock_graphql_clien
         repo="special-repo",
         pull_number=999,
         comment_node_id="SpecialCommentId123",
-        token="special-token"
+        token="special-token",
     )
 
     # Assert
@@ -365,7 +357,6 @@ def test_get_review_thread_comments_malformed_response_structure(
 
         assert result == []
         mock_graphql_client.execute.assert_called_once()
-
 
 
 def test_get_review_thread_comments_missing_comment_fields(
@@ -422,7 +413,11 @@ def test_get_review_thread_comments_function_has_proper_docstring():
     assert get_review_thread_comments.__doc__ is not None
     assert "Get all comments in a review thread" in get_review_thread_comments.__doc__
     assert "GraphQL API" in get_review_thread_comments.__doc__
-    assert "https://docs.github.com/en/graphql/reference/objects#pullrequestreviewcomment" in get_review_thread_comments.__doc__
+    assert (
+        "https://docs.github.com/en/graphql/reference/objects#pullrequestreviewcomment"
+        in get_review_thread_comments.__doc__
+    )
+
 
 def test_get_review_thread_comments_multiple_threads_finds_correct_one(
     mock_graphql_client, sample_params
@@ -459,7 +454,7 @@ def test_get_review_thread_comments_multiple_threads_finds_correct_one(
                                         "author": {"login": "user3"},
                                         "body": "Correct thread comment 2",
                                         "createdAt": "2023-01-01T12:00:00Z",
-                                    }
+                                    },
                                 ]
                             }
                         },
@@ -474,7 +469,7 @@ def test_get_review_thread_comments_multiple_threads_finds_correct_one(
                                     }
                                 ]
                             }
-                        }
+                        },
                     ]
                 }
             }
@@ -497,7 +492,7 @@ def test_get_review_thread_comments_multiple_threads_finds_correct_one(
             "author": {"login": "user3"},
             "body": "Correct thread comment 2",
             "createdAt": "2023-01-01T12:00:00Z",
-        }
+        },
     ]
     assert result == expected_comments
     mock_graphql_client.execute.assert_called_once()
@@ -515,12 +510,8 @@ def test_get_review_thread_comments_thread_with_missing_comments_structure(
                         {
                             # Missing comments field entirely
                         },
-                        {
-                            "comments": None  # comments is null
-                        },
-                        {
-                            "comments": {}  # comments missing nodes
-                        }
+                        {"comments": None},  # comments is null
+                        {"comments": {}},  # comments missing nodes
                     ]
                 }
             }

--- a/services/openai/test_count_tokens.py
+++ b/services/openai/test_count_tokens.py
@@ -26,57 +26,67 @@ def test_count_tokens_empty_messages(mock_tiktoken_encoding_for_model, mock_enco
     """Test count_tokens with empty message list"""
     messages = []
     result = count_tokens(messages)
-    
+
     assert result == 0
     mock_tiktoken_encoding_for_model.assert_called_once()
 
 
-def test_count_tokens_message_with_role_only(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_role_only(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing only role"""
     messages = [{"role": "user"}]
     result = count_tokens(messages)
-    
+
     # "user" = 4 characters = 4 tokens
     assert result == 4
     mock_encoding.encode.assert_called_with("user")
 
 
-def test_count_tokens_message_with_string_content(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_string_content(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing role and string content"""
     messages = [{"role": "user", "content": "Hello world"}]
     result = count_tokens(messages)
-    
+
     # "user" (4) + "Hello world" (11) = 15 tokens
     assert result == 15
     assert mock_encoding.encode.call_count == 2
 
 
-def test_count_tokens_message_with_empty_string_content(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_empty_string_content(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing empty string content"""
     messages = [{"role": "user", "content": ""}]
     result = count_tokens(messages)
-    
+
     # "user" (4) + "" (0) = 4 tokens
     assert result == 4
     mock_encoding.encode.assert_any_call("user")
     mock_encoding.encode.assert_any_call("")
 
 
-def test_count_tokens_message_with_none_string_content(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_none_string_content(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing None string content"""
     messages = [{"role": "user", "content": None}]
     result = count_tokens(messages)
-    
+
     # "user" (4) + 0 (None content is not processed as string) = 4 tokens
     assert result == 4
     mock_encoding.encode.assert_any_call("user")
 
 
-def test_count_tokens_message_with_name(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_name(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing name field"""
     messages = [{"role": "user", "content": "Hello", "name": "assistant"}]
     result = count_tokens(messages)
-    
+
     # "user" (4) + "Hello" (5) + "assistant" (9) = 18 tokens
     assert result == 18
     mock_encoding.encode.assert_any_call("user")
@@ -84,49 +94,54 @@ def test_count_tokens_message_with_name(mock_tiktoken_encoding_for_model, mock_e
     mock_encoding.encode.assert_any_call("assistant")
 
 
-def test_count_tokens_message_with_list_content_text_block(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_list_content_text_block(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing list content with text block"""
-    messages = [{
-        "role": "user",
-        "content": [
-            {"type": "text", "text": "Hello world"}
-        ]
-    }]
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hello world"}]}]
     result = count_tokens(messages)
-    
+
     # "user" (4) + "Hello world" (11) = 15 tokens
     assert result == 15
     mock_encoding.encode.assert_any_call("user")
     mock_encoding.encode.assert_any_call("Hello world")
 
 
-def test_count_tokens_message_with_list_content_text_block_empty_text(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_list_content_text_block_empty_text(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing list content with text block having empty text"""
-    messages = [{
-        "role": "user",
-        "content": [
-            {"type": "text", "text": ""},
-            {"type": "text"}  # Missing text field
-        ]
-    }]
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": ""},
+                {"type": "text"},  # Missing text field
+            ],
+        }
+    ]
     result = count_tokens(messages)
-    
+
     # "user" (4) + "" (0) + "" (0, default for missing text) = 4 tokens
     assert result == 4
     mock_encoding.encode.assert_any_call("user")
     mock_encoding.encode.assert_any_call("")
 
 
-def test_count_tokens_message_with_list_content_tool_use_block(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_list_content_tool_use_block(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing list content with tool_use block"""
-    messages = [{
-        "role": "assistant",
-        "content": [
-            {"type": "tool_use", "name": "search", "input": {"query": "test"}}
-        ]
-    }]
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "name": "search", "input": {"query": "test"}}
+            ],
+        }
+    ]
     result = count_tokens(messages)
-    
+
     # "assistant" (9) + "search" (6) + "{'query': 'test'}" (17) = 32 tokens
     assert result == 32
     mock_encoding.encode.assert_any_call("assistant")
@@ -134,88 +149,98 @@ def test_count_tokens_message_with_list_content_tool_use_block(mock_tiktoken_enc
     mock_encoding.encode.assert_any_call("{'query': 'test'}")
 
 
-def test_count_tokens_message_with_list_content_tool_use_block_empty_fields(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_list_content_tool_use_block_empty_fields(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing list content with tool_use block having empty fields"""
-    messages = [{
-        "role": "assistant",
-        "content": [
-            {"type": "tool_use"},  # Missing name and input
-            {"type": "tool_use", "name": "", "input": ""}
-        ]
-    }]
+    messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use"},  # Missing name and input
+                {"type": "tool_use", "name": "", "input": ""},
+            ],
+        }
+    ]
     result = count_tokens(messages)
-    
+
     # "assistant" (9) + "" (0, default name) + "" (0, default input) + "" (0, empty name) + "" (0, empty input) = 9 tokens
     assert result == 9
     mock_encoding.encode.assert_any_call("assistant")
     mock_encoding.encode.assert_any_call("")
 
 
-def test_count_tokens_message_with_list_content_tool_result_block(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_list_content_tool_result_block(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing list content with tool_result block"""
-    messages = [{
-        "role": "user",
-        "content": [
-            {"type": "tool_result", "content": "Result data"}
-        ]
-    }]
+    messages = [
+        {"role": "user", "content": [{"type": "tool_result", "content": "Result data"}]}
+    ]
     result = count_tokens(messages)
-    
+
     # "user" (4) + "Result data" (11) = 15 tokens
     assert result == 15
     mock_encoding.encode.assert_any_call("user")
     mock_encoding.encode.assert_any_call("Result data")
 
 
-def test_count_tokens_message_with_list_content_tool_result_block_empty_content(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_list_content_tool_result_block_empty_content(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing list content with tool_result block having empty content"""
-    messages = [{
-        "role": "user",
-        "content": [
-            {"type": "tool_result"},  # Missing content
-            {"type": "tool_result", "content": ""}
-        ]
-    }]
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result"},  # Missing content
+                {"type": "tool_result", "content": ""},
+            ],
+        }
+    ]
     result = count_tokens(messages)
-    
+
     # "user" (4) + "" (0, default content) + "" (0, empty content) = 4 tokens
     assert result == 4
     mock_encoding.encode.assert_any_call("user")
     mock_encoding.encode.assert_any_call("")
 
 
-def test_count_tokens_message_with_list_content_unknown_block_type(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_list_content_unknown_block_type(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing list content with unknown block type"""
-    messages = [{
-        "role": "user",
-        "content": [
-            {"type": "unknown", "data": "some data"},
-            {"type": "image", "url": "http://example.com/image.jpg"}
-        ]
-    }]
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "unknown", "data": "some data"},
+                {"type": "image", "url": "http://example.com/image.jpg"},
+            ],
+        }
+    ]
     result = count_tokens(messages)
-    
+
     # Only "user" (4) tokens, unknown blocks are ignored
     assert result == 4
     mock_encoding.encode.assert_called_once_with("user")
 
 
-def test_count_tokens_message_with_tool_calls(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_tool_calls(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing tool_calls"""
-    messages = [{
-        "role": "assistant",
-        "content": "I'll search for that",
-        "tool_calls": [
-            {
-                "function": {
-                    "name": "search",
-                    "arguments": '{"query": "test"}'
-                }
-            }
-        ]
-    }]
+    messages = [
+        {
+            "role": "assistant",
+            "content": "I'll search for that",
+            "tool_calls": [
+                {"function": {"name": "search", "arguments": '{"query": "test"}'}}
+            ],
+        }
+    ]
     result = count_tokens(messages)
-    
+
     # "assistant" (9) + "I'll search for that" (20) + "search" (6) + '{"query": "test"}' (17) = 52 tokens
     assert result == 52
     mock_encoding.encode.assert_any_call("assistant")
@@ -224,45 +249,48 @@ def test_count_tokens_message_with_tool_calls(mock_tiktoken_encoding_for_model, 
     mock_encoding.encode.assert_any_call('{"query": "test"}')
 
 
-def test_count_tokens_message_with_tool_calls_no_function(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_tool_calls_no_function(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing tool_calls without function field"""
-    messages = [{
-        "role": "assistant",
-        "content": "Hello",
-        "tool_calls": [
-            {"id": "call_123"},  # No function field
-            {}  # Empty tool call
-        ]
-    }]
+    messages = [
+        {
+            "role": "assistant",
+            "content": "Hello",
+            "tool_calls": [
+                {"id": "call_123"},  # No function field
+                {},  # Empty tool call
+            ],
+        }
+    ]
     result = count_tokens(messages)
-    
+
     # Only "assistant" (9) + "Hello" (5) = 14 tokens, tool_calls without function are ignored
     assert result == 14
     mock_encoding.encode.assert_any_call("assistant")
     mock_encoding.encode.assert_any_call("Hello")
 
 
-def test_count_tokens_message_with_multiple_tool_calls(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_multiple_tool_calls(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing multiple tool_calls"""
-    messages = [{
-        "role": "assistant",
-        "tool_calls": [
-            {
-                "function": {
-                    "name": "search",
-                    "arguments": '{"query": "test1"}'
-                }
-            },
-            {
-                "function": {
-                    "name": "calculate",
-                    "arguments": '{"expression": "2+2"}'
-                }
-            }
-        ]
-    }]
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {"function": {"name": "search", "arguments": '{"query": "test1"}'}},
+                {
+                    "function": {
+                        "name": "calculate",
+                        "arguments": '{"expression": "2+2"}',
+                    }
+                },
+            ],
+        }
+    ]
     result = count_tokens(messages)
-    
+
     # "assistant" (9) + "search" (6) + '{"query": "test1"}' (18) + "calculate" (9) + '{"expression": "2+2"}' (21) = 63 tokens
     assert result == 63
     mock_encoding.encode.assert_any_call("assistant")
@@ -272,30 +300,26 @@ def test_count_tokens_message_with_multiple_tool_calls(mock_tiktoken_encoding_fo
     mock_encoding.encode.assert_any_call('{"expression": "2+2"}')
 
 
-def test_count_tokens_multiple_messages_complex(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_multiple_messages_complex(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with multiple complex messages"""
     messages = [
-        {
-            "role": "user",
-            "content": "Hello",
-            "name": "john"
-        },
+        {"role": "user", "content": "Hello", "name": "john"},
         {
             "role": "assistant",
             "content": [
                 {"type": "text", "text": "Hi there"},
-                {"type": "tool_use", "name": "search", "input": {"q": "test"}}
-            ]
+                {"type": "tool_use", "name": "search", "input": {"q": "test"}},
+            ],
         },
         {
             "role": "user",
-            "content": [
-                {"type": "tool_result", "content": "Found results"}
-            ]
-        }
+            "content": [{"type": "tool_result", "content": "Found results"}],
+        },
     ]
     result = count_tokens(messages)
-    
+
     # Message 1: "user" (4) + "Hello" (5) + "john" (4) = 13
     # Message 2: "assistant" (9) + "Hi there" (8) + "search" (6) + "{'q': 'test'}" (13) = 36
     # Message 3: "user" (4) + "Found results" (13) = 17
@@ -303,33 +327,32 @@ def test_count_tokens_multiple_messages_complex(mock_tiktoken_encoding_for_model
     assert result == 66
 
 
-def test_count_tokens_message_without_role(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_without_role(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message without role field"""
     messages = [{"content": "Hello world"}]
     result = count_tokens(messages)
-    
+
     # Only "Hello world" (11) tokens, no role
     assert result == 11
     mock_encoding.encode.assert_called_once_with("Hello world")
 
 
-def test_count_tokens_message_with_all_fields(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_message_with_all_fields(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with message containing all possible fields"""
-    messages = [{
-        "role": "assistant",
-        "content": "Response",
-        "name": "bot",
-        "tool_calls": [
-            {
-                "function": {
-                    "name": "func",
-                    "arguments": "{}"
-                }
-            }
-        ]
-    }]
+    messages = [
+        {
+            "role": "assistant",
+            "content": "Response",
+            "name": "bot",
+            "tool_calls": [{"function": {"name": "func", "arguments": "{}"}}],
+        }
+    ]
     result = count_tokens(messages)
-    
+
     # "assistant" (9) + "Response" (8) + "bot" (3) + "func" (4) + "{}" (2) = 26 tokens
     assert result == 26
     mock_encoding.encode.assert_any_call("assistant")
@@ -339,19 +362,23 @@ def test_count_tokens_message_with_all_fields(mock_tiktoken_encoding_for_model, 
     mock_encoding.encode.assert_any_call("{}")
 
 
-def test_count_tokens_mixed_content_types(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_mixed_content_types(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with mixed content types in list"""
-    messages = [{
-        "role": "user",
-        "content": [
-            {"type": "text", "text": "Question"},
-            {"type": "tool_use", "name": "search", "input": "query"},
-            {"type": "tool_result", "content": "answer"},
-            {"type": "unknown", "data": "ignored"}
-        ]
-    }]
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Question"},
+                {"type": "tool_use", "name": "search", "input": "query"},
+                {"type": "tool_result", "content": "answer"},
+                {"type": "unknown", "data": "ignored"},
+            ],
+        }
+    ]
     result = count_tokens(messages)
-    
+
     # "user" (4) + "Question" (8) + "search" (6) + "query" (5) + "answer" (6) = 29 tokens
     # unknown type is ignored
     assert result == 29
@@ -362,24 +389,28 @@ def test_count_tokens_mixed_content_types(mock_tiktoken_encoding_for_model, mock
     mock_encoding.encode.assert_any_call("answer")
 
 
-def test_count_tokens_uses_correct_model(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_uses_correct_model(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test that count_tokens uses the correct OpenAI model"""
     from config import OPENAI_MODEL_ID_GPT_4O
-    
+
     messages = [{"role": "user", "content": "test"}]
     count_tokens(messages)
-    
-    mock_tiktoken_encoding_for_model.assert_called_once_with(model_name=OPENAI_MODEL_ID_GPT_4O)
+
+    mock_tiktoken_encoding_for_model.assert_called_once_with(
+        model_name=OPENAI_MODEL_ID_GPT_4O
+    )
 
 
 @patch("services.openai.count_tokens.tiktoken.encoding_for_model")
 def test_count_tokens_tiktoken_error_returns_default(mock_tiktoken_encoding_for_model):
     """Test that count_tokens returns default value (0) when tiktoken raises an error"""
     mock_tiktoken_encoding_for_model.side_effect = Exception("Tiktoken error")
-    
+
     messages = [{"role": "user", "content": "test"}]
     result = count_tokens(messages)
-    
+
     # Should return default value due to handle_exceptions decorator
     assert result == 0
 
@@ -390,23 +421,19 @@ def test_count_tokens_encoding_error_returns_default(mock_tiktoken_encoding_for_
     mock_encoding = MagicMock()
     mock_encoding.encode.side_effect = Exception("Encoding error")
     mock_tiktoken_encoding_for_model.return_value = mock_encoding
-    
+
     messages = [{"role": "user", "content": "test"}]
     result = count_tokens(messages)
-    
+
     # Should return default value due to handle_exceptions decorator
     assert result == 0
 
 
 def test_count_tokens_unicode_content(mock_tiktoken_encoding_for_model, mock_encoding):
     """Test count_tokens with unicode characters"""
-    messages = [{
-        "role": "user",
-        "content": "Hello 🌍 世界",
-        "name": "用户"
-    }]
+    messages = [{"role": "user", "content": "Hello 🌍 世界", "name": "用户"}]
     result = count_tokens(messages)
-    
+
     # "user" (4) + "Hello 🌍 世界" (10) + "用户" (2) = 16 tokens
     assert result == 16
     mock_encoding.encode.assert_any_call("user")
@@ -414,14 +441,15 @@ def test_count_tokens_unicode_content(mock_tiktoken_encoding_for_model, mock_enc
     mock_encoding.encode.assert_any_call("用户")
 
 
-def test_count_tokens_special_characters(mock_tiktoken_encoding_for_model, mock_encoding):
+def test_count_tokens_special_characters(
+    mock_tiktoken_encoding_for_model, mock_encoding
+):
     """Test count_tokens with special characters and newlines"""
-    messages = [{
-        "role": "user",
-        "content": "Line 1\nLine 2\tTabbed\r\nWindows newline"
-    }]
+    messages = [
+        {"role": "user", "content": "Line 1\nLine 2\tTabbed\r\nWindows newline"}
+    ]
     result = count_tokens(messages)
-    
+
     # "user" (4) + content (37) = 41 tokens
     assert result == 41
     mock_encoding.encode.assert_any_call("user")
@@ -431,12 +459,9 @@ def test_count_tokens_special_characters(mock_tiktoken_encoding_for_model, mock_
 def test_count_tokens_large_input(mock_tiktoken_encoding_for_model, mock_encoding):
     """Test count_tokens with large input"""
     large_content = "x" * 10000
-    messages = [{
-        "role": "user",
-        "content": large_content
-    }]
+    messages = [{"role": "user", "content": large_content}]
     result = count_tokens(messages)
-    
+
     # "user" (4) + large_content (10000) = 10004 tokens
     assert result == 10004
     mock_encoding.encode.assert_any_call("user")

--- a/services/stripe/test_check_subscription_limit.py
+++ b/services/stripe/test_check_subscription_limit.py
@@ -25,12 +25,18 @@ def mock_count_completed_unique_requests():
         yield mock
 
 
-def create_mock_subscription(product_id, interval, quantity=1, start_timestamp=1640995200, end_timestamp=1643673600):
+def create_mock_subscription(
+    product_id,
+    interval,
+    quantity=1,
+    start_timestamp=1640995200,
+    end_timestamp=1643673600,
+):
     """Helper to create a mock subscription with proper structure."""
     mock_subscription = MagicMock()
     mock_subscription.current_period_start = start_timestamp
     mock_subscription.current_period_end = end_timestamp
-    
+
     # Mock the subscription's items data access using a direct dictionary approach
     subscription_data = {
         "items": {
@@ -45,7 +51,7 @@ def create_mock_subscription(product_id, interval, quantity=1, start_timestamp=1
             ]
         }
     }
-    
+
     mock_subscription.__getitem__ = lambda self, key: subscription_data[key]
     return mock_subscription
 
@@ -77,21 +83,26 @@ def test_check_subscription_limit_monthly_subscription_with_requests_left(
     """Test monthly subscription with requests remaining."""
     # Setup mocks
     mock_get_base_request_limit.return_value = 100
-    mock_count_completed_unique_requests.return_value = {"req1", "req2", "req3"}  # 3 requests used
-    
-    result = check_subscription_limit(sample_monthly_subscription, sample_installation_id)
-    
+    mock_count_completed_unique_requests.return_value = {
+        "req1",
+        "req2",
+        "req3",
+    }  # 3 requests used
+
+    result = check_subscription_limit(
+        sample_monthly_subscription, sample_installation_id
+    )
+
     # Assertions
     assert result["can_proceed"] is True
     assert result["requests_left"] == 97  # 100 - 3
     assert result["request_limit"] == 100  # base_limit * 1 (quantity)
     assert result["period_end_date"] == datetime.fromtimestamp(1643673600, tz=TZ)
-    
+
     # Verify function calls
     mock_get_base_request_limit.assert_called_once_with("prod_test123")
     mock_count_completed_unique_requests.assert_called_once_with(
-        sample_installation_id, 
-        datetime.fromtimestamp(1640995200, tz=TZ)
+        sample_installation_id, datetime.fromtimestamp(1640995200, tz=TZ)
     )
 
 
@@ -104,10 +115,14 @@ def test_check_subscription_limit_monthly_subscription_no_requests_left(
     """Test monthly subscription with no requests remaining."""
     # Setup mocks
     mock_get_base_request_limit.return_value = 50
-    mock_count_completed_unique_requests.return_value = set(f"req{i}" for i in range(50))  # 50 requests used
-    
-    result = check_subscription_limit(sample_monthly_subscription, sample_installation_id)
-    
+    mock_count_completed_unique_requests.return_value = set(
+        f"req{i}" for i in range(50)
+    )  # 50 requests used
+
+    result = check_subscription_limit(
+        sample_monthly_subscription, sample_installation_id
+    )
+
     # Assertions
     assert result["can_proceed"] is False
     assert result["requests_left"] == 0  # 50 - 50
@@ -124,10 +139,14 @@ def test_check_subscription_limit_monthly_subscription_exceeded_limit(
     """Test monthly subscription with requests exceeding limit."""
     # Setup mocks
     mock_get_base_request_limit.return_value = 30
-    mock_count_completed_unique_requests.return_value = set(f"req{i}" for i in range(35))  # 35 requests used
-    
-    result = check_subscription_limit(sample_monthly_subscription, sample_installation_id)
-    
+    mock_count_completed_unique_requests.return_value = set(
+        f"req{i}" for i in range(35)
+    )  # 35 requests used
+
+    result = check_subscription_limit(
+        sample_monthly_subscription, sample_installation_id
+    )
+
     # Assertions
     assert result["can_proceed"] is False
     assert result["requests_left"] == -5  # 30 - 35
@@ -143,10 +162,15 @@ def test_check_subscription_limit_yearly_subscription(
     """Test yearly subscription with 12x multiplier."""
     # Setup mocks
     mock_get_base_request_limit.return_value = 100
-    mock_count_completed_unique_requests.return_value = {"req1", "req2"}  # 2 requests used
-    
-    result = check_subscription_limit(sample_yearly_subscription, sample_installation_id)
-    
+    mock_count_completed_unique_requests.return_value = {
+        "req1",
+        "req2",
+    }  # 2 requests used
+
+    result = check_subscription_limit(
+        sample_yearly_subscription, sample_installation_id
+    )
+
     # Assertions
     assert result["can_proceed"] is True
     assert result["requests_left"] == 1198  # (100 * 12 * 1) - 2
@@ -160,14 +184,18 @@ def test_check_subscription_limit_with_quantity_greater_than_one(
     sample_installation_id,
 ):
     """Test subscription with quantity > 1."""
-    subscription_with_quantity = create_mock_subscription("prod_test789", "month", 3, 1640995200, 1643673600)
-    
+    subscription_with_quantity = create_mock_subscription(
+        "prod_test789", "month", 3, 1640995200, 1643673600
+    )
+
     # Setup mocks
     mock_get_base_request_limit.return_value = 100
     mock_count_completed_unique_requests.return_value = {"req1"}  # 1 request used
-    
-    result = check_subscription_limit(subscription_with_quantity, sample_installation_id)
-    
+
+    result = check_subscription_limit(
+        subscription_with_quantity, sample_installation_id
+    )
+
     # Assertions
     assert result["can_proceed"] is True
     assert result["requests_left"] == 299  # (100 * 3) - 1
@@ -180,14 +208,18 @@ def test_check_subscription_limit_yearly_with_quantity(
     sample_installation_id,
 ):
     """Test yearly subscription with quantity > 1."""
-    yearly_subscription_with_quantity = create_mock_subscription("prod_test999", "year", 2, 1640995200, 1672531200)
-    
+    yearly_subscription_with_quantity = create_mock_subscription(
+        "prod_test999", "year", 2, 1640995200, 1672531200
+    )
+
     # Setup mocks
     mock_get_base_request_limit.return_value = 50
     mock_count_completed_unique_requests.return_value = set()  # 0 requests used
-    
-    result = check_subscription_limit(yearly_subscription_with_quantity, sample_installation_id)
-    
+
+    result = check_subscription_limit(
+        yearly_subscription_with_quantity, sample_installation_id
+    )
+
     # Assertions
     assert result["can_proceed"] is True
     assert result["requests_left"] == 1200  # (50 * 12 * 2) - 0
@@ -204,9 +236,11 @@ def test_check_subscription_limit_with_empty_unique_requests(
     # Setup mocks
     mock_get_base_request_limit.return_value = 100
     mock_count_completed_unique_requests.return_value = set()  # No requests used
-    
-    result = check_subscription_limit(sample_monthly_subscription, sample_installation_id)
-    
+
+    result = check_subscription_limit(
+        sample_monthly_subscription, sample_installation_id
+    )
+
     # Assertions
     assert result["can_proceed"] is True
     assert result["requests_left"] == 100  # 100 - 0
@@ -223,9 +257,11 @@ def test_check_subscription_limit_handles_get_base_request_limit_exception(
     # Setup mocks
     mock_get_base_request_limit.side_effect = Exception("Stripe API error")
     mock_count_completed_unique_requests.return_value = {"req1"}
-    
-    result = check_subscription_limit(sample_monthly_subscription, sample_installation_id)
-    
+
+    result = check_subscription_limit(
+        sample_monthly_subscription, sample_installation_id
+    )
+
     # Should return default error values due to @handle_exceptions decorator
     assert result["can_proceed"] is False
     assert result["requests_left"] == 0
@@ -243,9 +279,11 @@ def test_check_subscription_limit_handles_count_requests_exception(
     # Setup mocks
     mock_get_base_request_limit.return_value = 100
     mock_count_completed_unique_requests.side_effect = Exception("Database error")
-    
-    result = check_subscription_limit(sample_monthly_subscription, sample_installation_id)
-    
+
+    result = check_subscription_limit(
+        sample_monthly_subscription, sample_installation_id
+    )
+
     # Should return default error values due to @handle_exceptions decorator
     assert result["can_proceed"] is False
     assert result["requests_left"] == 0
@@ -259,17 +297,19 @@ def test_check_subscription_limit_handles_malformed_subscription_data(
     sample_installation_id,
 ):
     """Test that function returns default values when subscription data is malformed."""
-    malformed_subscription = create_mock_subscription("prod_test", "month", 1, 1640995200, 1643673600)
-    
+    malformed_subscription = create_mock_subscription(
+        "prod_test", "month", 1, 1640995200, 1643673600
+    )
+
     # Override the __getitem__ to return empty data array
     malformed_subscription.__getitem__ = lambda self, key: {"items": {"data": []}}[key]
-    
+
     # Setup mocks
     mock_get_base_request_limit.return_value = 100
     mock_count_completed_unique_requests.return_value = {"req1"}
-    
+
     result = check_subscription_limit(malformed_subscription, sample_installation_id)
-    
+
     # Should return default error values due to @handle_exceptions decorator
     assert result["can_proceed"] is False
     assert result["requests_left"] == 0
@@ -298,14 +338,16 @@ def test_check_subscription_limit_request_limit_calculation(
     expected_limit,
 ):
     """Test request limit calculation for various intervals and quantities."""
-    subscription = create_mock_subscription("prod_test", interval, quantity, 1640995200, 1643673600)
-    
+    subscription = create_mock_subscription(
+        "prod_test", interval, quantity, 1640995200, 1643673600
+    )
+
     # Setup mocks
     mock_get_base_request_limit.return_value = base_limit
     mock_count_completed_unique_requests.return_value = set()  # No requests used
-    
+
     result = check_subscription_limit(subscription, sample_installation_id)
-    
+
     # Assertions
     assert result["request_limit"] == expected_limit
     assert result["requests_left"] == expected_limit
@@ -322,13 +364,15 @@ def test_check_subscription_limit_return_type_structure(
     # Setup mocks
     mock_get_base_request_limit.return_value = 100
     mock_count_completed_unique_requests.return_value = {"req1"}
-    
-    result = check_subscription_limit(sample_monthly_subscription, sample_installation_id)
-    
+
+    result = check_subscription_limit(
+        sample_monthly_subscription, sample_installation_id
+    )
+
     # Verify all required keys are present
     required_keys = {"can_proceed", "requests_left", "request_limit", "period_end_date"}
     assert set(result.keys()) == required_keys
-    
+
     # Verify types
     assert isinstance(result["can_proceed"], bool)
     assert isinstance(result["requests_left"], int)
@@ -346,9 +390,11 @@ def test_check_subscription_limit_with_zero_base_limit(
     # Setup mocks
     mock_get_base_request_limit.return_value = 0
     mock_count_completed_unique_requests.return_value = set()
-    
-    result = check_subscription_limit(sample_monthly_subscription, sample_installation_id)
-    
+
+    result = check_subscription_limit(
+        sample_monthly_subscription, sample_installation_id
+    )
+
     # Assertions
     assert result["can_proceed"] is False
     assert result["requests_left"] == 0
@@ -365,9 +411,11 @@ def test_check_subscription_limit_with_negative_base_limit(
     # Setup mocks
     mock_get_base_request_limit.return_value = -10
     mock_count_completed_unique_requests.return_value = set()
-    
-    result = check_subscription_limit(sample_monthly_subscription, sample_installation_id)
-    
+
+    result = check_subscription_limit(
+        sample_monthly_subscription, sample_installation_id
+    )
+
     # Assertions
     assert result["can_proceed"] is False
     assert result["requests_left"] == -10
@@ -380,14 +428,16 @@ def test_check_subscription_limit_datetime_conversion(
     sample_installation_id,
 ):
     """Test that timestamps are correctly converted to datetime objects with proper timezone."""
-    subscription = create_mock_subscription("prod_datetime_test", "month", 1, 1609459200, 1612137600)
-    
+    subscription = create_mock_subscription(
+        "prod_datetime_test", "month", 1, 1609459200, 1612137600
+    )
+
     # Setup mocks
     mock_get_base_request_limit.return_value = 100
     mock_count_completed_unique_requests.return_value = {"req1"}
-    
+
     result = check_subscription_limit(subscription, sample_installation_id)
-    
+
     # Verify datetime conversion with proper timezone
     assert result["period_end_date"] == datetime.fromtimestamp(1612137600, tz=TZ)
     assert result["period_end_date"].tzinfo == TZ
@@ -402,10 +452,14 @@ def test_check_subscription_limit_boundary_condition_exactly_zero_requests_left(
     """Test boundary condition where requests_left is exactly 0."""
     # Setup mocks - limit equals used requests
     mock_get_base_request_limit.return_value = 5
-    mock_count_completed_unique_requests.return_value = set(f"req{i}" for i in range(5))  # Exactly 5 requests used
-    
-    result = check_subscription_limit(sample_monthly_subscription, sample_installation_id)
-    
+    mock_count_completed_unique_requests.return_value = set(
+        f"req{i}" for i in range(5)
+    )  # Exactly 5 requests used
+
+    result = check_subscription_limit(
+        sample_monthly_subscription, sample_installation_id
+    )
+
     # When requests_left is 0, can_proceed should be False (> 0 condition)
     assert result["can_proceed"] is False
     assert result["requests_left"] == 0

--- a/services/supabase/test_create_user_request.py
+++ b/services/supabase/test_create_user_request.py
@@ -1,10 +1,9 @@
 """Test for create_user_request function."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 import pytest
 
 from services.supabase.create_user_request import create_user_request
-from services.supabase.usage.insert_usage import Trigger
 
 
 class TestCreateUserRequest:
@@ -32,11 +31,16 @@ class TestCreateUserRequest:
     @pytest.fixture
     def mock_dependencies(self):
         """Mock all dependencies."""
-        with patch("services.supabase.create_user_request.get_issue") as mock_get_issue, \
-             patch("services.supabase.create_user_request.insert_issue") as mock_insert_issue, \
-             patch("services.supabase.create_user_request.insert_usage") as mock_insert_usage, \
-             patch("services.supabase.create_user_request.upsert_user") as mock_upsert_user:
-            
+        with patch(
+            "services.supabase.create_user_request.get_issue"
+        ) as mock_get_issue, patch(
+            "services.supabase.create_user_request.insert_issue"
+        ) as mock_insert_issue, patch(
+            "services.supabase.create_user_request.insert_usage"
+        ) as mock_insert_usage, patch(
+            "services.supabase.create_user_request.upsert_user"
+        ) as mock_upsert_user:
+
             yield {
                 "get_issue": mock_get_issue,
                 "insert_issue": mock_insert_issue,
@@ -56,7 +60,7 @@ class TestCreateUserRequest:
 
         # Assert
         assert result == 999
-        
+
         # Verify get_issue was called with correct parameters
         mock_dependencies["get_issue"].assert_called_once_with(
             owner_type="Organization",
@@ -64,10 +68,10 @@ class TestCreateUserRequest:
             repo_name="test_repo",
             issue_number=123,
         )
-        
+
         # Verify insert_issue was NOT called since issue exists
         mock_dependencies["insert_issue"].assert_not_called()
-        
+
         # Verify insert_usage was called with correct parameters
         mock_dependencies["insert_usage"].assert_called_once_with(
             owner_id=11111,
@@ -82,7 +86,7 @@ class TestCreateUserRequest:
             trigger="issue_comment",
             pr_number=456,
         )
-        
+
         # Verify upsert_user was called with correct parameters
         mock_dependencies["upsert_user"].assert_called_once_with(
             user_id=12345,
@@ -101,7 +105,7 @@ class TestCreateUserRequest:
 
         # Assert
         assert result == 888
-        
+
         # Verify get_issue was called
         mock_dependencies["get_issue"].assert_called_once_with(
             owner_type="Organization",
@@ -109,7 +113,7 @@ class TestCreateUserRequest:
             repo_name="test_repo",
             issue_number=123,
         )
-        
+
         # Verify insert_issue WAS called since issue doesn't exist
         mock_dependencies["insert_issue"].assert_called_once_with(
             owner_id=11111,
@@ -120,19 +124,21 @@ class TestCreateUserRequest:
             issue_number=123,
             installation_id=67890,
         )
-        
+
         # Verify insert_usage was called
         mock_dependencies["insert_usage"].assert_called_once()
-        
+
         # Verify upsert_user was called
         mock_dependencies["upsert_user"].assert_called_once()
 
-    def test_create_user_request_without_pr_number(self, sample_params, mock_dependencies):
+    def test_create_user_request_without_pr_number(
+        self, sample_params, mock_dependencies
+    ):
         """Test create_user_request without pr_number."""
         # Setup
         params_without_pr = sample_params.copy()
         del params_without_pr["pr_number"]
-        
+
         mock_dependencies["get_issue"].return_value = {"id": 1}
         mock_dependencies["insert_usage"].return_value = 777
 
@@ -141,7 +147,7 @@ class TestCreateUserRequest:
 
         # Assert
         assert result == 777
-        
+
         # Verify insert_usage was called with pr_number=None
         mock_dependencies["insert_usage"].assert_called_once_with(
             owner_id=11111,
@@ -162,7 +168,7 @@ class TestCreateUserRequest:
         # Setup
         params_without_email = sample_params.copy()
         params_without_email["email"] = None
-        
+
         mock_dependencies["get_issue"].return_value = {"id": 1}
         mock_dependencies["insert_usage"].return_value = 666
 
@@ -171,7 +177,7 @@ class TestCreateUserRequest:
 
         # Assert
         assert result == 666
-        
+
         # Verify upsert_user was called with email=None
         mock_dependencies["upsert_user"].assert_called_once_with(
             user_id=12345,
@@ -179,18 +185,26 @@ class TestCreateUserRequest:
             email=None,
         )
 
-    def test_create_user_request_different_trigger_types(self, sample_params, mock_dependencies):
+    def test_create_user_request_different_trigger_types(
+        self, sample_params, mock_dependencies
+    ):
         """Test create_user_request with different trigger types."""
-        triggers = ["issue_label", "review_comment", "test_failure", "pr_checkbox", "pr_merge"]
-        
+        triggers = [
+            "issue_label",
+            "review_comment",
+            "test_failure",
+            "pr_checkbox",
+            "pr_merge",
+        ]
+
         for trigger in triggers:
             # Setup
             params = sample_params.copy()
             params["trigger"] = trigger
-            
+
             mock_dependencies["get_issue"].return_value = {"id": 1}
             mock_dependencies["insert_usage"].return_value = 555
-            
+
             # Reset mocks
             for mock in mock_dependencies.values():
                 mock.reset_mock()
@@ -200,19 +214,21 @@ class TestCreateUserRequest:
 
             # Assert
             assert result == 555
-            
+
             # Verify insert_usage was called with correct trigger
             mock_dependencies["insert_usage"].assert_called_once()
             call_args = mock_dependencies["insert_usage"].call_args[1]
             assert call_args["trigger"] == trigger
 
-    def test_create_user_request_user_owner_type(self, sample_params, mock_dependencies):
+    def test_create_user_request_user_owner_type(
+        self, sample_params, mock_dependencies
+    ):
         """Test create_user_request with User owner type."""
         # Setup
         params = sample_params.copy()
         params["owner_type"] = "User"
         params["owner_name"] = "individual_user"
-        
+
         mock_dependencies["get_issue"].return_value = None
         mock_dependencies["insert_usage"].return_value = 444
 
@@ -221,7 +237,7 @@ class TestCreateUserRequest:
 
         # Assert
         assert result == 444
-        
+
         # Verify get_issue was called with User owner_type
         mock_dependencies["get_issue"].assert_called_once_with(
             owner_type="User",
@@ -229,7 +245,7 @@ class TestCreateUserRequest:
             repo_name="test_repo",
             issue_number=123,
         )
-        
+
         # Verify insert_issue was called with User owner_type
         mock_dependencies["insert_issue"].assert_called_once_with(
             owner_id=11111,
@@ -241,14 +257,16 @@ class TestCreateUserRequest:
             installation_id=67890,
         )
 
-    def test_create_user_request_with_special_characters(self, sample_params, mock_dependencies):
+    def test_create_user_request_with_special_characters(
+        self, sample_params, mock_dependencies
+    ):
         """Test create_user_request with special characters in names."""
         # Setup
         params = sample_params.copy()
         params["owner_name"] = "org-with-dashes"
         params["repo_name"] = "repo_with_underscores"
         params["user_name"] = "user.with.dots"
-        
+
         mock_dependencies["get_issue"].return_value = {"id": 1}
         mock_dependencies["insert_usage"].return_value = 333
 
@@ -257,7 +275,7 @@ class TestCreateUserRequest:
 
         # Assert
         assert result == 333
-        
+
         # Verify all functions were called with special character names
         mock_dependencies["get_issue"].assert_called_once_with(
             owner_type="Organization",
@@ -265,19 +283,21 @@ class TestCreateUserRequest:
             repo_name="repo_with_underscores",
             issue_number=123,
         )
-        
+
         mock_dependencies["upsert_user"].assert_called_once_with(
             user_id=12345,
             user_name="user.with.dots",
             email="test@example.com",
         )
 
-    def test_create_user_request_with_zero_issue_number(self, sample_params, mock_dependencies):
+    def test_create_user_request_with_zero_issue_number(
+        self, sample_params, mock_dependencies
+    ):
         """Test create_user_request with issue number 0."""
         # Setup
         params = sample_params.copy()
         params["issue_number"] = 0
-        
+
         mock_dependencies["get_issue"].return_value = None
         mock_dependencies["insert_usage"].return_value = 222
 
@@ -286,7 +306,7 @@ class TestCreateUserRequest:
 
         # Assert
         assert result == 222
-        
+
         # Verify functions were called with issue_number=0
         mock_dependencies["get_issue"].assert_called_once_with(
             owner_type="Organization",
@@ -304,11 +324,13 @@ class TestCreateUserRequest:
             # Execute - should raise exception due to @handle_exceptions(raise_on_error=True)
             with pytest.raises(Exception) as exc_info:
                 create_user_request(**sample_params)
-            
+
             # Assert - should raise the original exception
             assert str(exc_info.value) == "Database error"
 
-    def test_create_user_request_insert_usage_returns_none(self, sample_params, mock_dependencies):
+    def test_create_user_request_insert_usage_returns_none(
+        self, sample_params, mock_dependencies
+    ):
         """Test when insert_usage returns None."""
         # Setup
         mock_dependencies["get_issue"].return_value = {"id": 1}
@@ -319,7 +341,7 @@ class TestCreateUserRequest:
 
         # Assert
         assert result is None
-        
+
         # Verify all functions were still called
         mock_dependencies["get_issue"].assert_called_once()
         mock_dependencies["insert_usage"].assert_called_once()
@@ -333,7 +355,7 @@ class TestCreateUserRequest:
         params["owner_id"] = 888888888
         params["repo_id"] = 777777777
         params["installation_id"] = 666666666
-        
+
         mock_dependencies["get_issue"].return_value = None
         mock_dependencies["insert_usage"].return_value = 111
 
@@ -342,7 +364,7 @@ class TestCreateUserRequest:
 
         # Assert
         assert result == 111
-        
+
         # Verify functions were called with large IDs
         mock_dependencies["insert_issue"].assert_called_once_with(
             owner_id=888888888,
@@ -353,25 +375,27 @@ class TestCreateUserRequest:
             issue_number=123,
             installation_id=666666666,
         )
-        
+
         mock_dependencies["upsert_user"].assert_called_once_with(
             user_id=999999999,
             user_name="test_user",
             email="test@example.com",
         )
 
-    def test_create_user_request_different_sources(self, sample_params, mock_dependencies):
+    def test_create_user_request_different_sources(
+        self, sample_params, mock_dependencies
+    ):
         """Test create_user_request with different source values."""
         sources = ["github", "webhook", "api", "manual"]
-        
+
         for source in sources:
             # Setup
             params = sample_params.copy()
             params["source"] = source
-            
+
             mock_dependencies["get_issue"].return_value = {"id": 1}
             mock_dependencies["insert_usage"].return_value = 100
-            
+
             # Reset mocks
             for mock in mock_dependencies.values():
                 mock.reset_mock()
@@ -381,21 +405,23 @@ class TestCreateUserRequest:
 
             # Assert
             assert result == 100
-            
+
             # Verify insert_usage was called with correct source
             mock_dependencies["insert_usage"].assert_called_once()
             call_args = mock_dependencies["insert_usage"].call_args[1]
             assert call_args["source"] == source
 
-    def test_create_user_request_function_call_order(self, sample_params, mock_dependencies):
+    def test_create_user_request_function_call_order(
+        self, sample_params, mock_dependencies
+    ):
         """Test that functions are called in the correct order."""
         # Setup
         mock_dependencies["get_issue"].return_value = None
         mock_dependencies["insert_usage"].return_value = 123
-        
+
         # Execute
         create_user_request(**sample_params)
-        
+
         # Verify call order by checking that get_issue is called before insert_issue
         # and insert_usage is called after both
         assert mock_dependencies["get_issue"].call_count == 1

--- a/services/webhook/test_process_repositories.py
+++ b/services/webhook/test_process_repositories.py
@@ -1,8 +1,7 @@
 """Unit tests for process_repositories.py"""
 
 # Standard imports
-import tempfile
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 # Third-party imports
 import pytest
@@ -424,7 +423,12 @@ class TestProcessRepositories:
     ):
         """Test processing when stats return zero values."""
         # Setup
-        zero_stats = {"file_count": 0, "blank_lines": 0, "comment_lines": 0, "code_lines": 0}
+        zero_stats = {
+            "file_count": 0,
+            "blank_lines": 0,
+            "comment_lines": 0,
+            "code_lines": 0,
+        }
         mock_get_repository_stats.return_value = zero_stats
 
         # Execute
@@ -622,7 +626,7 @@ class TestProcessRepositories:
             "Cloning repository test-repo-2 into /tmp/test_repo_12345",
             f"Repository test-repo-2 stats: {sample_stats}",
         ]
-        
+
         # Check that all expected print calls were made
         actual_calls = [call.args[0] for call in mock_print.call_args_list]
         for expected_call in expected_calls:
@@ -644,13 +648,13 @@ class TestProcessRepositories:
             {"id": 222, "name": "fail-repo"},
             {"id": 333, "name": "another-success-repo"},
         ]
-        
+
         # Make clone fail for the second repository only
         def clone_side_effect(owner, repo, token, target_dir):
             if repo == "fail-repo":
                 raise Exception("Clone failed for fail-repo")
             return None
-        
+
         mock_clone_repo.side_effect = clone_side_effect
         mock_get_repository_stats.return_value = sample_stats
 
@@ -666,8 +670,10 @@ class TestProcessRepositories:
 
         # Verify processing stops at the first failure due to @handle_exceptions decorator
         # First repository succeeds, second fails and causes early exit
-        assert mock_tempfile.call_count == 2  # First repo succeeds, second repo starts but fails
-        assert mock_shutil.call_count == 2    # Cleanup happens for both
+        assert (
+            mock_tempfile.call_count == 2
+        )  # First repo succeeds, second repo starts but fails
+        assert mock_shutil.call_count == 2  # Cleanup happens for both
         assert mock_clone_repo.call_count == 2  # Both repos attempted
         assert mock_get_repository_stats.call_count == 1  # Only first repo gets stats
         assert mock_upsert_repository.call_count == 1  # Only first repo gets upserted

--- a/services/webhook/utils/test_create_system_message.py
+++ b/services/webhook/utils/test_create_system_message.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch, MagicMock
+
 """
 Unit tests for services/webhook/utils/create_system_message.py
 
@@ -87,7 +88,9 @@ def mock_read_xml_file():
 @pytest.fixture
 def mock_get_trigger_prompt():
     """Mock the get_trigger_prompt function."""
-    with patch("services.webhook.utils.create_system_message.get_trigger_prompt") as mock:
+    with patch(
+        "services.webhook.utils.create_system_message.get_trigger_prompt"
+    ) as mock:
         yield mock
 
 
@@ -107,8 +110,12 @@ class TestCreateSystemMessage:
         """Test creating system message with minimal parameters."""
         # Arrange
         mock_read_xml_file.return_value = "<test_rules>Common test rules</test_rules>"
-        mock_get_trigger_prompt.return_value = "<trigger_instruction>Issue trigger</trigger_instruction>"
-        mock_get_mode_prompt.return_value = "<mode_instruction>Comment mode</mode_instruction>"
+        mock_get_trigger_prompt.return_value = (
+            "<trigger_instruction>Issue trigger</trigger_instruction>"
+        )
+        mock_get_mode_prompt.return_value = (
+            "<mode_instruction>Comment mode</mode_instruction>"
+        )
 
         # Act
         result = create_system_message("issue_comment", "comment")
@@ -120,7 +127,9 @@ class TestCreateSystemMessage:
             "<mode_instruction>Comment mode</mode_instruction>"
         )
         assert result == expected_content
-        mock_read_xml_file.assert_called_once_with("utils/prompts/common_test_rules.xml")
+        mock_read_xml_file.assert_called_once_with(
+            "utils/prompts/common_test_rules.xml"
+        )
         mock_get_trigger_prompt.assert_called_once_with("issue_comment")
         mock_get_mode_prompt.assert_called_once_with("comment")
 
@@ -347,10 +356,7 @@ class TestCreateSystemMessage:
         result = create_system_message("issue_comment", "comment")
 
         # Assert
-        expected_content = (
-            "<test_rules>Rules</test_rules>\n\n"
-            "<mode>Mode</mode>"
-        )
+        expected_content = "<test_rules>Rules</test_rules>\n\n" "<mode>Mode</mode>"
         assert result == expected_content
 
     def test_mode_prompt_returns_none(
@@ -367,8 +373,7 @@ class TestCreateSystemMessage:
 
         # Assert
         expected_content = (
-            "<test_rules>Rules</test_rules>\n\n"
-            "<trigger>Trigger</trigger>"
+            "<test_rules>Rules</test_rules>\n\n" "<trigger>Trigger</trigger>"
         )
         assert result == expected_content
 
@@ -465,8 +470,14 @@ class TestCreateSystemMessage:
         assert parts[0] == "COMMON_RULES"
         assert parts[1] == "TRIGGER_CONTENT"
         assert parts[2] == "MODE_CONTENT"
-        assert parts[3] == "<structured_repository_rules>\nrule: value\n</structured_repository_rules>"
-        assert parts[4] == "<freeform_repository_rules>\nFree form rule\n</freeform_repository_rules>"
+        assert (
+            parts[3]
+            == "<structured_repository_rules>\nrule: value\n</structured_repository_rules>"
+        )
+        assert (
+            parts[4]
+            == "<freeform_repository_rules>\nFree form rule\n</freeform_repository_rules>"
+        )
 
     def test_empty_content_parts_returns_empty_string(
         self, mock_read_xml_file, mock_get_trigger_prompt, mock_get_mode_prompt
@@ -487,7 +498,7 @@ class TestCreateSystemMessage:
         """Test the function with actual dependencies (integration test)."""
         # This test uses real dependencies to ensure the function works end-to-end
         # We'll use a simple case to avoid file system dependencies
-        
+
         # Arrange
         structured_rules = {"testRule": "testValue"}
         repo_rules = "Test repo rule"

--- a/services/webhook/utils/test_create_test_selection_comment.py
+++ b/services/webhook/utils/test_create_test_selection_comment.py
@@ -261,10 +261,10 @@ def test_create_test_selection_comment_with_mixed_checked_states():
 def test_create_test_selection_comment_structure_consistency():
     """Test that the comment structure is consistent regardless of checklist content."""
     branch_name = "consistency-test"
-    
+
     # Basic structure verification for empty checklist
     result = create_test_selection_comment([], branch_name)
-    
+
     # Verify consistent structure elements are always present
     assert TEST_SELECTION_COMMENT_IDENTIFIER in result
     assert "Select files to manage tests for (create, update, or remove):" in result
@@ -272,9 +272,9 @@ def test_create_test_selection_comment_structure_consistency():
     assert "- [ ] Yes, manage tests" in result
     assert PRODUCT_NAME in result
     assert SETTINGS_LINKS in result
-    
+
     # Verify the structure is consistent
-    lines = result.split('\n')
+    lines = result.split("\n")
     assert lines[0] == TEST_SELECTION_COMMENT_IDENTIFIER
     assert lines[1] == ""
     assert lines[2] == "Select files to manage tests for (create, update, or remove):"
@@ -284,20 +284,22 @@ def test_create_test_selection_comment_structure_consistency():
 def test_create_test_selection_comment_structure_consistency_complete():
     """Test that the comment structure is consistent regardless of checklist content."""
     branch_name = "consistency-test"
-    
+
     # Test with different checklist sizes
     for size in [0, 1, 3, 5]:
         checklist: list[FileChecklistItem] = []
         for i in range(size):
-            checklist.append({
-                "path": f"src/file{i}.py",
-                "checked": i % 2 == 0,  # Alternate checked state
-                "coverage_info": f" (Coverage: {i * 20}%)" if i > 0 else "",
-                "status": "modified",
-            })
-        
+            checklist.append(
+                {
+                    "path": f"src/file{i}.py",
+                    "checked": i % 2 == 0,  # Alternate checked state
+                    "coverage_info": f" (Coverage: {i * 20}%)" if i > 0 else "",
+                    "status": "modified",
+                }
+            )
+
         result = create_test_selection_comment(checklist, branch_name)
-        
+
         # Verify consistent structure elements are always present
         assert TEST_SELECTION_COMMENT_IDENTIFIER in result
         assert "Select files to manage tests for (create, update, or remove):" in result
@@ -305,9 +307,9 @@ def test_create_test_selection_comment_structure_consistency_complete():
         assert "- [ ] Yes, manage tests" in result
         assert PRODUCT_NAME in result
         assert SETTINGS_LINKS in result
-        
+
         # Verify the number of file items matches the checklist size
-        file_lines = [line for line in result.split('\n') if line.startswith('- [')]
+        file_lines = [line for line in result.split("\n") if line.startswith("- [")]
         # Subtract 1 for the "Yes, manage tests" line
         assert len(file_lines) - 1 == size
 
@@ -429,8 +431,8 @@ def test_create_test_selection_comment_line_endings():
     result = create_test_selection_comment(checklist, branch_name)
 
     # Verify consistent line endings (should use \n)
-    assert '\r\n' not in result  # No Windows line endings
-    assert result.count('\n') > 0  # Has Unix line endings
+    assert "\r\n" not in result  # No Windows line endings
+    assert result.count("\n") > 0  # Has Unix line endings
 
 
 def test_create_test_selection_comment_with_edge_case_coverage():
@@ -462,15 +464,19 @@ def test_create_test_selection_comment_with_large_checklist():
     """Test creating a comment with a large number of checklist items."""
     branch_name = "large-checklist"
     checklist: list[FileChecklistItem] = []
-    
+
     # Create a large checklist with 20 items
     for i in range(20):
-        checklist.append({
-            "path": f"src/file_{i:02d}.py",
-            "checked": i % 3 == 0,  # Every third item checked
-            "coverage_info": f" (Coverage: {i * 5}%)" if i < 20 else " (Coverage: 100%)",
-            "status": "modified" if i % 2 == 0 else "added",
-        })
+        checklist.append(
+            {
+                "path": f"src/file_{i:02d}.py",
+                "checked": i % 3 == 0,  # Every third item checked
+                "coverage_info": (
+                    f" (Coverage: {i * 5}%)" if i < 20 else " (Coverage: 100%)"
+                ),
+                "status": "modified" if i % 2 == 0 else "added",
+            }
+        )
 
     result = create_test_selection_comment(checklist, branch_name)
 

--- a/utils/files/test_should_test_file.py
+++ b/utils/files/test_should_test_file.py
@@ -268,11 +268,13 @@ class DataProcessor:
         result = should_test_file(None, "some content")
         assert result is False
 
-        # Test with None content - should handle gracefully  
+        # Test with None content - should handle gracefully
         result = should_test_file("test.py", None)
         assert result is False
 
-    def test_should_test_file_with_very_long_content(self, mock_evaluate_condition, sample_file_path):
+    def test_should_test_file_with_very_long_content(
+        self, mock_evaluate_condition, sample_file_path
+    ):
         """Test function behavior with very long content."""
         # Create a very long content string
         long_content = "def function():\n    pass\n" * 1000
@@ -288,7 +290,9 @@ class DataProcessor:
         content_arg = call_args[1]["content"]
         assert long_content in content_arg
 
-    def test_should_test_file_system_prompt_immutable(self, mock_evaluate_condition, sample_file_path, sample_code_content):
+    def test_should_test_file_system_prompt_immutable(
+        self, mock_evaluate_condition, sample_file_path, sample_code_content
+    ):
         """Test that the system prompt remains consistent across calls."""
         mock_evaluate_condition.return_value = True
 
@@ -303,10 +307,12 @@ class DataProcessor:
         # System prompt should be identical
         assert first_call_prompt == second_call_prompt
 
-    def test_should_test_file_content_formatting_consistency(self, mock_evaluate_condition):
+    def test_should_test_file_content_formatting_consistency(
+        self, mock_evaluate_condition
+    ):
         """Test that content formatting is consistent."""
         mock_evaluate_condition.return_value = True
-        
+
         test_cases = [
             ("file.py", "content"),
             ("path/to/file.js", "function test() {}"),
@@ -317,16 +323,18 @@ class DataProcessor:
         for file_path, content in test_cases:
             mock_evaluate_condition.reset_mock()
             should_test_file(file_path, content)
-            
+
             call_args = mock_evaluate_condition.call_args
             content_arg = call_args[1]["content"]
-            
+
             # Verify consistent formatting pattern
             expected_start = f"File path: {file_path}\n\nContent:\n"
             assert content_arg.startswith(expected_start)
             assert content_arg == f"{expected_start}{content}"
 
-    def test_should_test_file_return_type_consistency(self, mock_evaluate_condition, sample_file_path, sample_code_content):
+    def test_should_test_file_return_type_consistency(
+        self, mock_evaluate_condition, sample_file_path, sample_code_content
+    ):
         """Test that function always returns a boolean."""
         # Test with True return value
         mock_evaluate_condition.return_value = True
@@ -346,27 +354,31 @@ class DataProcessor:
         assert isinstance(result, bool)
         assert result is False
 
-    def test_should_test_file_integration_with_handle_exceptions_decorator(self, mock_evaluate_condition, sample_file_path, sample_code_content):
+    def test_should_test_file_integration_with_handle_exceptions_decorator(
+        self, mock_evaluate_condition, sample_file_path, sample_code_content
+    ):
         """Integration test to verify the decorator is properly applied."""
         # Test that the function has the decorator applied
         from utils.files.should_test_file import should_test_file as original_function
-        
+
         # Check that the function is wrapped (has __wrapped__ attribute)
-        assert hasattr(original_function, '__wrapped__')
-        
+        assert hasattr(original_function, "__wrapped__")
+
         # Test that exceptions are handled according to decorator configuration
         mock_evaluate_condition.side_effect = Exception("Test exception")
-        
+
         result = should_test_file(sample_file_path, sample_code_content)
-        
+
         # Should return False (default_return_value) and not raise
         assert result is False
 
-    def test_should_test_file_with_realistic_code_samples(self, mock_evaluate_condition):
+    def test_should_test_file_with_realistic_code_samples(
+        self, mock_evaluate_condition
+    ):
         """Test with realistic code samples that should/shouldn't be tested."""
-        
+
         # Code that should be tested (complex logic)
-        complex_code = '''
+        complex_code = """
 class UserManager:
     def __init__(self, db_connection):
         self.db = db_connection
@@ -383,14 +395,14 @@ class UserManager:
         
     def user_exists(self, username):
         return self.db.query_user(username) is not None
-'''
-        
+"""
+
         # Simple code that might not need tests
-        simple_code = '''
+        simple_code = """
 from app import main
 if __name__ == "__main__":
     main()
-'''
+"""
 
         # Test complex code
         mock_evaluate_condition.return_value = True
@@ -402,62 +414,70 @@ if __name__ == "__main__":
         result = should_test_file("main.py", simple_code)
         assert result is False
 
-    def test_should_test_file_mock_call_count_verification(self, mock_evaluate_condition, sample_file_path, sample_code_content):
+    def test_should_test_file_mock_call_count_verification(
+        self, mock_evaluate_condition, sample_file_path, sample_code_content
+    ):
         """Test that evaluate_condition is called exactly once per function call."""
         mock_evaluate_condition.return_value = True
-        
+
         # Single call
         should_test_file(sample_file_path, sample_code_content)
         assert mock_evaluate_condition.call_count == 1
-        
+
         # Multiple calls should each call evaluate_condition once
         should_test_file(sample_file_path, sample_code_content)
         assert mock_evaluate_condition.call_count == 2
-        
+
         should_test_file("another_file.py", "different content")
         assert mock_evaluate_condition.call_count == 3
 
-    def test_should_test_file_with_unicode_file_paths(self, mock_evaluate_condition, sample_code_content):
+    def test_should_test_file_with_unicode_file_paths(
+        self, mock_evaluate_condition, sample_code_content
+    ):
         """Test function behavior with unicode characters in file paths."""
         unicode_paths = [
             "测试文件.py",
-            "файл.py", 
+            "файл.py",
             "ファイル.py",
             "archivo_español.py",
-            "tệp_tiếng_việt.py"
+            "tệp_tiếng_việt.py",
         ]
-        
+
         mock_evaluate_condition.return_value = True
-        
+
         for file_path in unicode_paths:
             mock_evaluate_condition.reset_mock()
             result = should_test_file(file_path, sample_code_content)
-            
+
             assert result is True
             mock_evaluate_condition.assert_called_once()
-            
+
             # Verify unicode file path is preserved
             call_args = mock_evaluate_condition.call_args
             content_arg = call_args[1]["content"]
             assert f"File path: {file_path}" in content_arg
 
-    def test_should_test_file_thread_safety_simulation(self, mock_evaluate_condition, sample_file_path, sample_code_content):
+    def test_should_test_file_thread_safety_simulation(
+        self, mock_evaluate_condition, sample_file_path, sample_code_content
+    ):
         """Test that function calls don't interfere with each other (simulating thread safety)."""
         # Simulate concurrent calls with different return values
         call_results = []
-        
+
         for i in range(5):
             mock_evaluate_condition.reset_mock()
             mock_evaluate_condition.return_value = i % 2 == 0  # Alternate True/False
-            
+
             result = should_test_file(f"file_{i}.py", f"content_{i}")
             call_results.append(result)
-        
+
         # Verify results match expected pattern
         expected_results = [True, False, True, False, True]
         assert call_results == expected_results
 
-    def test_should_test_file_comprehensive_error_scenarios(self, mock_evaluate_condition, sample_file_path, sample_code_content):
+    def test_should_test_file_comprehensive_error_scenarios(
+        self, mock_evaluate_condition, sample_file_path, sample_code_content
+    ):
         """Test various error scenarios to ensure robust error handling."""
         error_scenarios = [
             ValueError("Invalid input"),
@@ -468,11 +488,11 @@ if __name__ == "__main__":
             ConnectionError("Network error"),
             TimeoutError("Request timeout"),
         ]
-        
+
         for error in error_scenarios:
             mock_evaluate_condition.reset_mock()
             mock_evaluate_condition.side_effect = error
-            
+
             # Should handle all errors gracefully and return False
             result = should_test_file(sample_file_path, sample_code_content)
             assert result is False
@@ -482,10 +502,10 @@ if __name__ == "__main__":
         """Test that the function has the correct signature."""
         import inspect
         from utils.files.should_test_file import should_test_file
-        
+
         sig = inspect.signature(should_test_file)
         params = list(sig.parameters.keys())
-        
+
         # Should have exactly 2 parameters
         assert len(params) == 2
         assert "file_path" in params

--- a/utils/prompts/diff.py
+++ b/utils/prompts/diff.py
@@ -56,13 +56,6 @@ A UNIFIED DIFF FORMAT with ZERO CONTEXT LINES like command `diff -U0` or `diff -
 + added line 3
 ```
 
-3. For deleted Files
-
-```diff(unified=0)
---- path/to/delete
-+++ /dev/null
-```
-
 ## Hunk header format rules
 
 - A hunk represents where changes occur in a file.


### PR DESCRIPTION
- Remove deletion diff format from DIFF_DESCRIPTION prompt
- Add safety check in apply_diff_to_file to reject deletion diffs
- Direct users to use delete_file tool for file deletions
- Add comprehensive tests for deletion diff rejection

This resolves 422 HTTP errors when agents try to delete files using apply_diff_to_file instead of the dedicated delete_file tool.

🤖 Generated with [Claude Code](https://claude.ai/code)