### PR TITLE
Add two-layer deduplication for check_suite webhooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -754,30 +754,29 @@ When refactoring or replacing old systems, always be PROACTIVE and think compreh
 
 When the user says "LGTM" (Looks Good To Me), automatically execute this workflow:
 
-1. Activate virtual environment: `source venv/bin/activate`
-2. Run black formatting: `black .`
-3. Run ruff linting: `ruff check . --fix` (fix ALL ruff errors, not just modified files - if any errors remain unfixed, STOP and fix them before continuing)
-4. **CRITICAL**: Check `git status` FIRST to see ALL changes including deleted/renamed files
-5. Get list of modified, created, AND deleted files ONCE: `{ git diff --name-only; git diff --name-only --staged; git ls-files --others --exclude-standard; } | sort -u`
+1. Run black formatting: `black .`
+2. Run ruff linting: `ruff check . --fix` (fix ALL ruff errors, not just modified files - if any errors remain unfixed, STOP and fix them before continuing)
+3. **CRITICAL**: Check `git status` FIRST to see ALL changes including deleted/renamed files
+4. Get list of modified, created, AND deleted files ONCE: `{ git diff --name-only; git diff --name-only --staged; git ls-files --others --exclude-standard; } | sort -u`
    - This command captures: modified files, staged files, and newly created untracked files
    - NOTE: Deleted files that are already staged won't appear in this list but MUST be included in the commit
    - Store this list and use it for all subsequent steps
    - Extract Python files from this list: filter for `.py` files
    - Extract test files from this list: filter for `test_*.py` files
    - **CRITICAL**: For pylint, pyright, flake8, and pytest, filter out deleted files that no longer exist
-6. Run flake8 on the Python files identified in step 5 (excluding deleted files): `ls <files> 2>/dev/null | xargs flake8` - **IF ANY FLAKE8 ERRORS/WARNINGS ARE FOUND, FIX THEM ALL BEFORE CONTINUING**
-7. Run pylint on the Python files identified in step 5 (excluding deleted files): `ls <files> 2>/dev/null | xargs pylint` - **IF ANY PYLINT ERRORS/WARNINGS ARE FOUND, FIX THEM ALL BEFORE CONTINUING**
-8. Run pyright on the Python files identified in step 5 (excluding deleted files): `ls <files> 2>/dev/null | xargs pyright` - **IF ANY PYRIGHT ERRORS/WARNINGS ARE FOUND, FIX THEM ALL BEFORE CONTINUING**
-9. Run pytest on the test files identified in step 5 (excluding deleted files): `ls <test_files> 2>/dev/null | xargs python -m pytest` - **IF ANY TESTS FAIL, FIX THEM ALL BEFORE CONTINUING**
-10. Check current branch is not main: `git branch --show-current`
-11. Merge latest main: `git fetch origin main && git merge origin/main`
-12. **CRITICAL**: Review `git status` again to ensure ALL changes are staged:
-    - Add all modified/new files identified in step 5
+5. Run flake8 on the Python files identified in step 4 (excluding deleted files): `ls <files> 2>/dev/null | xargs flake8` - **IF ANY FLAKE8 ERRORS/WARNINGS ARE FOUND, FIX THEM ALL BEFORE CONTINUING**
+6. Run pylint on the Python files identified in step 4 (excluding deleted files): `ls <files> 2>/dev/null | xargs pylint` - **IF ANY PYLINT ERRORS/WARNINGS ARE FOUND, FIX THEM ALL BEFORE CONTINUING**
+7. Run pyright on the Python files identified in step 4 (excluding deleted files): `ls <files> 2>/dev/null | xargs pyright` - **IF ANY PYRIGHT ERRORS/WARNINGS ARE FOUND, FIX THEM ALL BEFORE CONTINUING**
+8. Run pytest on the test files identified in step 4 (excluding deleted files): `ls <test_files> 2>/dev/null | xargs python -m pytest` - **IF ANY TESTS FAIL, FIX THEM ALL BEFORE CONTINUING**
+9. Check current branch is not main: `git branch --show-current`
+10. Merge latest main: `git fetch origin main && git merge origin/main`
+11. **CRITICAL**: Review `git status` again to ensure ALL changes are staged:
+    - Add all modified/new files identified in step 4
     - Ensure deleted files are staged (they should already be if renamed with `mv`)
     - Use specific file names: `git add file1.py file2.py file3.py` (**NEVER use `git add .`**)
     - For deleted files already staged, they'll be included automatically in the commit
-13. Commit with descriptive message: `git commit -m "descriptive message"` (NO Claude credits in commit message)
-14. Push to remote: `git push`
+12. Commit with descriptive message: `git commit -m "descriptive message"` (NO Claude credits in commit message)
+13. Push to remote: `git push`
 
 **CRITICAL GIT RULES:**
 

--- a/services/supabase/check_suites/insert_check_suite.py
+++ b/services/supabase/check_suites/insert_check_suite.py
@@ -1,0 +1,16 @@
+from services.supabase.client import supabase
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=False, raise_on_error=False)
+def insert_check_suite(check_suite_id: int):
+    result = (
+        supabase.table("check_suites")
+        .insert({"check_suite_id": check_suite_id})
+        .execute()
+    )
+
+    if result.data and len(result.data) > 0:
+        return True
+
+    return False

--- a/services/supabase/check_suites/test_insert_check_suite.py
+++ b/services/supabase/check_suites/test_insert_check_suite.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from services.supabase.check_suites.insert_check_suite import insert_check_suite
+
+
+@pytest.fixture
+def mock_supabase_client():
+    with patch("services.supabase.check_suites.insert_check_suite.supabase") as mock:
+        mock_table = MagicMock()
+        mock_insert = MagicMock()
+        mock_execute = MagicMock()
+
+        mock.table.return_value = mock_table
+        mock_table.insert.return_value = mock_insert
+        mock_insert.execute.return_value = mock_execute
+
+        yield mock, mock_execute
+
+
+def test_insert_check_suite_success(mock_supabase_client):
+    mock, mock_execute = mock_supabase_client
+    mock_execute.data = [{"check_suite_id": 12345, "created_at": "2025-12-18T00:00:00"}]
+
+    result = insert_check_suite(check_suite_id=12345)
+
+    assert result is True
+    mock.table.assert_called_once_with("check_suites")
+    mock.table.return_value.insert.assert_called_once_with({"check_suite_id": 12345})
+    mock.table.return_value.insert.return_value.execute.assert_called_once()
+
+
+def test_insert_check_suite_duplicate(mock_supabase_client):
+    _, mock_execute = mock_supabase_client
+    mock_execute.data = []
+
+    result = insert_check_suite(check_suite_id=12345)
+
+    assert result is False
+
+
+def test_insert_check_suite_exception_returns_false(mock_supabase_client):
+    mock, _ = mock_supabase_client
+    mock.table.return_value.insert.return_value.execute.side_effect = Exception(
+        "Database error"
+    )
+
+    result = insert_check_suite(check_suite_id=12345)
+
+    assert result is False

--- a/services/supabase/webhook_deliveries/test_insert_webhook_delivery.py
+++ b/services/supabase/webhook_deliveries/test_insert_webhook_delivery.py
@@ -1,0 +1,63 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from services.supabase.webhook_deliveries.insert_webhook_delivery import (
+    insert_webhook_delivery,
+)
+
+
+@pytest.fixture
+def mock_supabase_client():
+    with patch(
+        "services.supabase.webhook_deliveries.insert_webhook_delivery.supabase"
+    ) as mock:
+        mock_table = MagicMock()
+        mock_insert = MagicMock()
+        mock_execute = MagicMock()
+
+        mock.table.return_value = mock_table
+        mock_table.insert.return_value = mock_insert
+        mock_insert.execute.return_value = mock_execute
+
+        yield mock, mock_execute
+
+
+def test_insert_webhook_delivery_success(mock_supabase_client):
+    mock, mock_execute = mock_supabase_client
+    mock_execute.data = [
+        {
+            "id": 1,
+            "delivery_id": "abc-123",
+            "event_name": "check_suite",
+            "created_at": "2025-12-18T00:00:00",
+        }
+    ]
+
+    result = insert_webhook_delivery(delivery_id="abc-123", event_name="check_suite")
+
+    assert result is True
+    mock.table.assert_called_once_with("webhook_deliveries")
+    mock.table.return_value.insert.assert_called_once_with(
+        {"delivery_id": "abc-123", "event_name": "check_suite"}
+    )
+    mock.table.return_value.insert.return_value.execute.assert_called_once()
+
+
+def test_insert_webhook_delivery_duplicate(mock_supabase_client):
+    _, mock_execute = mock_supabase_client
+    mock_execute.data = []
+
+    result = insert_webhook_delivery(delivery_id="abc-123", event_name="check_suite")
+
+    assert result is False
+
+
+def test_insert_webhook_delivery_exception_returns_false(mock_supabase_client):
+    mock, _ = mock_supabase_client
+    mock.table.return_value.insert.return_value.execute.side_effect = Exception(
+        "Database error"
+    )
+
+    result = insert_webhook_delivery(delivery_id="abc-123", event_name="check_suite")
+
+    assert result is False

--- a/services/webhook/check_suite_handler.py
+++ b/services/webhook/check_suite_handler.py
@@ -38,6 +38,7 @@ from services.github.workflow_runs.get_workflow_run_logs import get_workflow_run
 from services.slack.slack_notify import slack_notify
 
 # Local imports (Supabase)
+from services.supabase.check_suites.insert_check_suite import insert_check_suite
 from services.supabase.create_user_request import create_user_request
 from services.supabase.get_circleci_token import get_circleci_token
 from services.supabase.repositories.get_repository import get_repository
@@ -77,6 +78,12 @@ def handle_check_suite(
     print(
         f"handle_check_suite called for {owner_name}/{repo_name} check_suite_id={check_suite_id} delivery_id={delivery_id}"
     )
+
+    # Deduplicate by check_suite_id (GitHub may send duplicate webhooks with different delivery_ids)
+    if not insert_check_suite(check_suite_id=check_suite_id):
+        msg = f"Duplicate check_suite_id={check_suite_id} ignored for {owner_name}/{repo_name}"
+        print(msg)
+        return
 
     # Check if this is a GitAuto PR by branch name (early return)
     check_suite = payload["check_suite"]


### PR DESCRIPTION
Layer 1 (main.py): Deduplicate by delivery_id to prevent duplicate AWS Lambda invocations
Layer 2 (check_suite_handler.py): Deduplicate by check_suite_id to prevent GitHub duplicate webhooks
- a
- v
Created webhook_deliveries and check_suites tables with UNIQUE constraints and pg_cron cleanup jobs. Updated LGTM workflow in CLAUDE.md to remove venv activation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)