### PR TITLE
Add webhook deduplication to prevent duplicate Lambda invocations

### DIFF
--- a/services/supabase/webhook_deliveries/insert_webhook_delivery.py
+++ b/services/supabase/webhook_deliveries/insert_webhook_delivery.py
@@ -1,0 +1,16 @@
+from services.supabase.client import supabase
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=False, raise_on_error=False)
+def insert_webhook_delivery(delivery_id: str, event_name: str):
+    result = (
+        supabase.table("webhook_deliveries")
+        .insert({"delivery_id": delivery_id, "event_name": event_name})
+        .execute()
+    )
+
+    if result.data and len(result.data) > 0:
+        return True
+
+    return False

--- a/services/webhook/utils/test_create_pr_checkbox_comment.py
+++ b/services/webhook/utils/test_create_pr_checkbox_comment.py
@@ -4,11 +4,10 @@ from unittest.mock import patch
 
 import pytest
 from services.github.types.pull_request_webhook_payload import PullRequestWebhookPayload
-from utils.text.comment_identifiers import TEST_SELECTION_COMMENT_IDENTIFIER
-
 from services.webhook.utils.create_pr_checkbox_comment import (
     create_pr_checkbox_comment,
 )
+from utils.text.comment_identifiers import TEST_SELECTION_COMMENT_IDENTIFIER
 
 
 @pytest.fixture
@@ -130,22 +129,25 @@ def create_test_payload(
     branch_name="feature-branch",
 ):
     """Helper function to create a test payload."""
-    return cast(PullRequestWebhookPayload, {
-        "action": "opened",
-        "number": pull_number,
-        "sender": {"login": sender_name},
-        "repository": {
-            "id": repo_id,
-            "name": repo_name,
-            "owner": {"id": owner_id, "login": owner_name},
-        },
-        "pull_request": {
+    return cast(
+        PullRequestWebhookPayload,
+        {
+            "action": "opened",
             "number": pull_number,
-            "url": pull_url,
-            "head": {"ref": branch_name},
+            "sender": {"login": sender_name},
+            "repository": {
+                "id": repo_id,
+                "name": repo_name,
+                "owner": {"id": owner_id, "login": owner_name},
+            },
+            "pull_request": {
+                "number": pull_number,
+                "url": pull_url,
+                "head": {"ref": branch_name},
+            },
+            "installation": {"id": installation_id},
         },
-        "installation": {"id": installation_id},
-    })
+    )
 
 
 def test_skips_bot_sender(


### PR DESCRIPTION
- Create webhook_deliveries table with UNIQUE constraint on delivery_id for atomic duplicate detection
- Add insert_webhook_delivery() to handle atomic INSERT with deduplication
- Pass delivery_id through lambda_info to check_suite_handler for debugging
- Add logging to track delivery_id and check_suite_id in check_suite_handler
- Replace logging.info() with print() in check_suite_handler (logging.info doesn't show in CloudWatch)
- Setup pg_cron job to automatically cleanup webhook_deliveries older than 1 hour
- Fix import grouping in test_create_pr_checkbox_comment.py

This fixes the issue where 2-3 Lambda instances process the same check_suite webhook simultaneously, causing duplicate Slack notifications and race conditions.