### PR TITLE
Fix duplicate update_usage call in check_run_handler when older activ…

### DIFF
--- a/services/webhook/check_run_handler.py
+++ b/services/webhook/check_run_handler.py
@@ -433,16 +433,6 @@ def handle_check_run(
             msg = f"Stopped - older active test failure request found for PR #{pull_number} in `{owner_name}/{repo_name}`. Avoiding race condition."
             logging.info(msg)
             slack_notify(msg, thread_ts)
-
-            # Mark current request as completed and exit
-            update_usage(
-                usage_id=usage_id,
-                token_input=total_token_input,
-                token_output=total_token_output,
-                total_seconds=int(time.time() - current_time),
-                is_completed=True,
-                pr_number=pull_number,
-            )
             break
 
         # Explore repo


### PR DESCRIPTION
…e request detected

The older active request check was calling update_usage before breaking from the while loop, then the function continued and called update_usage again at the end (line 528). This caused update_usage to be called twice.

Fixed by removing the duplicate update_usage call inside the older active request check, making it consistent with other early exit cases (timeout, PR closed, branch deleted) which only rely on the final update_usage call.

Also added missing mocks (is_pull_request_open, check_branch_exists) to test_handle_check_run_skips_duplicate_older_request and updated slack_notify call count assertion from 2 to 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)