### PR TITLE
Fix AGENT-ZY: improve is_pull_request_open error handling

### DIFF
--- a/services/github/pulls/is_pull_request_open.py
+++ b/services/github/pulls/is_pull_request_open.py
@@ -3,8 +3,8 @@ from services.github.graphql_client import get_graphql_client
 from utils.error.handle_exceptions import handle_exceptions
 
 
-@handle_exceptions(default_return_value=False, raise_on_error=False)
-def is_pull_request_open(owner: str, repo: str, pull_number: int, token: str) -> bool:
+@handle_exceptions(default_return_value=True, raise_on_error=False)
+def is_pull_request_open(owner: str, repo: str, pull_number: int, token: str):
     """Check if a pull request is still open using GraphQL"""
     client = get_graphql_client(token=token)
     query = gql(
@@ -24,5 +24,16 @@ def is_pull_request_open(owner: str, repo: str, pull_number: int, token: str) ->
         variable_values={"owner": owner, "repo": repo, "pullNumber": pull_number},
     )
 
-    pr_state = result.get("repository", {}).get("pullRequest", {}).get("state")
+    repository = result.get("repository")
+    if repository is None:
+        # Repository not found or no access - PR doesn't exist
+        return False
+
+    pull_request = repository.get("pullRequest")
+    if pull_request is None:
+        # PR not found - PR doesn't exist
+        return False
+
+    pr_state = pull_request.get("state")
+    # GitHub GraphQL returns "OPEN", "CLOSED", or "MERGED"
     return pr_state == "OPEN"

--- a/services/github/pulls/test_is_pull_request_open.py
+++ b/services/github/pulls/test_is_pull_request_open.py
@@ -87,7 +87,7 @@ def test_is_pull_request_open_returns_false_when_repository_not_found(
     result = is_pull_request_open(**sample_params)
 
     # Assert
-    assert result is False
+    assert result is False  # Repository not found means PR doesn't exist
     mock_graphql_client.execute.assert_called_once()
 
 
@@ -102,7 +102,7 @@ def test_is_pull_request_open_returns_false_when_pull_request_not_found(
     result = is_pull_request_open(**sample_params)
 
     # Assert
-    assert result is False
+    assert result is False  # PR not found means it doesn't exist
     mock_graphql_client.execute.assert_called_once()
 
 
@@ -164,8 +164,8 @@ def test_is_pull_request_open_creates_graphql_client_with_token(sample_params):
         mock_get_client.assert_called_once_with(token="test-token")
 
 
-def test_is_pull_request_open_handles_exception_returns_false(sample_params):
-    """Test that function returns False when an exception occurs (due to @handle_exceptions decorator)."""
+def test_is_pull_request_open_handles_exception_returns_true(sample_params):
+    """Test that function returns True when an exception occurs (fail-open due to @handle_exceptions decorator)."""
     with patch(
         "services.github.pulls.is_pull_request_open.get_graphql_client"
     ) as mock_get_client:
@@ -175,4 +175,4 @@ def test_is_pull_request_open_handles_exception_returns_false(sample_params):
         result = is_pull_request_open(**sample_params)
 
         # Assert
-        assert result is False
+        assert result is True  # Network errors return True (fail-open)

--- a/services/github/search/test_search_remote_file_contents.py
+++ b/services/github/search/test_search_remote_file_contents.py
@@ -4,9 +4,11 @@ from unittest.mock import Mock, patch
 # Third-party imports
 import pytest
 import requests
+
 # Local imports
-from services.github.search.search_remote_file_contents import \
-    search_remote_file_contents
+from services.github.search.search_remote_file_contents import (
+    search_remote_file_contents,
+)
 
 
 @pytest.fixture
@@ -24,11 +26,7 @@ def mock_response_success():
                 "url": "https://api.github.com/repos/owner/repo/contents/src/test_file1.py",
                 "git_url": "https://api.github.com/repos/owner/repo/git/blobs/abc123",
                 "html_url": "https://github.com/owner/repo/blob/main/src/test_file1.py",
-                "repository": {
-                    "id": 123456,
-                    "name": "repo",
-                    "full_name": "owner/repo"
-                }
+                "repository": {"id": 123456, "name": "repo", "full_name": "owner/repo"},
             },
             {
                 "name": "test_file2.py",
@@ -37,13 +35,9 @@ def mock_response_success():
                 "url": "https://api.github.com/repos/owner/repo/contents/tests/test_file2.py",
                 "git_url": "https://api.github.com/repos/owner/repo/git/blobs/def456",
                 "html_url": "https://github.com/owner/repo/blob/main/tests/test_file2.py",
-                "repository": {
-                    "id": 123456,
-                    "name": "repo",
-                    "full_name": "owner/repo"
-                }
-            }
-        ]
+                "repository": {"id": 123456, "name": "repo", "full_name": "owner/repo"},
+            },
+        ],
     }
     mock_response.raise_for_status.return_value = None
     return mock_response
@@ -56,7 +50,7 @@ def mock_response_empty():
     mock_response.json.return_value = {
         "total_count": 0,
         "incomplete_results": False,
-        "items": []
+        "items": [],
     }
     mock_response.raise_for_status.return_value = None
     return mock_response
@@ -77,13 +71,9 @@ def mock_response_single_file():
                 "url": "https://api.github.com/repos/owner/repo/contents/config.py",
                 "git_url": "https://api.github.com/repos/owner/repo/git/blobs/xyz789",
                 "html_url": "https://github.com/owner/repo/blob/main/config.py",
-                "repository": {
-                    "id": 123456,
-                    "name": "repo",
-                    "full_name": "owner/repo"
-                }
+                "repository": {"id": 123456, "name": "repo", "full_name": "owner/repo"},
             }
-        ]
+        ],
     }
     mock_response.raise_for_status.return_value = None
     return mock_response
@@ -94,25 +84,23 @@ def mock_response_many_files():
     """Mock GitHub API response with many files (testing pagination limit)."""
     items = []
     for i in range(10):  # per_page limit is 10
-        items.append({
-            "name": f"file_{i}.py",
-            "path": f"src/file_{i}.py",
-            "sha": f"sha{i:03d}",
-            "url": f"https://api.github.com/repos/owner/repo/contents/src/file_{i}.py",
-            "git_url": f"https://api.github.com/repos/owner/repo/git/blobs/sha{i:03d}",
-            "html_url": f"https://github.com/owner/repo/blob/main/src/file_{i}.py",
-            "repository": {
-                "id": 123456,
-                "name": "repo",
-                "full_name": "owner/repo"
+        items.append(
+            {
+                "name": f"file_{i}.py",
+                "path": f"src/file_{i}.py",
+                "sha": f"sha{i:03d}",
+                "url": f"https://api.github.com/repos/owner/repo/contents/src/file_{i}.py",
+                "git_url": f"https://api.github.com/repos/owner/repo/git/blobs/sha{i:03d}",
+                "html_url": f"https://github.com/owner/repo/blob/main/src/file_{i}.py",
+                "repository": {"id": 123456, "name": "repo", "full_name": "owner/repo"},
             }
-        })
+        )
 
     mock_response = Mock()
     mock_response.json.return_value = {
         "total_count": 10,
         "incomplete_results": False,
-        "items": items
+        "items": items,
     }
     mock_response.raise_for_status.return_value = None
     return mock_response
@@ -121,25 +109,28 @@ def mock_response_many_files():
 class TestSearchRemoteFileContents:
     """Test cases for search_remote_file_contents function."""
 
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_successful_search_multiple_files(self, mock_create_headers, mock_get,
-                                            create_test_base_args, mock_response_success, capsys):
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_successful_search_multiple_files(
+        self,
+        mock_create_headers,
+        mock_get,
+        create_test_base_args,
+        mock_response_success,
+        capsys,
+    ):
         """Test successful search returning multiple files."""
         # Arrange
         mock_create_headers.return_value = {
             "Authorization": "Bearer test-token",
             "Accept": "application/vnd.github.v3+json",
             "User-Agent": "test-app",
-            "X-GitHub-Api-Version": "2022-11-28"
+            "X-GitHub-Api-Version": "2022-11-28",
         }
         mock_get.return_value = mock_response_success
 
         base_args = create_test_base_args(
-            owner="test-owner",
-            repo="test-repo",
-            is_fork=False,
-            token="test-token"
+            owner="test-owner", repo="test-repo", is_fork=False, token="test-token"
         )
         query = "def search_function"
 
@@ -155,34 +146,41 @@ class TestSearchRemoteFileContents:
         # Verify API call parameters
         mock_get.assert_called_once()
         call_args = mock_get.call_args
-        assert call_args[1]['url'] == "https://api.github.com/search/code"
-        assert call_args[1]['params']['q'] == "def search_function repo:test-owner/test-repo"
-        assert call_args[1]['params']['per_page'] == 10
-        assert call_args[1]['params']['page'] == 1
-        assert call_args[1]['timeout'] == 120
+        assert call_args[1]["url"] == "https://api.github.com/search/code"
+        assert (
+            call_args[1]["params"]["q"]
+            == "def search_function repo:test-owner/test-repo"
+        )
+        assert call_args[1]["params"]["per_page"] == 10
+        assert call_args[1]["params"]["page"] == 1
+        assert call_args[1]["timeout"] == 120
 
         # Verify headers were set correctly
-        headers = call_args[1]['headers']
-        assert headers['Accept'] == "application/vnd.github.text-match+json"
+        headers = call_args[1]["headers"]
+        assert headers["Accept"] == "application/vnd.github.text-match+json"
 
         # Verify console output
         captured = capsys.readouterr()
-        assert "2 files found for the search query 'def search_function':" in captured.out
+        assert (
+            "2 files found for the search query 'def search_function':" in captured.out
+        )
 
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_successful_search_fork_repository(self, mock_create_headers, mock_get,
-                                             create_test_base_args, mock_response_single_file):
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_successful_search_fork_repository(
+        self,
+        mock_create_headers,
+        mock_get,
+        create_test_base_args,
+        mock_response_single_file,
+    ):
         """Test successful search in a forked repository."""
         # Arrange
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
         mock_get.return_value = mock_response_single_file
 
         base_args = create_test_base_args(
-            owner="fork-owner",
-            repo="fork-repo",
-            is_fork=True,
-            token="test-token"
+            owner="fork-owner", repo="fork-repo", is_fork=True, token="test-token"
         )
         query = "import config"
 
@@ -195,22 +193,28 @@ class TestSearchRemoteFileContents:
 
         # Verify fork-specific query parameter
         call_args = mock_get.call_args
-        assert call_args[1]['params']['q'] == "import config repo:fork-owner/fork-repo fork:true"
+        assert (
+            call_args[1]["params"]["q"]
+            == "import config repo:fork-owner/fork-repo fork:true"
+        )
 
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_search_no_results(self, mock_create_headers, mock_get,
-                              create_test_base_args, mock_response_empty, capsys):
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_search_no_results(
+        self,
+        mock_create_headers,
+        mock_get,
+        create_test_base_args,
+        mock_response_empty,
+        capsys,
+    ):
         """Test search returning no results."""
         # Arrange
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
         mock_get.return_value = mock_response_empty
 
         base_args = create_test_base_args(
-            owner="test-owner",
-            repo="test-repo",
-            is_fork=False,
-            token="test-token"
+            owner="test-owner", repo="test-repo", is_fork=False, token="test-token"
         )
         query = "nonexistent_function"
 
@@ -223,22 +227,26 @@ class TestSearchRemoteFileContents:
 
         # Verify console output
         captured = capsys.readouterr()
-        assert "0 files found for the search query 'nonexistent_function':" in captured.out
+        assert (
+            "0 files found for the search query 'nonexistent_function':" in captured.out
+        )
 
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_search_single_file_result(self, mock_create_headers, mock_get,
-                                     create_test_base_args, mock_response_single_file):
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_search_single_file_result(
+        self,
+        mock_create_headers,
+        mock_get,
+        create_test_base_args,
+        mock_response_single_file,
+    ):
         """Test search returning exactly one file."""
         # Arrange
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
         mock_get.return_value = mock_response_single_file
 
         base_args = create_test_base_args(
-            owner="test-owner",
-            repo="test-repo",
-            is_fork=False,
-            token="test-token"
+            owner="test-owner", repo="test-repo", is_fork=False, token="test-token"
         )
         query = "class Config"
 
@@ -250,20 +258,22 @@ class TestSearchRemoteFileContents:
         assert "config.py" in result
         assert result.count("\n- ") == 1  # Only one file listed
 
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_search_many_files_pagination_limit(self, mock_create_headers, mock_get,
-                                               create_test_base_args, mock_response_many_files):
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_search_many_files_pagination_limit(
+        self,
+        mock_create_headers,
+        mock_get,
+        create_test_base_args,
+        mock_response_many_files,
+    ):
         """Test search with maximum per_page results (10 files)."""
         # Arrange
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
         mock_get.return_value = mock_response_many_files
 
         base_args = create_test_base_args(
-            owner="test-owner",
-            repo="test-repo",
-            is_fork=False,
-            token="test-token"
+            owner="test-owner", repo="test-repo", is_fork=False, token="test-token"
         )
         query = "def function"
 
@@ -275,9 +285,11 @@ class TestSearchRemoteFileContents:
         for i in range(10):
             assert f"src/file_{i}.py" in result
 
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_http_error_handling(self, mock_create_headers, mock_get, create_test_base_args):
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_http_error_handling(
+        self, mock_create_headers, mock_get, create_test_base_args
+    ):
         """Test handling of HTTP errors (should return empty string due to decorator)."""
         # Arrange
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
@@ -289,7 +301,7 @@ class TestSearchRemoteFileContents:
             owner="test-owner",
             repo="nonexistent-repo",
             is_fork=False,
-            token="test-token"
+            token="test-token",
         )
         query = "test query"
 
@@ -299,9 +311,11 @@ class TestSearchRemoteFileContents:
         # Assert - decorator should return empty string on error
         assert result == ""
 
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_json_decode_error_handling(self, mock_create_headers, mock_get, create_test_base_args):
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_json_decode_error_handling(
+        self, mock_create_headers, mock_get, create_test_base_args
+    ):
         """Test handling of JSON decode errors (should return empty string due to decorator)."""
         # Arrange
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
@@ -319,9 +333,11 @@ class TestSearchRemoteFileContents:
         # Assert - decorator should return empty string on error
         assert result == ""
 
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_requests_exception_handling(self, mock_create_headers, mock_get, create_test_base_args):
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_requests_exception_handling(
+        self, mock_create_headers, mock_get, create_test_base_args
+    ):
         """Test handling of requests exceptions (should return empty string due to decorator)."""
         # Arrange
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
@@ -336,16 +352,18 @@ class TestSearchRemoteFileContents:
         # Assert - decorator should return empty string on error
         assert result == ""
 
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_missing_items_key_in_response(self, mock_create_headers, mock_get, create_test_base_args):
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_missing_items_key_in_response(
+        self, mock_create_headers, mock_get, create_test_base_args
+    ):
         """Test handling when 'items' key is missing from response."""
         # Arrange
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
         mock_response = Mock()
         mock_response.json.return_value = {
             "total_count": 0,
-            "incomplete_results": False
+            "incomplete_results": False,
             # Missing 'items' key
         }
         mock_response.raise_for_status.return_value = None
@@ -360,9 +378,11 @@ class TestSearchRemoteFileContents:
         # Assert - should handle missing 'items' gracefully
         assert "0 files found for the search query 'test query':" in result
 
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_malformed_item_structure(self, mock_create_headers, mock_get, create_test_base_args):
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_malformed_item_structure(
+        self, mock_create_headers, mock_get, create_test_base_args
+    ):
         """Test handling when item structure is malformed (missing 'path' key)."""
         # Arrange
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
@@ -374,9 +394,9 @@ class TestSearchRemoteFileContents:
                 {
                     "name": "test_file.py",
                     # Missing 'path' key
-                    "sha": "abc123"
+                    "sha": "abc123",
                 }
-            ]
+            ],
         }
         mock_response.raise_for_status.return_value = None
         mock_get.return_value = mock_response
@@ -390,10 +410,15 @@ class TestSearchRemoteFileContents:
         # Assert - decorator should return empty string on KeyError
         assert result == ""
 
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_create_headers_called_correctly(self, mock_create_headers, mock_get,
-                                           create_test_base_args, mock_response_success):
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_create_headers_called_correctly(
+        self,
+        mock_create_headers,
+        mock_get,
+        create_test_base_args,
+        mock_response_success,
+    ):
         """Test that create_headers is called with correct token."""
         # Arrange
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
@@ -408,15 +433,20 @@ class TestSearchRemoteFileContents:
         # Assert
         mock_create_headers.assert_called_once_with(token="specific-test-token")
 
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_headers_accept_override(self, mock_create_headers, mock_get,
-                                   create_test_base_args, mock_response_success):
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_headers_accept_override(
+        self,
+        mock_create_headers,
+        mock_get,
+        create_test_base_args,
+        mock_response_success,
+    ):
         """Test that Accept header is correctly overridden for text-match."""
         # Arrange
         mock_create_headers.return_value = {
             "Authorization": "Bearer test-token",
-            "Accept": "application/vnd.github.v3+json"  # This should be overridden
+            "Accept": "application/vnd.github.v3+json",  # This should be overridden
         }
         mock_get.return_value = mock_response_success
 
@@ -428,23 +458,32 @@ class TestSearchRemoteFileContents:
 
         # Assert
         call_args = mock_get.call_args
-        headers = call_args[1]['headers']
-        assert headers['Accept'] == "application/vnd.github.text-match+json"
+        headers = call_args[1]["headers"]
+        assert headers["Accept"] == "application/vnd.github.text-match+json"
 
-    @pytest.mark.parametrize("query,expected_in_result", [
-        ("simple query", "simple query"),
-        ("query with spaces", "query with spaces"),
-        ("query-with-dashes", "query-with-dashes"),
-        ("query_with_underscores", "query_with_underscores"),
-        ("query.with.dots", "query.with.dots"),
-        ("query/with/slashes", "query/with/slashes"),
-        ("", ""),
-    ])
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_various_query_formats(self, mock_create_headers, mock_get,
-                                  create_test_base_args, mock_response_empty,
-                                  query, expected_in_result):
+    @pytest.mark.parametrize(
+        "query,expected_in_result",
+        [
+            ("simple query", "simple query"),
+            ("query with spaces", "query with spaces"),
+            ("query-with-dashes", "query-with-dashes"),
+            ("query_with_underscores", "query_with_underscores"),
+            ("query.with.dots", "query.with.dots"),
+            ("query/with/slashes", "query/with/slashes"),
+            ("", ""),
+        ],
+    )
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_various_query_formats(
+        self,
+        mock_create_headers,
+        mock_get,
+        create_test_base_args,
+        mock_response_empty,
+        query,
+        expected_in_result,
+    ):
         """Test function with various query formats."""
         # Arrange
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
@@ -458,25 +497,31 @@ class TestSearchRemoteFileContents:
         # Assert
         assert f"0 files found for the search query '{expected_in_result}':" in result
 
-    @pytest.mark.parametrize("is_fork,expected_fork_param", [
-        (True, "fork:true"),
-        (False, ""),
-    ])
-    @patch('services.github.search.search_remote_file_contents.requests.get')
-    @patch('services.github.search.search_remote_file_contents.create_headers')
-    def test_fork_parameter_handling(self, mock_create_headers, mock_get,
-                                   create_test_base_args, mock_response_empty,
-                                   is_fork, expected_fork_param):
+    @pytest.mark.parametrize(
+        "is_fork,expected_fork_param",
+        [
+            (True, "fork:true"),
+            (False, ""),
+        ],
+    )
+    @patch("services.github.search.search_remote_file_contents.requests.get")
+    @patch("services.github.search.search_remote_file_contents.create_headers")
+    def test_fork_parameter_handling(
+        self,
+        mock_create_headers,
+        mock_get,
+        create_test_base_args,
+        mock_response_empty,
+        is_fork,
+        expected_fork_param,
+    ):
         """Test that fork parameter is handled correctly."""
         # Arrange
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
         mock_get.return_value = mock_response_empty
 
         base_args = create_test_base_args(
-            owner="test-owner",
-            repo="test-repo",
-            is_fork=is_fork,
-            token="test-token"
+            owner="test-owner", repo="test-repo", is_fork=is_fork, token="test-token"
         )
         query = "test query"
 
@@ -485,11 +530,13 @@ class TestSearchRemoteFileContents:
 
         # Assert
         call_args = mock_get.call_args
-        q_param = call_args[1]['params']['q']
+        q_param = call_args[1]["params"]["q"]
 
         if expected_fork_param:
             assert expected_fork_param in q_param
-            assert q_param == f"test query repo:test-owner/test-repo {expected_fork_param}"
+            assert (
+                q_param == f"test query repo:test-owner/test-repo {expected_fork_param}"
+            )
         else:
             assert "fork:" not in q_param
             assert q_param == "test query repo:test-owner/test-repo"
@@ -506,7 +553,7 @@ class TestSearchRemoteFileContents:
     def test_function_has_handle_exceptions_decorator(self):
         """Test that the function is properly decorated with handle_exceptions."""
         # The function should have the decorator applied
-        assert hasattr(search_remote_file_contents, '__wrapped__')
+        assert hasattr(search_remote_file_contents, "__wrapped__")
 
         # Test that it returns empty string on error (default_return_value="")
         # This is implicitly tested in the error handling test cases above


### PR DESCRIPTION
- Change default_return_value to True for network errors (fail-open)
- Keep explicit False return for PR/repo not found cases
- Add proper null handling for repository and pullRequest objects
- Update tests to reflect new behavior
- Fix integration test exception handling