### PR TITLE
Fix AGENT-1NA: Remove action_required from check run failures

### DIFF
--- a/config.py
+++ b/config.py
@@ -36,7 +36,6 @@ GITHUB_CHECK_RUN_FAILURES = [
     "startup_failure",
     "failure",
     "timed_out",
-    "action_required",
 ]
 GITHUB_ISSUE_DIR = ".github/ISSUE_TEMPLATE"
 GITHUB_ISSUE_TEMPLATES = ["bug_report.yml", "feature_request.yml"]

--- a/services/supabase/coverages/test_get_coverages.py
+++ b/services/supabase/coverages/test_get_coverages.py
@@ -821,7 +821,11 @@ class TestGetCoveragesIntegration:
                     ).execute()
                     max_working = mid
                     low = mid + 1
-                except (ValueError, TypeError, KeyError, Exception) as e:  # pylint: disable=broad-exception-caught
+                except (
+                    ValueError,
+                    TypeError,
+                    KeyError,
+                ) as e:
                     if (
                         "400" in str(e)
                         or "Bad Request" in str(e)


### PR DESCRIPTION
- Remove "action_required" from GITHUB_CHECK_RUN_FAILURES config
- action_required check runs need human intervention, not automated fixes
- This prevents GitAuto from processing check runs that require manual action
- Fix pylint broad-exception-caught error in test_get_coverages.py

🤖 Generated with [Claude Code](https://claude.ai/code)