### PR TITLE
Implement threshold-based auto-reload for credit users

### DIFF
--- a/services/stripe/test_check_availability.py
+++ b/services/stripe/test_check_availability.py
@@ -1,0 +1,127 @@
+from unittest.mock import patch
+
+from services.stripe.check_availability import check_availability
+
+
+@patch("services.stripe.check_availability.trigger_auto_reload")
+@patch("services.stripe.check_availability.get_owner")
+@patch("services.stripe.check_availability.get_stripe_customer_id")
+@patch("services.stripe.check_availability.get_billing_type")
+def test_check_availability_triggers_auto_reload_when_below_threshold(
+    mock_get_billing_type,
+    mock_get_stripe_customer_id,
+    mock_get_owner,
+    mock_trigger_auto_reload,
+):
+    mock_get_billing_type.return_value = "credit"
+    mock_get_stripe_customer_id.return_value = None
+    mock_get_owner.return_value = {
+        "credit_balance_usd": 5,
+        "auto_reload_enabled": True,
+        "auto_reload_threshold_usd": 10,
+    }
+
+    result = check_availability(
+        owner_id=123,
+        owner_name="test_owner",
+        repo_name="test_repo",
+        installation_id=456,
+        sender_name="test_sender",
+    )
+
+    assert result["can_proceed"] is True
+    assert result["credit_balance_usd"] == 5
+    mock_trigger_auto_reload.assert_called_once()
+
+
+@patch("services.stripe.check_availability.trigger_auto_reload")
+@patch("services.stripe.check_availability.get_owner")
+@patch("services.stripe.check_availability.get_stripe_customer_id")
+@patch("services.stripe.check_availability.get_billing_type")
+def test_check_availability_no_auto_reload_when_above_threshold(
+    mock_get_billing_type,
+    mock_get_stripe_customer_id,
+    mock_get_owner,
+    mock_trigger_auto_reload,
+):
+    mock_get_billing_type.return_value = "credit"
+    mock_get_stripe_customer_id.return_value = None
+    mock_get_owner.return_value = {
+        "credit_balance_usd": 15,
+        "auto_reload_enabled": True,
+        "auto_reload_threshold_usd": 10,
+    }
+
+    result = check_availability(
+        owner_id=123,
+        owner_name="test_owner",
+        repo_name="test_repo",
+        installation_id=456,
+        sender_name="test_sender",
+    )
+
+    assert result["can_proceed"] is True
+    assert result["credit_balance_usd"] == 15
+    mock_trigger_auto_reload.assert_not_called()
+
+
+@patch("services.stripe.check_availability.trigger_auto_reload")
+@patch("services.stripe.check_availability.get_owner")
+@patch("services.stripe.check_availability.get_stripe_customer_id")
+@patch("services.stripe.check_availability.get_billing_type")
+def test_check_availability_no_auto_reload_when_disabled(
+    mock_get_billing_type,
+    mock_get_stripe_customer_id,
+    mock_get_owner,
+    mock_trigger_auto_reload,
+):
+    mock_get_billing_type.return_value = "credit"
+    mock_get_stripe_customer_id.return_value = None
+    mock_get_owner.return_value = {
+        "credit_balance_usd": 5,
+        "auto_reload_enabled": False,
+        "auto_reload_threshold_usd": 10,
+    }
+
+    result = check_availability(
+        owner_id=123,
+        owner_name="test_owner",
+        repo_name="test_repo",
+        installation_id=456,
+        sender_name="test_sender",
+    )
+
+    assert result["can_proceed"] is True
+    assert result["credit_balance_usd"] == 5
+    mock_trigger_auto_reload.assert_not_called()
+
+
+@patch("services.stripe.check_availability.trigger_auto_reload")
+@patch("services.stripe.check_availability.get_owner")
+@patch("services.stripe.check_availability.get_stripe_customer_id")
+@patch("services.stripe.check_availability.get_billing_type")
+def test_check_availability_no_auto_reload_when_insufficient_credits(
+    mock_get_billing_type,
+    mock_get_stripe_customer_id,
+    mock_get_owner,
+    mock_trigger_auto_reload,
+):
+    mock_get_billing_type.return_value = "credit"
+    mock_get_stripe_customer_id.return_value = None
+    mock_get_owner.return_value = {
+        "credit_balance_usd": 0,
+        "auto_reload_enabled": True,
+        "auto_reload_threshold_usd": 10,
+    }
+
+    result = check_availability(
+        owner_id=123,
+        owner_name="test_owner",
+        repo_name="test_repo",
+        installation_id=456,
+        sender_name="test_sender",
+    )
+
+    assert result["can_proceed"] is False
+    assert result["credit_balance_usd"] == 0
+    mock_trigger_auto_reload.assert_not_called()

--- a/services/vercel/test_trigger_auto_reload.py
+++ b/services/vercel/test_trigger_auto_reload.py
@@ -1,0 +1,28 @@
+from unittest.mock import Mock, patch
+
+from config import TIMEOUT
+from services.vercel.trigger_auto_reload import trigger_auto_reload
+
+
+@patch("services.vercel.trigger_auto_reload.requests.get")
+def test_trigger_auto_reload_success(mock_get):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_get.return_value = mock_response
+
+    trigger_auto_reload()
+
+    mock_get.assert_called_once_with(
+        url="https://gitauto.ai/api/cron/auto-reload",
+        headers={"User-Agent": "vercel-cron/1.0"},
+        timeout=TIMEOUT,
+    )
+
+
+@patch("services.vercel.trigger_auto_reload.requests.get")
+def test_trigger_auto_reload_with_exception(mock_get):
+    mock_get.side_effect = Exception("Network error")
+
+    result = trigger_auto_reload()
+
+    assert result is None

--- a/services/vercel/trigger_auto_reload.py
+++ b/services/vercel/trigger_auto_reload.py
@@ -1,0 +1,16 @@
+import requests
+
+from config import TIMEOUT
+from constants.urls import BASE_URL
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=None, raise_on_error=False)
+def trigger_auto_reload():
+    # https://gitauto.ai/api/cron/auto-reload
+
+    requests.get(
+        url=f"{BASE_URL}/api/cron/auto-reload",
+        headers={"User-Agent": "vercel-cron/1.0"},
+        timeout=TIMEOUT,
+    )

--- a/services/webhook/test_issue_handler.py
+++ b/services/webhook/test_issue_handler.py
@@ -1,0 +1,93 @@
+from unittest.mock import patch
+from typing import cast
+
+from services.webhook.issue_handler import create_pr_from_issue
+from services.github.types.github_types import GitHubLabeledPayload
+
+
+@patch("services.webhook.issue_handler.check_availability")
+@patch("services.webhook.issue_handler.deconstruct_github_payload")
+def test_check_availability_is_called_for_auto_reload_integration(
+    mock_deconstruct_github_payload,
+    mock_check_availability,
+):
+    """Test that check_availability is called, which handles auto-reload internally"""
+    # Mock the payload deconstruction to return insufficient data to exit early
+    mock_base_args = {
+        "owner": "test_owner",
+        "repo": "test_repo",
+        "issue_number": 123,
+        "issue_title": "Test Issue",
+        "sender_name": "test_sender",
+        "installation_id": 456,
+        "owner_id": 789,
+        "owner_type": "Organization",
+        "repo_id": 101112,
+        "issue_body": "Test issue body",
+        "issuer_name": "test_issuer",
+        "new_branch": "gitauto/issue-123",
+        "sender_id": 131415,
+        "sender_email": "test@example.com",
+        "github_urls": [],
+        "token": "test_token",
+        "is_automation": False,
+        "skip_ci": True,
+    }
+    mock_repo_settings = {}
+    mock_deconstruct_github_payload.return_value = (mock_base_args, mock_repo_settings)
+
+    # Mock check_availability to return insufficient credits to exit early
+    mock_check_availability.return_value = {
+        "can_proceed": False,
+        "billing_type": "credit",
+        "requests_left": None,
+        "credit_balance_usd": 0,
+        "period_end_date": None,
+        "user_message": "Insufficient credits. Please add more credits to continue.",
+        "log_message": "Insufficient credits for test_owner/test_repo",
+    }
+
+    # Mock the payload
+    test_payload = {
+        "action": "labeled",
+        "label": {"name": "gitauto-wes"},
+        "issue": {"number": 123, "title": "Test Issue"},
+        "repository": {"name": "test_repo"},
+        "sender": {"login": "test_sender"},
+    }
+
+    # We need to mock more dependencies to avoid deep execution
+    with patch("services.webhook.issue_handler.slack_notify"), patch(
+        "services.webhook.issue_handler.get_stripe_customer_id",
+        return_value="cus_test123",
+    ), patch("services.webhook.issue_handler.create_stripe_customer"), patch(
+        "services.webhook.issue_handler.update_stripe_customer_id"
+    ), patch(
+        "services.webhook.issue_handler.delete_comments_by_identifiers"
+    ), patch(
+        "services.webhook.issue_handler.create_comment",
+        return_value="https://github.com/test/comment",
+    ), patch(
+        "services.webhook.issue_handler.update_comment"
+    ), patch(
+        "services.webhook.issue_handler.render_text", return_value="Test issue body"
+    ), patch(
+        "services.webhook.issue_handler.create_user_request", return_value=12345
+    ):
+
+        # Call the function - it should exit early due to insufficient credits
+        # but check_availability should still be called
+        create_pr_from_issue(
+            payload=cast(GitHubLabeledPayload, test_payload),
+            trigger="issue_label",
+            input_from="github",
+        )
+
+    # Verify check_availability was called - this is where auto-reload logic lives
+    mock_check_availability.assert_called_once_with(
+        owner_id=789,
+        owner_name="test_owner",
+        repo_name="test_repo",
+        installation_id=456,
+        sender_name="test_sender",
+    )


### PR DESCRIPTION
- Add trigger_auto_reload() function in services/vercel/ to call website API
- Enhance check_availability() to trigger auto-reload when credits are low but still available
- Prevent users from hitting "Insufficient credits" errors by reloading before depletion
- Add comprehensive test coverage for all auto-reload scenarios
- Integrate seamlessly with all existing handlers via check_availability()

🤖 Generated with [Claude Code](https://claude.ai/code)