### PR TITLE
Prevent EventBridge retries for invalid installations in schedule_han…

### DIFF
--- a/services/webhook/schedule_handler.py
+++ b/services/webhook/schedule_handler.py
@@ -71,7 +71,9 @@ def schedule_handler(event: EventBridgeSchedulerEvent):
         # Delete scheduler since installation is invalid
         schedule_name = f"gitauto-repo-{owner_id}-{repo_id}"
         delete_scheduler(schedule_name)
-        raise ValueError(f"Token is None for installation_id: {installation_id}")
+        msg = f"Installation {installation_id} no longer exists. Cleaned up scheduler."
+        logging.info(msg)
+        return {"status": "skipped", "message": msg}
 
     # Get repository settings - check if trigger_on_schedule is enabled
     repo_settings = get_repository(repo_id=repo_id)

--- a/services/webhook/test_schedule_handler.py
+++ b/services/webhook/test_schedule_handler.py
@@ -42,13 +42,17 @@ class TestScheduleHandler:
 
     @patch("services.webhook.schedule_handler.get_installation_access_token")
     def test_schedule_handler_no_token(self, mock_get_token, mock_event):
-        """Test that schedule_handler raises ValueError when token is None."""
+        """Test that schedule_handler returns skipped status when token is None."""
         # Setup
         mock_get_token.return_value = None
 
-        # Execute and verify
-        with pytest.raises(ValueError, match="Token is None for installation_id"):
-            schedule_handler(mock_event)
+        # Execute
+        result = schedule_handler(mock_event)
+
+        # Verify
+        assert result["status"] == "skipped"
+        assert "Installation" in result["message"]
+        assert "no longer exists" in result["message"]
 
     @patch("services.webhook.schedule_handler.get_installation_access_token")
     @patch("services.webhook.schedule_handler.get_repository")


### PR DESCRIPTION
…dler

When installation_id doesn't exist (returns None token), schedule_handler now returns "skipped" status instead of raising ValueError. This prevents EventBridge from retrying the failed invocation, eliminating retry-based error noise in Sentry.

Changes:
- Modified schedule_handler to return {"status": "skipped", "message": "..."} for invalid installations
- Updated test to verify skipped return instead of ValueError exception
- Eliminates the root cause of the AGENT-11G ghost scheduler scenario

🤖 Generated with [Claude Code](https://claude.ai/code)