### PR TITLE
Filter out AI bot review comments to prevent webhook loops

### DIFF
--- a/services/webhook/review_run_handler.py
+++ b/services/webhook/review_run_handler.py
@@ -49,6 +49,11 @@ def handle_review_run(
     # review_position: int = review["position"]
     review_body: str = review["body"]
 
+    comment_author: dict[str, Any] = review["user"]
+    comment_author_type: str = comment_author["type"]
+    if comment_author_type == "Bot":
+        return
+
     # Extract repository related variables
     repo: Repository = payload["repository"]
     repo_id: int = repo["id"]


### PR DESCRIPTION
Prevent GitAuto from responding to review comments made by AI bots (like codereviewbot-ai[bot]) by checking the comment author's type. This prevents expensive feedback loops where bots comment on each other's PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)