### PR TITLE
Fix null branch_name issue in coverage reports for detached HEAD builds

### DIFF
--- a/services/webhook/handle_coverage_report.py
+++ b/services/webhook/handle_coverage_report.py
@@ -37,10 +37,19 @@ def handle_coverage_report(
     repo_name: str,
     installation_id: int,
     run_id: int,
-    head_branch: str,
+    head_branch: str | None,
     user_name: str,
     source: str = "github",
 ):
+    # Default to "detached" for builds without branch context (tag builds, API triggers, etc.)
+    if head_branch is None:
+        head_branch = "detached"
+        logging.info(
+            "No branch context for coverage report (run_id: %s, source: %s). Using 'detached'.",
+            run_id,
+            source,
+        )
+
     github_token = get_installation_access_token(installation_id=installation_id)
     circle_token = None
     if source == "github":

--- a/services/webhook/test_handle_coverage_report.py
+++ b/services/webhook/test_handle_coverage_report.py
@@ -211,6 +211,65 @@ def test_handle_coverage_report_with_javascript_sample():
         mock_upsert_repo.assert_called_once()
 
 
+def test_handle_coverage_report_with_null_head_branch():
+    """Test handling coverage report when head_branch is None (detached HEAD state)"""
+    with open("payloads/lcov/lcov-python-sample.info", "r", encoding=UTF8) as f:
+        sample_lcov = f.read()
+
+    with patch(
+        "services.webhook.handle_coverage_report.get_installation_access_token"
+    ) as mock_token, patch(
+        "services.webhook.handle_coverage_report.get_workflow_artifacts"
+    ) as mock_artifacts, patch(
+        "services.webhook.handle_coverage_report.download_artifact"
+    ) as mock_download, patch(
+        "services.webhook.handle_coverage_report.get_file_tree"
+    ) as mock_tree, patch(
+        "services.webhook.handle_coverage_report.get_coverages"
+    ) as mock_get_cov, patch(
+        "services.webhook.handle_coverage_report.upsert_coverages"
+    ) as mock_upsert_cov, patch(
+        "services.webhook.handle_coverage_report.upsert_repo_coverage"
+    ) as mock_upsert_repo, patch(
+        "services.webhook.handle_coverage_report.logging"
+    ) as mock_logging:
+
+        mock_token.return_value = "fake-token"
+        mock_artifacts.return_value = [{"id": 123, "name": "coverage-lcov.info"}]
+        mock_download.return_value = sample_lcov
+        mock_tree.return_value = []
+        mock_get_cov.return_value = {}
+        mock_upsert_cov.return_value = True
+        mock_upsert_repo.return_value = True
+
+        # Act - pass None for head_branch
+        result = handle_coverage_report(
+            owner_id=12345,
+            owner_name="test-owner",
+            repo_id=67890,
+            repo_name="test-repo",
+            installation_id=111,
+            run_id=222,
+            head_branch=None,  # Testing null head_branch
+            user_name="test-user",
+        )
+
+        # Assert
+        assert result is True
+        mock_upsert_cov.assert_called_once()
+
+        # Verify the branch_name was set to "detached" in the upserted data
+        upsert_call_args = mock_upsert_cov.call_args[0][0]
+        assert all(item.get("branch_name") == "detached" for item in upsert_call_args)
+
+        # Verify logging was called
+        mock_logging.info.assert_any_call(
+            "No branch context for coverage report (run_id: %s, source: %s). Using 'detached'.",
+            222,
+            "github",
+        )
+
+
 def test_handle_coverage_report_circleci():
     with open("payloads/lcov/lcov-python-sample.info", "r", encoding=UTF8) as f:
         sample_lcov = f.read()

--- a/services/webhook/test_pr_checkbox_handler.py
+++ b/services/webhook/test_pr_checkbox_handler.py
@@ -62,7 +62,9 @@ def mock_issue_comment_payload():
 @patch("services.webhook.pr_checkbox_handler.extract_selected_files")
 @patch("services.webhook.pr_checkbox_handler.slack_notify")
 @patch("services.webhook.pr_checkbox_handler.PRODUCT_ID", new="gitauto")
-@patch("services.webhook.pr_checkbox_handler.GITHUB_APP_USER_NAME", new="gitauto-ai[bot]")
+@patch(
+    "services.webhook.pr_checkbox_handler.GITHUB_APP_USER_NAME", new="gitauto-ai[bot]"
+)
 @patch("services.webhook.pr_checkbox_handler.create_comment")
 @patch("services.webhook.pr_checkbox_handler.cancel_workflow_runs")
 @pytest.mark.asyncio


### PR DESCRIPTION
- Handle null head_branch in CircleCI check_suite events
- Default to 'detached' when builds run without branch context (tag builds, API triggers)
- Add test coverage for null head_branch scenario
- Update CLAUDE.md with improved testing workflow and LGTM process