### PR TITLE
Add claude-sonnet-4-5 as primary model and remove claude-3-5-sonnet-l…

### DIFF
--- a/config.py
+++ b/config.py
@@ -66,9 +66,9 @@ OPENAI_TEMPERATURE = 0.0
 # Anthropic Credentials from environment variables
 # https://docs.anthropic.com/en/docs/about-claude/models/overview#model-aliases
 ANTHROPIC_API_KEY = get_env_var(name="ANTHROPIC_API_KEY")
-ANTHROPIC_MODEL_ID_35 = "claude-3-5-sonnet-latest"
-ANTHROPIC_MODEL_ID_37 = "claude-3-7-sonnet-latest"
+ANTHROPIC_MODEL_ID_45 = "claude-sonnet-4-5"
 ANTHROPIC_MODEL_ID_40 = "claude-sonnet-4-0"
+ANTHROPIC_MODEL_ID_37 = "claude-3-7-sonnet-latest"
 
 # Resend Credentials
 RESEND_API_KEY = get_env_var(name="RESEND_API_KEY")

--- a/services/anthropic/chat_with_functions.py
+++ b/services/anthropic/chat_with_functions.py
@@ -8,7 +8,7 @@ from anthropic._exceptions import OverloadedError
 from anthropic.types import MessageParam, ToolUnionParam, ToolUseBlock
 
 # Local imports
-from config import ANTHROPIC_MODEL_ID_37, ANTHROPIC_MODEL_ID_40
+from config import ANTHROPIC_MODEL_ID_45
 from services.anthropic.client import claude
 from services.anthropic.remove_duplicate_get_remote_file_content_results import (
     remove_duplicate_get_remote_file_content_results,
@@ -35,7 +35,7 @@ def chat_with_claude(
     messages: list[MessageParam],
     system_content: str,
     tools: list[dict[str, Any]],
-    model_id: str = ANTHROPIC_MODEL_ID_40,
+    model_id: str = ANTHROPIC_MODEL_ID_45,
     usage_id: int | None = None,
 ):
     # https://docs.anthropic.com/en/api/client-sdks
@@ -47,9 +47,7 @@ def chat_with_claude(
     messages = remove_outdated_apply_diff_to_file_attempts_and_results(messages)
 
     # Check token count and delete messages if necessary
-    max_tokens = (
-        64000 if model_id in [ANTHROPIC_MODEL_ID_37, ANTHROPIC_MODEL_ID_40] else 8192
-    )
+    max_tokens = 64000
     buffer = 4096
     max_input = 200_000 - max_tokens - buffer
     messages = trim_messages_to_token_limit(

--- a/services/anthropic/evaluate_condition.py
+++ b/services/anthropic/evaluate_condition.py
@@ -1,4 +1,4 @@
-from config import ANTHROPIC_MODEL_ID_40
+from config import ANTHROPIC_MODEL_ID_45
 from services.anthropic.client import claude
 from utils.error.handle_exceptions import handle_exceptions
 
@@ -13,7 +13,7 @@ def evaluate_condition(
         return False
 
     response = claude.messages.create(
-        model=ANTHROPIC_MODEL_ID_40,
+        model=ANTHROPIC_MODEL_ID_45,
         max_tokens=max_tokens,
         temperature=0,
         system=f"""{system_prompt}
@@ -23,7 +23,8 @@ Respond with ONLY the word TRUE or FALSE. Nothing else.""",
     )
 
     # Parse the response
-    response_text = response.content[0].text.strip().lower()
+    first_content = response.content[0]
+    response_text = getattr(first_content, 'text', '').strip().lower()
 
     # Simple parsing - just check for true or false
     if "true" in response_text:

--- a/services/anthropic/test_trim_messages.py
+++ b/services/anthropic/test_trim_messages.py
@@ -360,7 +360,7 @@ def test_message_object_conversion(mock_client):
 def test_custom_model_parameter(mock_client):
     """Test using a custom model parameter."""
     messages = [make_message("user"), make_message("assistant")]
-    custom_model = "claude-3-sonnet-20240229"
+    custom_model = "claude-sonnet-4-5"
 
     def count_tokens_custom(messages, model):
         assert model == custom_model

--- a/services/model_selection.py
+++ b/services/model_selection.py
@@ -2,17 +2,17 @@
 # pylint: disable=invalid-name
 
 from config import (
-    ANTHROPIC_MODEL_ID_35,
     ANTHROPIC_MODEL_ID_37,
     ANTHROPIC_MODEL_ID_40,
+    ANTHROPIC_MODEL_ID_45,
     OPENAI_MODEL_ID_GPT_5,
 )
 from utils.colors.colorize_log import colorize
 
 MODEL_CHAIN = [
+    ANTHROPIC_MODEL_ID_45,
     ANTHROPIC_MODEL_ID_40,
     ANTHROPIC_MODEL_ID_37,
-    ANTHROPIC_MODEL_ID_35,
     OPENAI_MODEL_ID_GPT_5,
 ]
 

--- a/services/supabase/llm_requests/calculate_costs.py
+++ b/services/supabase/llm_requests/calculate_costs.py
@@ -9,9 +9,9 @@ def calculate_costs(
 ):
     pricing = {
         "claude": {
+            "claude-sonnet-4-5": {"input": 3.00, "output": 15.00},
             "claude-sonnet-4-0": {"input": 3.00, "output": 15.00},
             "claude-3-7-sonnet-latest": {"input": 3.00, "output": 15.00},
-            "claude-3-5-sonnet-latest": {"input": 3.00, "output": 15.00},
         },
         "openai": {
             "gpt-5": {"input": 1.25, "output": 10.00},

--- a/services/supabase/llm_requests/test_calculate_costs.py
+++ b/services/supabase/llm_requests/test_calculate_costs.py
@@ -1,9 +1,18 @@
 from services.supabase.llm_requests.calculate_costs import calculate_costs
 
 
+def test_calculate_costs_claude_45():
+    input_cost, output_cost = calculate_costs("claude", "claude-sonnet-4-5", 1000, 500)
+    expected_input = (1000 / 1_000_000) * 3.00
+    expected_output = (500 / 1_000_000) * 15.00
+
+    assert input_cost == expected_input
+    assert output_cost == expected_output
+
+
 def test_calculate_costs_claude():
     input_cost, output_cost = calculate_costs(
-        "claude", "claude-3-5-sonnet-latest", 1000, 500
+        "claude", "claude-3-7-sonnet-latest", 1000, 500
     )
     expected_input = (1000 / 1_000_000) * 3.00
     expected_output = (500 / 1_000_000) * 15.00
@@ -35,7 +44,7 @@ def test_calculate_costs_unknown_model():
 
 def test_calculate_costs_zero_tokens():
     input_cost, output_cost = calculate_costs(
-        "claude", "claude-3-5-sonnet-latest", 0, 0
+        "claude", "claude-3-7-sonnet-latest", 0, 0
     )
     assert input_cost == 0
     assert output_cost == 0

--- a/services/supabase/llm_requests/test_insert_llm_request.py
+++ b/services/supabase/llm_requests/test_insert_llm_request.py
@@ -19,7 +19,7 @@ def test_insert_llm_request_success(mock_calculate_costs, mock_supabase):
     result = insert_llm_request(
         usage_id=123,
         provider="claude",
-        model_id="claude-3-5-sonnet-latest",
+        model_id="claude-3-7-sonnet-latest",
         input_messages=input_messages,
         input_tokens=10,
         output_message=output_message,
@@ -30,13 +30,13 @@ def test_insert_llm_request_success(mock_calculate_costs, mock_supabase):
 
     assert result == {"id": 1}
     mock_calculate_costs.assert_called_once_with(
-        "claude", "claude-3-5-sonnet-latest", 10, 5
+        "claude", "claude-3-7-sonnet-latest", 10, 5
     )
 
     expected_data = {
         "usage_id": 123,
         "provider": "claude",
-        "model_id": "claude-3-5-sonnet-latest",
+        "model_id": "claude-3-7-sonnet-latest",
         "input_content": json.dumps(input_messages, ensure_ascii=False),
         "input_length": len(json.dumps(input_messages, ensure_ascii=False)),
         "input_tokens": 10,
@@ -85,7 +85,7 @@ def test_insert_llm_request_database_error(mock_supabase):
     result = insert_llm_request(
         usage_id=123,
         provider="claude",
-        model_id="claude-3-5-sonnet-latest",
+        model_id="claude-3-7-sonnet-latest",
         input_messages=[{"role": "user", "content": "test"}],
         input_tokens=10,
         output_message={"role": "assistant", "content": "response"},

--- a/services/test_model_selection.py
+++ b/services/test_model_selection.py
@@ -5,9 +5,9 @@ from unittest.mock import patch
 import pytest
 
 from config import (
-    ANTHROPIC_MODEL_ID_35,
     ANTHROPIC_MODEL_ID_37,
     ANTHROPIC_MODEL_ID_40,
+    ANTHROPIC_MODEL_ID_45,
     OPENAI_MODEL_ID_GPT_5,
 )
 from services import model_selection
@@ -47,9 +47,9 @@ def mock_print():
 def test_model_chain_contains_expected_models():
     """Test that MODEL_CHAIN contains the expected models in correct order."""
     expected_models = [
+        ANTHROPIC_MODEL_ID_45,
         ANTHROPIC_MODEL_ID_40,
         ANTHROPIC_MODEL_ID_37,
-        ANTHROPIC_MODEL_ID_35,
         OPENAI_MODEL_ID_GPT_5,
     ]
     assert MODEL_CHAIN == expected_models
@@ -58,16 +58,16 @@ def test_model_chain_contains_expected_models():
 
 def test_model_chain_order():
     """Test that models are in the expected priority order."""
-    assert MODEL_CHAIN[0] == ANTHROPIC_MODEL_ID_40  # Highest priority
-    assert MODEL_CHAIN[1] == ANTHROPIC_MODEL_ID_37
-    assert MODEL_CHAIN[2] == ANTHROPIC_MODEL_ID_35
+    assert MODEL_CHAIN[0] == ANTHROPIC_MODEL_ID_45  # Highest priority
+    assert MODEL_CHAIN[1] == ANTHROPIC_MODEL_ID_40
+    assert MODEL_CHAIN[2] == ANTHROPIC_MODEL_ID_37
     assert MODEL_CHAIN[3] == OPENAI_MODEL_ID_GPT_5  # Lowest priority
 
 
 def test_get_model_returns_current_model(_):
     """Test that get_model returns the current model."""
     result = get_model()
-    assert result == ANTHROPIC_MODEL_ID_40  # Initial model
+    assert result == ANTHROPIC_MODEL_ID_45  # Initial model
 
 
 def test_get_model_returns_string():
@@ -80,16 +80,16 @@ def test_get_model_returns_string():
 def test_try_next_model_from_first_model(_, mock_colorize, mock_print):
     """Test switching from first model to second model."""
     # Ensure we start with the first model
-    assert get_model() == ANTHROPIC_MODEL_ID_40
+    assert get_model() == ANTHROPIC_MODEL_ID_45
 
     success, new_model = try_next_model()
 
     assert success is True
-    assert new_model == ANTHROPIC_MODEL_ID_37
-    assert get_model() == ANTHROPIC_MODEL_ID_37
+    assert new_model == ANTHROPIC_MODEL_ID_40
+    assert get_model() == ANTHROPIC_MODEL_ID_40
 
     # Verify colorize was called with correct message and color
-    expected_msg = f"Switching from {ANTHROPIC_MODEL_ID_40} to {ANTHROPIC_MODEL_ID_37}"
+    expected_msg = f"Switching from {ANTHROPIC_MODEL_ID_45} to {ANTHROPIC_MODEL_ID_40}"
     mock_colorize.assert_called_once_with(expected_msg, "yellow")
 
     # Verify print was called with colorized message
@@ -101,16 +101,16 @@ def test_try_next_model_from_second_model(_, mock_colorize, mock_print):
     # Use already imported model_selection
 
     # Set current model to second model
-    model_selection._current_model = ANTHROPIC_MODEL_ID_37
+    model_selection._current_model = ANTHROPIC_MODEL_ID_40
 
     success, new_model = try_next_model()
 
     assert success is True
-    assert new_model == ANTHROPIC_MODEL_ID_35
-    assert get_model() == ANTHROPIC_MODEL_ID_35
+    assert new_model == ANTHROPIC_MODEL_ID_37
+    assert get_model() == ANTHROPIC_MODEL_ID_37
 
     # Verify colorize was called with correct message
-    expected_msg = f"Switching from {ANTHROPIC_MODEL_ID_37} to {ANTHROPIC_MODEL_ID_35}"
+    expected_msg = f"Switching from {ANTHROPIC_MODEL_ID_40} to {ANTHROPIC_MODEL_ID_37}"
     mock_colorize.assert_called_once_with(expected_msg, "yellow")
     mock_print.assert_called_once_with("mocked_colored_text")
 
@@ -120,7 +120,7 @@ def test_try_next_model_from_third_model(_, mock_colorize, mock_print):
     # Use already imported model_selection
 
     # Set current model to third model
-    model_selection._current_model = ANTHROPIC_MODEL_ID_35
+    model_selection._current_model = ANTHROPIC_MODEL_ID_37
 
     success, new_model = try_next_model()
 
@@ -129,7 +129,7 @@ def test_try_next_model_from_third_model(_, mock_colorize, mock_print):
     assert get_model() == OPENAI_MODEL_ID_GPT_5
 
     # Verify colorize was called with correct message
-    expected_msg = f"Switching from {ANTHROPIC_MODEL_ID_35} to {OPENAI_MODEL_ID_GPT_5}"
+    expected_msg = f"Switching from {ANTHROPIC_MODEL_ID_37} to {OPENAI_MODEL_ID_GPT_5}"
     mock_colorize.assert_called_once_with(expected_msg, "yellow")
     mock_print.assert_called_once_with("mocked_colored_text")
 
@@ -155,19 +155,19 @@ def test_try_next_model_from_last_model(_, mock_colorize, mock_print):
 def test_try_next_model_sequential_calls(_, mock_colorize, mock_print):
     """Test sequential calls to try_next_model through all models."""
     # Start with first model
-    assert get_model() == ANTHROPIC_MODEL_ID_40
+    assert get_model() == ANTHROPIC_MODEL_ID_45
 
     # First call: switch to second model
     success1, model1 = try_next_model()
     assert success1 is True
-    assert model1 == ANTHROPIC_MODEL_ID_37
-    assert get_model() == ANTHROPIC_MODEL_ID_37
+    assert model1 == ANTHROPIC_MODEL_ID_40
+    assert get_model() == ANTHROPIC_MODEL_ID_40
 
     # Second call: switch to third model
     success2, model2 = try_next_model()
     assert success2 is True
-    assert model2 == ANTHROPIC_MODEL_ID_35
-    assert get_model() == ANTHROPIC_MODEL_ID_35
+    assert model2 == ANTHROPIC_MODEL_ID_37
+    assert get_model() == ANTHROPIC_MODEL_ID_37
 
     # Third call: switch to fourth model
     success3, model3 = try_next_model()
@@ -198,21 +198,21 @@ def test_try_next_model_return_types():
 def test_model_selection_state_persistence(_):
     """Test that model state persists between function calls."""
     # Initial state
-    assert get_model() == ANTHROPIC_MODEL_ID_40
+    assert get_model() == ANTHROPIC_MODEL_ID_45
 
     # Switch model
     try_next_model()
-    assert get_model() == ANTHROPIC_MODEL_ID_37
+    assert get_model() == ANTHROPIC_MODEL_ID_40
 
     # State should persist
-    assert get_model() == ANTHROPIC_MODEL_ID_37
+    assert get_model() == ANTHROPIC_MODEL_ID_40
 
     # Switch again
     try_next_model()
-    assert get_model() == ANTHROPIC_MODEL_ID_35
+    assert get_model() == ANTHROPIC_MODEL_ID_37
 
     # State should still persist
-    assert get_model() == ANTHROPIC_MODEL_ID_35
+    assert get_model() == ANTHROPIC_MODEL_ID_37
 
 
 def test_try_next_model_with_invalid_current_model(_):


### PR DESCRIPTION
…atest

- Added ANTHROPIC_MODEL_ID_45 for claude-sonnet-4-5 model
- Removed ANTHROPIC_MODEL_ID_35 (claude-3-5-sonnet-latest) globally
- Updated MODEL_CHAIN to prioritize claude-sonnet-4-5 as primary model
- Updated default parameters in chat_with_functions, trim_messages, and evaluate_condition
- Fixed max_tokens logic in chat_with_functions (all models use 64000)
- Updated calculate_costs with pricing for new model
- Updated all related test files
- Fixed pylint issues in trim_messages.py (reduced nesting with early returns)
- Fixed pyright type issues in evaluate_condition.py