### PR TITLE
Handle suspended/deleted installations gracefully in get_installation…

### DIFF
--- a/services/github/commits/test_get_latest_remote_commit_sha.py
+++ b/services/github/commits/test_get_latest_remote_commit_sha.py
@@ -45,7 +45,9 @@ def test_get_latest_remote_commit_sha_success(base_args, mock_successful_respons
         mock_headers.return_value = {"Authorization": "Bearer test_token"}
 
         # Call function
-        result = get_latest_remote_commit_sha("https://github.com/owner/repo.git", base_args)
+        result = get_latest_remote_commit_sha(
+            "https://github.com/owner/repo.git", base_args
+        )
 
         # Verify API call
         mock_get.assert_called_once_with(
@@ -75,10 +77,15 @@ def test_get_latest_remote_commit_sha_headers_creation(
 
         # Create base args with custom token
         custom_base_args = create_test_base_args(
-            owner="test-owner", repo="test-repo", token="custom_token_123", base_branch="main"
+            owner="test-owner",
+            repo="test-repo",
+            token="custom_token_123",
+            base_branch="main",
         )
 
-        get_latest_remote_commit_sha("https://github.com/owner/repo.git", custom_base_args)
+        get_latest_remote_commit_sha(
+            "https://github.com/owner/repo.git", custom_base_args
+        )
 
         # Verify headers creation with correct token
         mock_headers.assert_called_once_with(token="custom_token_123")
@@ -100,9 +107,14 @@ def test_get_latest_remote_commit_sha_url_construction(
 
         # Test with different parameters
         custom_base_args = create_test_base_args(
-            owner="test-owner", repo="test-repo", token="test_token", base_branch="develop"
+            owner="test-owner",
+            repo="test-repo",
+            token="test_token",
+            base_branch="develop",
         )
-        get_latest_remote_commit_sha("https://github.com/owner/repo.git", custom_base_args)
+        get_latest_remote_commit_sha(
+            "https://github.com/owner/repo.git", custom_base_args
+        )
 
         # Verify URL construction
         mock_get.assert_called_once_with(
@@ -128,9 +140,14 @@ def test_get_latest_remote_commit_sha_with_special_characters(
 
         # Test with special characters
         special_base_args = create_test_base_args(
-            owner="owner-name", repo="repo_name.test", token="token_123", base_branch="feature/test-branch"
+            owner="owner-name",
+            repo="repo_name.test",
+            token="token_123",
+            base_branch="feature/test-branch",
         )
-        get_latest_remote_commit_sha("https://github.com/owner/repo.git", special_base_args)
+        get_latest_remote_commit_sha(
+            "https://github.com/owner/repo.git", special_base_args
+        )
 
         # Verify URL construction handles the names correctly
         mock_get.assert_called_once_with(
@@ -140,7 +157,9 @@ def test_get_latest_remote_commit_sha_with_special_characters(
         )
 
 
-def test_get_latest_remote_commit_sha_timeout_parameter(base_args, mock_successful_response):
+def test_get_latest_remote_commit_sha_timeout_parameter(
+    base_args, mock_successful_response
+):
     """Test that the timeout parameter is correctly used."""
     with patch(
         "services.github.commits.get_latest_remote_commit_sha.requests.get"
@@ -161,7 +180,9 @@ def test_get_latest_remote_commit_sha_timeout_parameter(base_args, mock_successf
         assert call_args.kwargs["timeout"] == 60
 
 
-def test_get_latest_remote_commit_sha_custom_api_url(base_args, mock_successful_response):
+def test_get_latest_remote_commit_sha_custom_api_url(
+    base_args, mock_successful_response
+):
     """Test with a custom GitHub API URL."""
     with patch(
         "services.github.commits.get_latest_remote_commit_sha.requests.get"
@@ -206,11 +227,15 @@ def test_get_latest_remote_commit_sha_different_commit_shas(base_args):
             mock_get.return_value = mock_response
             mock_headers.return_value = {"Authorization": "Bearer test_token"}
 
-            result = get_latest_remote_commit_sha("https://github.com/owner/repo.git", base_args)
+            result = get_latest_remote_commit_sha(
+                "https://github.com/owner/repo.git", base_args
+            )
             assert result == commit_sha
 
 
-def test_get_latest_remote_commit_sha_empty_repository_409_error(base_args, mock_empty_repo_response):
+def test_get_latest_remote_commit_sha_empty_repository_409_error(
+    base_args, mock_empty_repo_response
+):
     """Test handling of 409 error for empty repository."""
     with patch(
         "services.github.commits.get_latest_remote_commit_sha.requests.get"
@@ -225,17 +250,19 @@ def test_get_latest_remote_commit_sha_empty_repository_409_error(base_args, mock
         mock_response_409 = MagicMock()
         mock_response_409.status_code = 409
         mock_response_409.json.return_value = mock_empty_repo_response
-        
+
         mock_response_success = MagicMock()
-        mock_response_success.json.return_value = {"object": {"sha": "new_commit_sha_123"}}
-        
+        mock_response_success.json.return_value = {
+            "object": {"sha": "new_commit_sha_123"}
+        }
+
         http_error = requests.exceptions.HTTPError("409 Client Error")
         http_error.response = mock_response_409
-        
+
         # First call raises 409, second call succeeds
         mock_get.side_effect = [
             MagicMock(raise_for_status=MagicMock(side_effect=http_error)),
-            mock_response_success
+            mock_response_success,
         ]
         mock_headers.return_value = {"Authorization": "Bearer test_token"}
 
@@ -247,13 +274,15 @@ def test_get_latest_remote_commit_sha_empty_repository_409_error(base_args, mock
         mock_initialize.assert_called_once_with(
             repo_path=expected_repo_path, remote_url=clone_url, token=base_args["token"]
         )
-        
+
         # Verify logging message
-        mock_logging.assert_called_once_with("Repository is empty. So, creating an initial empty commit.")
-        
+        mock_logging.assert_called_once_with(
+            "Repository is empty. So, creating an initial empty commit."
+        )
+
         # Verify function was called twice (recursive call)
         assert mock_get.call_count == 2
-        
+
         # Verify result from second call
         assert result == "new_commit_sha_123"
 
@@ -348,14 +377,20 @@ def test_get_latest_remote_commit_sha_network_error(base_args):
         # Call function - should raise RuntimeError due to Exception handling
         with pytest.raises(RuntimeError) as exc_info:
             get_latest_remote_commit_sha("https://github.com/owner/repo.git", base_args)
-        
+
         # Verify error message
-        assert "Error: Could not get the latest commit SHA in get_latest_remote_commit_sha" in str(exc_info.value)
-        
+        assert (
+            "Error: Could not get the latest commit SHA in get_latest_remote_commit_sha"
+            in str(exc_info.value)
+        )
+
         # Verify update_comment was called
         mock_update_comment.assert_called_once()
         call_args = mock_update_comment.call_args
-        assert "get_latest_remote_commit_sha encountered an error" in call_args.kwargs["body"]
+        assert (
+            "get_latest_remote_commit_sha encountered an error"
+            in call_args.kwargs["body"]
+        )
         assert call_args.kwargs["base_args"] == base_args
 
 
@@ -375,10 +410,13 @@ def test_get_latest_remote_commit_sha_timeout_error(base_args):
         # Call function - should raise RuntimeError due to Exception handling
         with pytest.raises(RuntimeError) as exc_info:
             get_latest_remote_commit_sha("https://github.com/owner/repo.git", base_args)
-        
+
         # Verify error message
-        assert "Error: Could not get the latest commit SHA in get_latest_remote_commit_sha" in str(exc_info.value)
-        
+        assert (
+            "Error: Could not get the latest commit SHA in get_latest_remote_commit_sha"
+            in str(exc_info.value)
+        )
+
         # Verify update_comment was called
         mock_update_comment.assert_called_once()
 
@@ -401,10 +439,13 @@ def test_get_latest_remote_commit_sha_json_decode_error(base_args):
         # Call function - should raise RuntimeError due to Exception handling
         with pytest.raises(RuntimeError) as exc_info:
             get_latest_remote_commit_sha("https://github.com/owner/repo.git", base_args)
-        
+
         # Verify error message
-        assert "Error: Could not get the latest commit SHA in get_latest_remote_commit_sha" in str(exc_info.value)
-        
+        assert (
+            "Error: Could not get the latest commit SHA in get_latest_remote_commit_sha"
+            in str(exc_info.value)
+        )
+
         # Verify update_comment was called
         mock_update_comment.assert_called_once()
 
@@ -430,10 +471,13 @@ def test_get_latest_remote_commit_sha_key_error_missing_object(base_args):
         # Call function - should raise RuntimeError due to Exception handling
         with pytest.raises(RuntimeError) as exc_info:
             get_latest_remote_commit_sha("https://github.com/owner/repo.git", base_args)
-        
+
         # Verify error message
-        assert "Error: Could not get the latest commit SHA in get_latest_remote_commit_sha" in str(exc_info.value)
-        
+        assert (
+            "Error: Could not get the latest commit SHA in get_latest_remote_commit_sha"
+            in str(exc_info.value)
+        )
+
         # Verify update_comment was called
         mock_update_comment.assert_called_once()
 
@@ -453,7 +497,7 @@ def test_get_latest_remote_commit_sha_key_error_missing_sha(base_args):
             "object": {
                 # Missing "sha" key
                 "type": "commit",
-                "url": "https://api.github.com/repos/owner/repo/git/commits/abc123"
+                "url": "https://api.github.com/repos/owner/repo/git/commits/abc123",
             }
         }
         mock_get.return_value = mock_response
@@ -462,10 +506,13 @@ def test_get_latest_remote_commit_sha_key_error_missing_sha(base_args):
         # Call function - should raise RuntimeError due to Exception handling
         with pytest.raises(RuntimeError) as exc_info:
             get_latest_remote_commit_sha("https://github.com/owner/repo.git", base_args)
-        
+
         # Verify error message
-        assert "Error: Could not get the latest commit SHA in get_latest_remote_commit_sha" in str(exc_info.value)
-        
+        assert (
+            "Error: Could not get the latest commit SHA in get_latest_remote_commit_sha"
+            in str(exc_info.value)
+        )
+
         # Verify update_comment was called
         mock_update_comment.assert_called_once()
 
@@ -499,13 +546,15 @@ def test_get_latest_remote_commit_sha_various_branch_names(
 
         # Create base args with custom branch
         custom_base_args = create_test_base_args(
-            owner=base_args["owner"], 
-            repo=base_args["repo"], 
-            token=base_args["token"], 
-            base_branch=branch_name
+            owner=base_args["owner"],
+            repo=base_args["repo"],
+            token=base_args["token"],
+            base_branch=branch_name,
         )
-        
-        result = get_latest_remote_commit_sha("https://github.com/owner/repo.git", custom_base_args)
+
+        result = get_latest_remote_commit_sha(
+            "https://github.com/owner/repo.git", custom_base_args
+        )
 
         # Verify the branch name is correctly used in the URL
         expected_url = f"https://api.github.com/repos/{custom_base_args['owner']}/{custom_base_args['repo']}/git/ref/heads/{branch_name}"
@@ -539,7 +588,7 @@ def test_get_latest_remote_commit_sha_clone_url_parameter_not_used_in_api_call(
             "git@github.com:owner/repo.git",
             "https://github.com/different-owner/different-repo.git",
         ]
-        
+
         for clone_url in clone_urls:
             mock_get.reset_mock()
             get_latest_remote_commit_sha(clone_url, base_args)
@@ -566,17 +615,19 @@ def test_get_latest_remote_commit_sha_empty_repo_recursive_call_success(base_arg
         mock_response_409 = MagicMock()
         mock_response_409.status_code = 409
         mock_response_409.json.return_value = {"message": "Git Repository is empty."}
-        
+
         mock_response_success = MagicMock()
-        mock_response_success.json.return_value = {"object": {"sha": "initialized_commit_sha"}}
-        
+        mock_response_success.json.return_value = {
+            "object": {"sha": "initialized_commit_sha"}
+        }
+
         http_error = requests.exceptions.HTTPError("409 Client Error")
         http_error.response = mock_response_409
-        
+
         # First call raises 409, second call succeeds
         mock_get.side_effect = [
             MagicMock(raise_for_status=MagicMock(side_effect=http_error)),
-            mock_response_success
+            mock_response_success,
         ]
         mock_headers.return_value = {"Authorization": "Bearer test_token"}
 
@@ -585,10 +636,10 @@ def test_get_latest_remote_commit_sha_empty_repo_recursive_call_success(base_arg
 
         # Verify both API calls were made
         assert mock_get.call_count == 2
-        
+
         # Verify result from successful second call
         assert result == "initialized_commit_sha"
-        
+
         # Verify initialize_repo was called with correct parameters
         expected_repo_path = f"/tmp/repo/{base_args['owner']}-{base_args['repo']}"
         mock_initialize.assert_called_once_with(
@@ -611,31 +662,34 @@ def test_get_latest_remote_commit_sha_empty_repo_recursive_call_fails(base_args)
         mock_response_409 = MagicMock()
         mock_response_409.status_code = 409
         mock_response_409.json.return_value = {"message": "Git Repository is empty."}
-        
+
         http_error = requests.exceptions.HTTPError("409 Client Error")
         http_error.response = mock_response_409
-        
+
         # First call raises 409, second call raises network error
         mock_get.side_effect = [
             MagicMock(raise_for_status=MagicMock(side_effect=http_error)),
-            requests.exceptions.ConnectionError("Network error on retry")
+            requests.exceptions.ConnectionError("Network error on retry"),
         ]
         mock_headers.return_value = {"Authorization": "Bearer test_token"}
 
         clone_url = "https://github.com/owner/repo.git"
-        
+
         # Call function - should raise RuntimeError due to Exception handling in recursive call
         with pytest.raises(RuntimeError) as exc_info:
             get_latest_remote_commit_sha(clone_url, base_args)
-        
+
         # Verify error message
-        assert "Error: Could not get the latest commit SHA in get_latest_remote_commit_sha" in str(exc_info.value)
-        
+        assert (
+            "Error: Could not get the latest commit SHA in get_latest_remote_commit_sha"
+            in str(exc_info.value)
+        )
+
         # Verify both API calls were attempted
         assert mock_get.call_count == 2
-        
+
         # Verify initialize_repo was called
         mock_initialize.assert_called_once()
-        
+
         # Verify update_comment was called for the recursive call error
         mock_update_comment.assert_called_once()

--- a/services/github/token/get_installation_token.py
+++ b/services/github/token/get_installation_token.py
@@ -25,8 +25,11 @@ def get_installation_access_token(installation_id: int):
         if (
             err.response.status_code == 403
             and "This installation has been suspended" in err.response.text
-        ):
+        ) or err.response.status_code == 404:
+            # 403: Installation suspended, 404: Installation doesn't exist (deleted/uninstalled)
             delete_installation(
-                installation_id=installation_id, user_id=0, user_name="Unknown"
+                installation_id=installation_id, user_id=0, user_name="System"
             )
+            return None
+
         raise

--- a/services/github/token/test_get_installation_token.py
+++ b/services/github/token/test_get_installation_token.py
@@ -79,14 +79,14 @@ def test_get_installation_access_token_suspended(
     mock_requests_post.assert_called_once()
     # Verify delete_installation was called with correct parameters
     mock_delete_installation.assert_called_once_with(
-        installation_id=installation_id, user_id=0, user_name="Unknown"
+        installation_id=installation_id, user_id=0, user_name="System"
     )
 
 
-def test_get_installation_access_token_other_error(
-    mock_get_jwt, mock_create_headers, mock_requests_post
+def test_get_installation_access_token_not_found(
+    mock_get_jwt, mock_create_headers, mock_requests_post, mock_delete_installation
 ):
-    """Test handling of other HTTP errors"""
+    """Test handling of installation not found (404)"""
     # Arrange
     installation_id = 12345
     mock_response = MagicMock()
@@ -98,4 +98,9 @@ def test_get_installation_access_token_other_error(
     result = get_installation_access_token(installation_id)
 
     # Assert
-    assert result is None  # Function should return None due to @handle_exceptions
+    assert result is None
+    mock_requests_post.assert_called_once()
+    # Verify delete_installation was called with correct parameters
+    mock_delete_installation.assert_called_once_with(
+        installation_id=installation_id, user_id=0, user_name="System"
+    )

--- a/tests/unit/test_is_test_file.py
+++ b/tests/unit/test_is_test_file.py
@@ -3,26 +3,28 @@ import pytest
 from utils.files.is_test_file import is_test_file
 
 
-@pytest.mark.parametrize("filename, expected", [
-    ("Button.test.tsx", True),
-    ("utils.spec.js", True),
-    ("test_file.py", True),
-    ("tests/Component.js", True),
-    ("src/__tests__/Component.tsx", True),
-    ("services/anthropic/test_client.py", True),
-    ("spec_helper.rb", True),
-    ("cypress/integration/login.js", True),
-    ("e2e/login.spec.ts", True),
-    ("ApiMock.java", True),
-    ("ApiMocks.java", True),
-    (".github/workflows/ci.yml", True),
-    ("README.md", False),
-    ("main.py", False),
-    ("utils/file.py", False),
-    ("Button.jsx", False),
-    ("folder/button", False)
-])
-
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("Button.test.tsx", True),
+        ("utils.spec.js", True),
+        ("test_file.py", True),
+        ("tests/Component.js", True),
+        ("src/__tests__/Component.tsx", True),
+        ("services/anthropic/test_client.py", True),
+        ("spec_helper.rb", True),
+        ("cypress/integration/login.js", True),
+        ("e2e/login.spec.ts", True),
+        ("ApiMock.java", True),
+        ("ApiMocks.java", True),
+        (".github/workflows/ci.yml", True),
+        ("README.md", False),
+        ("main.py", False),
+        ("utils/file.py", False),
+        ("Button.jsx", False),
+        ("folder/button", False),
+    ],
+)
 def test_is_test_file_with_various_filenames(filename, expected):
     assert is_test_file(filename) == expected
 


### PR DESCRIPTION
…_access_token

When GitHub returns 403 (suspended) or 404 (not found) for installation access tokens, the function now:
- Calls delete_installation to clean up database records
- Returns None instead of raising HTTPError
- Prevents unnecessary error noise in Sentry

Changes:
- Added 404 handling alongside existing 403 suspended installation logic
- Updated user_name to "System" for both cases
- Updated tests to verify graceful handling and database cleanup
- Eliminates the source HTTPError that triggers AGENT-11G scenario

🤖 Generated with [Claude Code](https://claude.ai/code)