### PR TITLE
Fix npm install in Lambda by setting npm cache to temp directory

### DIFF
--- a/services/eslint/run_eslint.py
+++ b/services/eslint/run_eslint.py
@@ -70,6 +70,8 @@ def run_eslint(
 
         if packages_to_install:
             logging.info("ESLint: Installing packages via npm...")
+            npm_env = os.environ.copy()
+            npm_env["npm_config_cache"] = os.path.join(temp_dir, ".npm")
             npm_result = subprocess.run(
                 ["npm", "install", "--no-save", "--prefix", temp_dir]
                 + packages_to_install,
@@ -78,6 +80,7 @@ def run_eslint(
                 timeout=120,
                 check=False,
                 cwd=temp_dir,
+                env=npm_env,
             )
             if npm_result.returncode != 0:
                 logging.error(


### PR DESCRIPTION
Lambda environment has limited writable directories - only /tmp is writable. npm was trying to create cache in /home/sbx_user1051 which doesn't exist, causing ENOENT errors (AGENT-1PN, AGENT-1PP).

Set npm_config_cache environment variable to use temp directory instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)