### PR TITLE
Add automated database size monitoring and cleanup

### DIFF
--- a/.github/scripts/check_table_size.sh
+++ b/.github/scripts/check_table_size.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+TABLE_NAME="${1:-llm_requests}"
+
+SIZE_MB=$(PGPASSWORD="$SUPABASE_DB_PASSWORD_PRD" psql \
+  -h "aws-0-us-west-1.pooler.supabase.com" \
+  -U "postgres.awegqusxzsmlgxaxyyrq" \
+  -d postgres \
+  -p 6543 \
+  -t \
+  -c "SELECT pg_total_relation_size('$TABLE_NAME') / (1024 * 1024)")
+
+echo "$SIZE_MB" | xargs

--- a/.github/scripts/vacuum_table.sh
+++ b/.github/scripts/vacuum_table.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+TABLE_NAME="${1:-llm_requests}"
+
+echo "Running VACUUM FULL on $TABLE_NAME..."
+PGPASSWORD="$SUPABASE_DB_PASSWORD_PRD" psql \
+  -h "aws-0-us-west-1.pooler.supabase.com" \
+  -U "postgres.awegqusxzsmlgxaxyyrq" \
+  -d postgres \
+  -p 6543 \
+  -c "VACUUM FULL $TABLE_NAME"
+
+echo "✓ Vacuum completed for $TABLE_NAME"

--- a/.github/workflows/check-database-size.yml
+++ b/.github/workflows/check-database-size.yml
@@ -1,0 +1,71 @@
+name: Check Database Size and Cleanup
+
+on:
+  schedule:
+    # Run daily at 2 AM UTC to monitor database size
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  check-and-cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client bc
+
+      - name: Check database size and cleanup if needed
+        env:
+          SUPABASE_DB_PASSWORD_PRD: ${{ secrets.PROD_SUPABASE_DB_PASSWORD }}
+          SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          THRESHOLD_MB=200
+          TABLE_NAME=llm_requests
+          RETENTION_DAYS=14
+
+          chmod +x .github/scripts/check_table_size.sh
+          chmod +x .github/scripts/vacuum_table.sh
+
+          SIZE_MB=$(.github/scripts/check_table_size.sh "$TABLE_NAME")
+          echo "Current $TABLE_NAME table size: $SIZE_MB MB"
+
+          if [ $(echo "$SIZE_MB > $THRESHOLD_MB" | bc -l) -eq 1 ]; then
+            echo "⚠️  Size exceeds threshold ($THRESHOLD_MB MB). Starting cleanup..."
+
+            SIZE_BEFORE=$SIZE_MB
+
+            echo "Clearing old content via Python..."
+            python3 << 'EOF'
+          from services.supabase.llm_requests.clear_old_content import clear_old_content
+          result = clear_old_content(retention_days=14)
+          print(f"✓ Cleared content from records older than 14 days")
+          EOF
+
+            .github/scripts/vacuum_table.sh "$TABLE_NAME"
+
+            SIZE_AFTER=$(.github/scripts/check_table_size.sh "$TABLE_NAME")
+            FREED=$(echo "$SIZE_BEFORE - $SIZE_AFTER" | bc)
+            echo "✓ New size: $SIZE_AFTER MB (freed $FREED MB)"
+
+            if [ $(echo "$SIZE_AFTER > $THRESHOLD_MB" | bc -l) -eq 1 ]; then
+              echo "❌ WARNING: Size still exceeds threshold after cleanup!"
+              exit 1
+            fi
+          else
+            echo "✓ Size is under threshold ($THRESHOLD_MB MB). No cleanup needed."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/scripts/
 .coverage*
 .env*
 .history
@@ -9,6 +10,5 @@ coverage/
 mcp.json
 ngrok.yml
 pylint_results.txt
-scripts/
 tmp
 venv

--- a/services/supabase/llm_requests/clear_old_content.py
+++ b/services/supabase/llm_requests/clear_old_content.py
@@ -1,0 +1,17 @@
+from datetime import datetime, timedelta
+from services.supabase.client import supabase
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=None, raise_on_error=False)
+def clear_old_content(retention_days: int = 14):
+    cutoff_date = (datetime.now() - timedelta(days=retention_days)).isoformat()
+
+    result = (
+        supabase.table("llm_requests")
+        .update({"input_content": "", "output_content": ""})
+        .lt("created_at", cutoff_date)
+        .execute()
+    )
+
+    return result.data if result.data else None


### PR DESCRIPTION
- Create GitHub Actions workflow to check llm_requests table size daily
- Add shell scripts for checking table size and running VACUUM
- Add Python function to clear old content via Supabase client
- Update .gitignore to exclude /scripts/ but allow .github/scripts/
- Trigger cleanup when table exceeds 200MB threshold
- Keep last 14 days of content to prevent database restrictions