### PR TITLE
Fix scheduler duplicate issue creation and prioritize zero coverage f…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,50 @@ sys.path.insert(0, '/Users/rwest/Repositories/gitauto')
 from scripts.github.update_file import update_file
 ```
 
+## CRITICAL: Never Bypass Workflow Scripts
+
+**NEVER use git commands directly to bypass workflow scripts like commit_file.py or push_repo.py.**
+
+When workflow scripts fail, fix the ROOT CAUSE instead of working around them:
+
+**Example of WRONG approach:**
+
+```bash
+# Script fails because eslint is missing, so bypass it with git directly
+git -C /path/to/repo add file.ts && git -C /path/to/repo commit -m "message"
+
+# Or modify the script to skip validation
+# Or add exceptions to skip certain file types
+```
+
+**Example of CORRECT approach:**
+
+```bash
+# Script fails because eslint is missing
+# Install the missing dependencies
+npm install --prefix /path/to/repo
+# or
+yarn --cwd /path/to/repo install
+
+# Then use the proper workflow:
+python3 << 'EOF'
+from scripts.git.commit_file import commit_file
+from scripts.github.get_installation_token import get_installation_token
+
+token = get_installation_token('owner')
+commit_file(owner='owner', repo='repo', file_path='file.ts', pr_number=123, commit_message='message', token=token)
+EOF
+```
+
+**Why:** Workflow scripts exist for a reason (linting, validation, safety checks). Bypassing them leads to:
+
+- Code quality issues
+- Broken CI/CD pipelines
+- Inconsistent commit history
+- Missing safety checks
+
+**Always fix the fundamental issue (install missing tools) instead of working around it (skip validation).**
+
 ## CRITICAL: Web Search Best Practices
 
 **NEVER include years in search queries unless specifically searching for historical information.**

--- a/services/github/comments/combine_and_create_comment.py
+++ b/services/github/comments/combine_and_create_comment.py
@@ -22,7 +22,7 @@ def combine_and_create_comment(
     owner_name: str,
     sender_name: str,
     base_args: BaseArgs,
-) -> None:
+):
     # Check availability
     availability_status = check_availability(
         owner_id=owner_id,
@@ -66,4 +66,10 @@ def combine_and_create_comment(
         body = user_message
 
     # Create the comment
-    create_comment(body=body, base_args=base_args)
+    create_comment(
+        owner=owner_name,
+        repo=base_args["repo"],
+        token=base_args["token"],
+        issue_number=base_args["issue_number"],
+        body=body,
+    )

--- a/services/github/comments/create_comment.py
+++ b/services/github/comments/create_comment.py
@@ -1,16 +1,20 @@
 import requests
 from config import GITHUB_API_URL, TIMEOUT
-from services.github.types.github_types import BaseArgs
 from services.github.utils.create_headers import create_headers
 from utils.error.handle_exceptions import handle_exceptions
 
 
 @handle_exceptions(default_return_value=None, raise_on_error=False)
-def create_comment(body: str, base_args: BaseArgs):
+def create_comment(
+    *,
+    owner: str,
+    repo: str,
+    token: str,
+    issue_number: int,
+    body: str,
+    input_from: str = "github",
+):
     """https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment"""
-    owner, repo, token = base_args["owner"], base_args["repo"], base_args["token"]
-    issue_number = base_args["issue_number"]
-    input_from = base_args.get("input_from", "github")
 
     if input_from == "github":
         response = requests.post(

--- a/services/github/comments/test_combine_and_create_comment.py
+++ b/services/github/comments/test_combine_and_create_comment.py
@@ -101,7 +101,13 @@ def test_combine_and_create_comment_success_subscription_user(
         credit_balance_usd=0,
     )
     expected_body = base_comment + mock_request_issue_comment.return_value
-    mock_create_comment.assert_called_once_with(body=expected_body, base_args=base_args)
+    mock_create_comment.assert_called_once_with(
+        owner=owner_name,
+        repo=base_args["repo"],
+        token=base_args["token"],
+        issue_number=base_args["issue_number"],
+        body=expected_body,
+    )
 
 
 def test_combine_and_create_comment_credit_user(
@@ -149,7 +155,13 @@ def test_combine_and_create_comment_credit_user(
         credit_balance_usd=50,
     )
     expected_body = base_comment + mock_request_issue_comment.return_value
-    mock_create_comment.assert_called_once_with(body=expected_body, base_args=base_args)
+    mock_create_comment.assert_called_once_with(
+        owner=owner_name,
+        repo=base_args["repo"],
+        token=base_args["token"],
+        issue_number=base_args["issue_number"],
+        body=expected_body,
+    )
 
 
 def test_combine_and_create_comment_no_period_end_date(
@@ -183,7 +195,13 @@ def test_combine_and_create_comment_no_period_end_date(
 
     # Assert
     mock_request_issue_comment.assert_not_called()
-    mock_create_comment.assert_called_once_with(body=base_comment, base_args=base_args)
+    mock_create_comment.assert_called_once_with(
+        owner=owner_name,
+        repo=base_args["repo"],
+        token=base_args["token"],
+        issue_number=base_args["issue_number"],
+        body=base_comment,
+    )
 
 
 def test_combine_and_create_comment_default_end_date(
@@ -219,7 +237,13 @@ def test_combine_and_create_comment_default_end_date(
 
     # Assert
     mock_request_issue_comment.assert_not_called()
-    mock_create_comment.assert_called_once_with(body=base_comment, base_args=base_args)
+    mock_create_comment.assert_called_once_with(
+        owner=owner_name,
+        repo=base_args["repo"],
+        token=base_args["token"],
+        issue_number=base_args["issue_number"],
+        body=base_comment,
+    )
 
 
 def test_combine_and_create_comment_cannot_proceed_with_user_message(
@@ -265,7 +289,11 @@ def test_combine_and_create_comment_cannot_proceed_with_user_message(
         credit_balance_usd=0,
     )
     mock_create_comment.assert_called_once_with(
-        body="You have reached your request limit.", base_args=base_args
+        owner=owner_name,
+        repo=base_args["repo"],
+        token=base_args["token"],
+        issue_number=base_args["issue_number"],
+        body="You have reached your request limit.",
     )
 
 
@@ -305,7 +333,13 @@ def test_combine_and_create_comment_cannot_proceed_no_user_message(
 
     # Assert
     expected_body = base_comment + mock_request_issue_comment.return_value
-    mock_create_comment.assert_called_once_with(body=expected_body, base_args=base_args)
+    mock_create_comment.assert_called_once_with(
+        owner=owner_name,
+        repo=base_args["repo"],
+        token=base_args["token"],
+        issue_number=base_args["issue_number"],
+        body=expected_body,
+    )
 
 
 def test_combine_and_create_comment_product_id_replacement(
@@ -343,7 +377,11 @@ def test_combine_and_create_comment_product_id_replacement(
             + mock_request_issue_comment.return_value
         )
         mock_create_comment.assert_called_once_with(
-            body=expected_body, base_args=base_args
+            owner=owner_name,
+            repo=base_args["repo"],
+            token=base_args["token"],
+            issue_number=base_args["issue_number"],
+            body=expected_body,
         )
 
 
@@ -375,7 +413,13 @@ def test_combine_and_create_comment_no_product_id_replacement_for_gitauto(
 
     # Assert
     expected_body = base_comment + mock_request_issue_comment.return_value
-    mock_create_comment.assert_called_once_with(body=expected_body, base_args=base_args)
+    mock_create_comment.assert_called_once_with(
+        owner=owner_name,
+        repo=base_args["repo"],
+        token=base_args["token"],
+        issue_number=base_args["issue_number"],
+        body=expected_body,
+    )
 
 
 def test_combine_and_create_comment_product_id_replacement_only_when_generate_present(
@@ -410,7 +454,11 @@ def test_combine_and_create_comment_product_id_replacement_only_when_generate_pr
         # Assert
         expected_body = base_comment + mock_request_issue_comment.return_value
         mock_create_comment.assert_called_once_with(
-            body=expected_body, base_args=base_args
+            owner=owner_name,
+            repo=base_args["repo"],
+            token=base_args["token"],
+            issue_number=base_args["issue_number"],
+            body=expected_body,
         )
 
 
@@ -568,7 +616,11 @@ def test_combine_and_create_comment_partial_generate_replacement(
             + mock_request_issue_comment.return_value
         )
         mock_create_comment.assert_called_once_with(
-            body=expected_body, base_args=base_args
+            owner=owner_name,
+            repo=base_args["repo"],
+            token=base_args["token"],
+            issue_number=base_args["issue_number"],
+            body=expected_body,
         )
 
 
@@ -604,5 +656,9 @@ def test_combine_and_create_comment_case_sensitive_generate(
         # Assert - should not replace lowercase 'generate'
         expected_body = base_comment + mock_request_issue_comment.return_value
         mock_create_comment.assert_called_once_with(
-            body=expected_body, base_args=base_args
+            owner=owner_name,
+            repo=base_args["repo"],
+            token=base_args["token"],
+            issue_number=base_args["issue_number"],
+            body=expected_body,
         )

--- a/services/github/comments/test_create_comment.py
+++ b/services/github/comments/test_create_comment.py
@@ -3,22 +3,12 @@ from unittest.mock import patch, MagicMock
 from services.github.comments.create_comment import create_comment
 
 
-def test_create_comment_github_success(
-    test_owner, test_repo, test_token, create_test_base_args
-):
+def test_create_comment_github_success(test_owner, test_repo, test_token):
     # Arrange
     mock_response = MagicMock()
     mock_response.json.return_value = {
         "url": "https://api.github.com/repos/owner/repo/issues/comments/123"
     }
-
-    base_args = create_test_base_args(
-        owner=test_owner,
-        repo=test_repo,
-        token=test_token,
-        issue_number=123,
-        input_from="github",
-    )
 
     # Act
     with patch(
@@ -28,7 +18,14 @@ def test_create_comment_github_success(
     ) as mock_create_headers:
         mock_create_headers.return_value = {"Authorization": f"Bearer {test_token}"}
         mock_post.return_value = mock_response
-        result = create_comment("Test comment", base_args)
+        result = create_comment(
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            issue_number=123,
+            body="Test comment",
+            input_from="github",
+        )
 
     # Assert
     mock_post.assert_called_once()
@@ -36,88 +33,78 @@ def test_create_comment_github_success(
     assert result == "https://api.github.com/repos/owner/repo/issues/comments/123"
 
 
-def test_create_comment_github_default_input_from(
-    test_owner, test_repo, test_token, create_test_base_args
-):
+def test_create_comment_github_default_input_from(test_owner, test_repo, test_token):
     # Arrange
     mock_response = MagicMock()
     mock_response.json.return_value = {
         "url": "https://api.github.com/repos/owner/repo/issues/comments/123"
     }
 
-    # Base args without input_from should default to "github"
-    base_args = create_test_base_args(
-        owner=test_owner, repo=test_repo, token=test_token, issue_number=123
-    )
-
     # Act
     with patch("services.github.comments.create_comment.requests.post") as mock_post:
         mock_post.return_value = mock_response
-        result = create_comment("Test comment", base_args)
+        result = create_comment(
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            issue_number=123,
+            body="Test comment",
+        )
 
     # Assert
     mock_post.assert_called_once()
     assert result == "https://api.github.com/repos/owner/repo/issues/comments/123"
 
 
-def test_create_comment_jira(test_owner, test_repo, test_token, create_test_base_args):
-    # Arrange
-    base_args = create_test_base_args(
-        owner=test_owner,
-        repo=test_repo,
-        token=test_token,
-        issue_number=123,
-        input_from="jira",
-    )
-
+def test_create_comment_jira(test_owner, test_repo, test_token):
     # Act
     with patch("services.github.comments.create_comment.requests.post") as mock_post:
-        result = create_comment("Test comment", base_args)
+        result = create_comment(
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            issue_number=123,
+            body="Test comment",
+            input_from="jira",
+        )
 
     # Assert
     mock_post.assert_not_called()
     assert result is None
 
 
-def test_create_comment_request_error(
-    test_owner, test_repo, test_token, create_test_base_args
-):
+def test_create_comment_request_error(test_owner, test_repo, test_token):
     # Arrange
     mock_response = MagicMock()
     mock_response.raise_for_status.side_effect = Exception("API error")
 
-    base_args = create_test_base_args(
-        owner=test_owner,
-        repo=test_repo,
-        token=test_token,
-        issue_number=123,
-        input_from="github",
-    )
-
     # Act
     with patch("services.github.comments.create_comment.requests.post") as mock_post:
         mock_post.return_value = mock_response
-        result = create_comment("Test comment", base_args)
+        result = create_comment(
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            issue_number=123,
+            body="Test comment",
+            input_from="github",
+        )
 
     # Assert
-    assert result is None  # The handle_exceptions decorator should return None on error
+    assert result is None
 
 
-def test_create_comment_unknown_input_from(
-    test_owner, test_repo, test_token, create_test_base_args
-):
-    # Arrange
-    base_args = create_test_base_args(
-        owner=test_owner,
-        repo=test_repo,
-        token=test_token,
-        issue_number=123,
-        input_from="unknown",  # Neither github nor jira
-    )
-
+def test_create_comment_unknown_input_from(test_owner, test_repo, test_token):
     # Act
     with patch("services.github.comments.create_comment.requests.post") as mock_post:
-        result = create_comment("Test comment", base_args)
+        result = create_comment(
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            issue_number=123,
+            body="Test comment",
+            input_from="unknown",
+        )
 
     # Assert
     mock_post.assert_not_called()

--- a/services/github/issues/create_issue.py
+++ b/services/github/issues/create_issue.py
@@ -2,18 +2,22 @@ import logging
 from typing import cast
 import requests
 from config import GITHUB_API_URL, PRODUCT_ID, TIMEOUT
-from services.github.types.github_types import BaseArgs
 from services.github.types.issue import Issue
 from services.github.utils.create_headers import create_headers
 from utils.error.handle_exceptions import handle_exceptions
 
 
 @handle_exceptions(default_return_value=(500, None), raise_on_error=False)
-def create_issue(title: str, body: str, assignees: list[str], base_args: BaseArgs):
+def create_issue(
+    *,
+    owner: str,
+    repo: str,
+    token: str,
+    title: str,
+    body: str,
+    assignees: list[str],
+):
     """https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#create-an-issue"""
-    owner = base_args["owner"]
-    repo = base_args["repo"]
-    token = base_args["token"]
     labels = [PRODUCT_ID]
 
     payload = {

--- a/services/github/issues/test_create_issue.py
+++ b/services/github/issues/test_create_issue.py
@@ -5,9 +5,7 @@ import requests
 from services.github.issues.create_issue import create_issue
 
 
-def test_create_issue_success_with_assignees(
-    test_owner, test_repo, test_token, create_test_base_args
-):
+def test_create_issue_success_with_assignees(test_owner, test_repo, test_token):
     mock_response = MagicMock()
     mock_response.raise_for_status.return_value = None
     mock_response.status_code = 200
@@ -15,10 +13,6 @@ def test_create_issue_success_with_assignees(
         "id": 123,
         "html_url": "https://github.com/owner/repo/issues/123",
     }
-
-    base_args = create_test_base_args(
-        owner=test_owner, repo=test_repo, token=test_token
-    )
 
     with patch("services.github.issues.create_issue.requests.post") as mock_post, patch(
         "services.github.issues.create_issue.create_headers"
@@ -29,7 +23,12 @@ def test_create_issue_success_with_assignees(
         mock_post.return_value = mock_response
 
         status_code, result = create_issue(
-            "Test Title", "Test Body", ["user1", "user2"], base_args
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            title="Test Title",
+            body="Test Body",
+            assignees=["user1", "user2"],
         )
 
     mock_post.assert_called_once()
@@ -44,9 +43,7 @@ def test_create_issue_success_with_assignees(
     assert result == {"id": 123, "html_url": "https://github.com/owner/repo/issues/123"}
 
 
-def test_create_issue_success_without_assignees(
-    test_owner, test_repo, test_token, create_test_base_args
-):
+def test_create_issue_success_without_assignees(test_owner, test_repo, test_token):
     mock_response = MagicMock()
     mock_response.raise_for_status.return_value = None
     mock_response.status_code = 200
@@ -54,10 +51,6 @@ def test_create_issue_success_without_assignees(
         "id": 456,
         "html_url": "https://github.com/owner/repo/issues/456",
     }
-
-    base_args = create_test_base_args(
-        owner=test_owner, repo=test_repo, token=test_token
-    )
 
     with patch("services.github.issues.create_issue.requests.post") as mock_post, patch(
         "services.github.issues.create_issue.create_headers"
@@ -67,7 +60,14 @@ def test_create_issue_success_without_assignees(
         mock_create_headers.return_value = {"Authorization": f"Bearer {test_token}"}
         mock_post.return_value = mock_response
 
-        status_code, result = create_issue("Test Title", "Test Body", [], base_args)
+        status_code, result = create_issue(
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            title="Test Title",
+            body="Test Body",
+            assignees=[],
+        )
 
     mock_post.assert_called_once()
     call_args = mock_post.call_args
@@ -82,7 +82,7 @@ def test_create_issue_success_without_assignees(
 
 
 def test_create_issue_success_with_empty_assignees_list(
-    test_owner, test_repo, test_token, create_test_base_args
+    test_owner, test_repo, test_token
 ):
     mock_response = MagicMock()
     mock_response.raise_for_status.return_value = None
@@ -92,10 +92,6 @@ def test_create_issue_success_with_empty_assignees_list(
         "html_url": "https://github.com/owner/repo/issues/789",
     }
 
-    base_args = create_test_base_args(
-        owner=test_owner, repo=test_repo, token=test_token
-    )
-
     with patch("services.github.issues.create_issue.requests.post") as mock_post, patch(
         "services.github.issues.create_issue.create_headers"
     ) as mock_create_headers, patch(
@@ -104,7 +100,14 @@ def test_create_issue_success_with_empty_assignees_list(
         mock_create_headers.return_value = {"Authorization": f"Bearer {test_token}"}
         mock_post.return_value = mock_response
 
-        status_code, result = create_issue("Test Title", "Test Body", [], base_args)
+        status_code, result = create_issue(
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            title="Test Title",
+            body="Test Body",
+            assignees=[],
+        )
 
     call_args = mock_post.call_args
     assert "assignees" not in call_args.kwargs["json"]
@@ -113,9 +116,7 @@ def test_create_issue_success_with_empty_assignees_list(
     assert result == {"id": 789, "html_url": "https://github.com/owner/repo/issues/789"}
 
 
-def test_create_issue_http_error(
-    test_owner, test_repo, test_token, create_test_base_args
-):
+def test_create_issue_http_error(test_owner, test_repo, test_token):
     mock_response = MagicMock()
     # Create a proper HTTPError with a response object
     http_error = requests.HTTPError("404 Not Found")
@@ -126,10 +127,6 @@ def test_create_issue_http_error(
     http_error.response = mock_error_response
     mock_response.raise_for_status.side_effect = http_error
 
-    base_args = create_test_base_args(
-        owner=test_owner, repo=test_repo, token=test_token
-    )
-
     with patch("services.github.issues.create_issue.requests.post") as mock_post, patch(
         "services.github.issues.create_issue.create_headers"
     ) as mock_create_headers, patch(
@@ -139,7 +136,12 @@ def test_create_issue_http_error(
         mock_post.return_value = mock_response
 
         status_code, result = create_issue(
-            "Test Title", "Test Body", ["user1"], base_args
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            title="Test Title",
+            body="Test Body",
+            assignees=["user1"],
         )
 
     mock_response.raise_for_status.assert_called_once()
@@ -147,13 +149,7 @@ def test_create_issue_http_error(
     assert result is None
 
 
-def test_create_issue_request_exception(
-    test_owner, test_repo, test_token, create_test_base_args
-):
-    base_args = create_test_base_args(
-        owner=test_owner, repo=test_repo, token=test_token
-    )
-
+def test_create_issue_request_exception(test_owner, test_repo, test_token):
     with patch("services.github.issues.create_issue.requests.post") as mock_post, patch(
         "services.github.issues.create_issue.create_headers"
     ) as mock_create_headers, patch(
@@ -163,16 +159,19 @@ def test_create_issue_request_exception(
         mock_post.side_effect = requests.RequestException("Connection error")
 
         status_code, result = create_issue(
-            "Test Title", "Test Body", ["user1"], base_args
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            title="Test Title",
+            body="Test Body",
+            assignees=["user1"],
         )
 
     assert status_code == 500
     assert result is None
 
 
-def test_create_issue_with_none_assignees(
-    test_owner, test_repo, test_token, create_test_base_args
-):
+def test_create_issue_with_none_assignees(test_owner, test_repo, test_token):
     mock_response = MagicMock()
     mock_response.raise_for_status.return_value = None
     mock_response.status_code = 200
@@ -180,10 +179,6 @@ def test_create_issue_with_none_assignees(
         "id": 101,
         "html_url": "https://github.com/owner/repo/issues/101",
     }
-
-    base_args = create_test_base_args(
-        owner=test_owner, repo=test_repo, token=test_token
-    )
 
     with patch("services.github.issues.create_issue.requests.post") as mock_post, patch(
         "services.github.issues.create_issue.create_headers"
@@ -193,7 +188,14 @@ def test_create_issue_with_none_assignees(
         mock_create_headers.return_value = {"Authorization": f"Bearer {test_token}"}
         mock_post.return_value = mock_response
 
-        status_code, result = create_issue("Test Title", "Test Body", [], base_args)
+        status_code, result = create_issue(
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            title="Test Title",
+            body="Test Body",
+            assignees=[],
+        )
 
     call_args = mock_post.call_args
     assert "assignees" not in call_args.kwargs["json"]
@@ -202,7 +204,7 @@ def test_create_issue_with_none_assignees(
     assert result == {"id": 101, "html_url": "https://github.com/owner/repo/issues/101"}
 
 
-def test_create_issue_api_url_construction(create_test_base_args):
+def test_create_issue_api_url_construction():
     mock_response = MagicMock()
     mock_response.raise_for_status.return_value = None
     mock_response.status_code = 200
@@ -210,10 +212,6 @@ def test_create_issue_api_url_construction(create_test_base_args):
         "id": 202,
         "html_url": "https://github.com/test-owner/test-repo/issues/202",
     }
-
-    base_args = create_test_base_args(
-        owner="test-owner", repo="test-repo", token="test-token"
-    )
 
     with patch("services.github.issues.create_issue.requests.post") as mock_post, patch(
         "services.github.issues.create_issue.create_headers"
@@ -225,7 +223,14 @@ def test_create_issue_api_url_construction(create_test_base_args):
         mock_create_headers.return_value = {"Authorization": "Bearer test-token"}
         mock_post.return_value = mock_response
 
-        create_issue("Test Title", "Test Body", ["user1"], base_args)
+        create_issue(
+            owner="test-owner",
+            repo="test-repo",
+            token="test-token",
+            title="Test Title",
+            body="Test Body",
+            assignees=["user1"],
+        )
 
     call_args = mock_post.call_args
     assert (
@@ -234,9 +239,7 @@ def test_create_issue_api_url_construction(create_test_base_args):
     )
 
 
-def test_create_issue_timeout_parameter(
-    test_owner, test_repo, test_token, create_test_base_args
-):
+def test_create_issue_timeout_parameter(test_owner, test_repo, test_token):
     mock_response = MagicMock()
     mock_response.raise_for_status.return_value = None
     mock_response.status_code = 200
@@ -244,10 +247,6 @@ def test_create_issue_timeout_parameter(
         "id": 303,
         "html_url": "https://github.com/owner/repo/issues/303",
     }
-
-    base_args = create_test_base_args(
-        owner=test_owner, repo=test_repo, token=test_token
-    )
 
     with patch("services.github.issues.create_issue.requests.post") as mock_post, patch(
         "services.github.issues.create_issue.create_headers"
@@ -259,13 +258,20 @@ def test_create_issue_timeout_parameter(
         mock_create_headers.return_value = {"Authorization": f"Bearer {test_token}"}
         mock_post.return_value = mock_response
 
-        create_issue("Test Title", "Test Body", ["user1"], base_args)
+        create_issue(
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            title="Test Title",
+            body="Test Body",
+            assignees=["user1"],
+        )
 
     call_args = mock_post.call_args
     assert call_args.kwargs["timeout"] == 60
 
 
-def test_create_issue_headers_creation(test_owner, test_repo, create_test_base_args):
+def test_create_issue_headers_creation(test_owner, test_repo):
     mock_response = MagicMock()
     mock_response.raise_for_status.return_value = None
     mock_response.status_code = 200
@@ -273,10 +279,6 @@ def test_create_issue_headers_creation(test_owner, test_repo, create_test_base_a
         "id": 404,
         "html_url": "https://github.com/owner/repo/issues/404",
     }
-
-    base_args = create_test_base_args(
-        owner=test_owner, repo=test_repo, token="test-token-123"
-    )
 
     with patch("services.github.issues.create_issue.requests.post") as mock_post, patch(
         "services.github.issues.create_issue.create_headers"
@@ -286,16 +288,21 @@ def test_create_issue_headers_creation(test_owner, test_repo, create_test_base_a
         mock_create_headers.return_value = {"Authorization": "Bearer test-token-123"}
         mock_post.return_value = mock_response
 
-        create_issue("Test Title", "Test Body", [], base_args)
+        create_issue(
+            owner=test_owner,
+            repo=test_repo,
+            token="test-token-123",
+            title="Test Title",
+            body="Test Body",
+            assignees=[],
+        )
 
     mock_create_headers.assert_called_once_with(token="test-token-123")
     call_args = mock_post.call_args
     assert call_args.kwargs["headers"] == {"Authorization": "Bearer test-token-123"}
 
 
-def test_create_issue_retry_on_invalid_assignees(
-    test_owner, test_repo, test_token, create_test_base_args
-):
+def test_create_issue_retry_on_invalid_assignees(test_owner, test_repo, test_token):
     # Mock first response with 422 error
     mock_first_response = MagicMock()
     mock_first_response.status_code = 422
@@ -310,10 +317,6 @@ def test_create_issue_retry_on_invalid_assignees(
         "html_url": "https://github.com/owner/repo/issues/555",
     }
 
-    base_args = create_test_base_args(
-        owner=test_owner, repo=test_repo, token=test_token
-    )
-
     with patch("services.github.issues.create_issue.requests.post") as mock_post, patch(
         "services.github.issues.create_issue.create_headers"
     ) as mock_create_headers, patch(
@@ -324,7 +327,12 @@ def test_create_issue_retry_on_invalid_assignees(
         mock_post.side_effect = [mock_first_response, mock_second_response]
 
         status_code, result = create_issue(
-            "Test Title", "Test Body", ["Copilot"], base_args
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            title="Test Title",
+            body="Test Body",
+            assignees=["Copilot"],
         )
 
     # Should make two calls - first with assignees, second without
@@ -347,17 +355,11 @@ def test_create_issue_retry_on_invalid_assignees(
     assert result == {"id": 555, "html_url": "https://github.com/owner/repo/issues/555"}
 
 
-def test_create_issue_410_issues_disabled(
-    test_owner, test_repo, test_token, create_test_base_args
-):
+def test_create_issue_410_issues_disabled(test_owner, test_repo, test_token):
     """Test that create_issue handles 410 Gone (issues disabled) correctly."""
     mock_response = MagicMock()
     mock_response.status_code = 410
     mock_response.raise_for_status.return_value = None  # Won't be called for 410
-
-    base_args = create_test_base_args(
-        owner=test_owner, repo=test_repo, token=test_token
-    )
 
     with patch("services.github.issues.create_issue.requests.post") as mock_post, patch(
         "services.github.issues.create_issue.create_headers"
@@ -370,7 +372,12 @@ def test_create_issue_410_issues_disabled(
         mock_post.return_value = mock_response
 
         status_code, result = create_issue(
-            "Test Title", "Test Body", ["user1"], base_args
+            owner=test_owner,
+            repo=test_repo,
+            token=test_token,
+            title="Test Title",
+            body="Test Body",
+            assignees=["user1"],
         )
 
     # Verify the function returns 410 status and None

--- a/services/supabase/coverages/insert_coverages.py
+++ b/services/supabase/coverages/insert_coverages.py
@@ -1,9 +1,9 @@
-from schemas.supabase.types import Coverages
+from schemas.supabase.types import CoveragesInsert
 from services.supabase.client import supabase
 from utils.error.handle_exceptions import handle_exceptions
 
 
 @handle_exceptions(default_return_value=None, raise_on_error=False)
-def insert_coverages(coverage_record: Coverages):
-    result = supabase.table("coverages").insert(coverage_record).execute()
+def insert_coverages(coverage_record: CoveragesInsert):
+    result = supabase.table("coverages").insert(dict(coverage_record)).execute()
     return result.data

--- a/services/supabase/coverages/test_insert_coverages.py
+++ b/services/supabase/coverages/test_insert_coverages.py
@@ -54,8 +54,9 @@ def test_insert_coverages_successful_insertion(mock_supabase, sample_coverage_re
 
     assert result == expected_data
     mock_supabase.table.assert_called_once_with("coverages")
+    # Verify insert is called with dict() wrapper to convert TypedDict to plain dict
     mock_supabase.table.return_value.insert.assert_called_once_with(
-        sample_coverage_record
+        dict(sample_coverage_record)
     )
     mock_supabase.table.return_value.insert.return_value.execute.assert_called_once()
 

--- a/services/webhook/check_suite_handler.py
+++ b/services/webhook/check_suite_handler.py
@@ -223,7 +223,13 @@ def handle_check_suite(
     msg = CHECK_RUN_STUMBLED_MESSAGE
     log_messages.append(msg)
     body = create_progress_bar(p=p, msg="\n".join(log_messages))
-    comment_url = create_comment(body=body, base_args=base_args)
+    comment_url = create_comment(
+        owner=owner_name,
+        repo=repo_name,
+        token=token,
+        issue_number=pull_number,
+        body=body,
+    )
     base_args["comment_url"] = comment_url
 
     # Create a usage record

--- a/services/webhook/issue_handler.py
+++ b/services/webhook/issue_handler.py
@@ -127,7 +127,13 @@ def create_pr_from_issue(
     msg = "Got your request."
     log_messages.append(msg)
     comment_body = create_progress_bar(p=p, msg="\n".join(log_messages))
-    comment_url: str | None = create_comment(body=comment_body, base_args=base_args)
+    comment_url = create_comment(
+        owner=owner_name,
+        repo=repo_name,
+        token=base_args["token"],
+        issue_number=issue_number,
+        body=comment_body,
+    )
     base_args["comment_url"] = comment_url
 
     # Get some base args
@@ -275,7 +281,13 @@ def create_pr_from_issue(
         description = describe_image(base64_image=base64_image, context=context)
         description = f"## {url['alt']}\n\n{description}"
         issue_comments.append(description)
-        create_comment(body=description, base_args=base_args)
+        create_comment(
+            owner=owner_name,
+            repo=repo_name,
+            token=token,
+            issue_number=issue_number,
+            body=description,
+        )
 
     # Check out the URLs in the issue body
     reference_contents: list[str] = []

--- a/services/webhook/pr_checkbox_handler.py
+++ b/services/webhook/pr_checkbox_handler.py
@@ -91,6 +91,8 @@ async def handle_pr_checkbox_trigger(
     owner_id = repository["owner"]["id"]
     installation_id = payload["installation"]["id"]
     token = get_installation_access_token(installation_id=installation_id)
+    if not token:
+        return
 
     issue_number = payload["issue"]["number"]
 
@@ -147,7 +149,13 @@ async def handle_pr_checkbox_trigger(
 
     # If access is denied, create a comment and return early
     if not can_proceed:
-        create_comment(body=user_message, base_args=base_args)
+        create_comment(
+            owner=owner_name,
+            repo=repo_name,
+            token=token,
+            issue_number=issue_number,
+            body=user_message,
+        )
 
         # Early return notification
         slack_notify(availability_status["log_message"], thread_ts)
@@ -183,7 +191,13 @@ async def handle_pr_checkbox_trigger(
     log_messages.append(msg)
 
     comment_body = create_progress_bar(p=0, msg="\n".join(log_messages))
-    comment_url = create_comment(body=comment_body, base_args=base_args)
+    comment_url = create_comment(
+        owner=owner_name,
+        repo=repo_name,
+        token=token,
+        issue_number=issue_number,
+        body=comment_body,
+    )
     base_args["comment_url"] = comment_url
 
     p += 10

--- a/services/webhook/screenshot_handler.py
+++ b/services/webhook/screenshot_handler.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse, quote
 
 # Third-party imports
 import boto3
-from playwright.async_api import async_playwright
+from playwright.async_api import async_playwright, ViewportSize
 
 # Local imports
 from config import GITHUB_APP_USER_NAME
@@ -63,7 +63,7 @@ async def capture_screenshots(urls: list[str], output_dir: str) -> None:
         )
         context = await browser.new_context()
         page = await context.new_page()
-        viewport_size = {"width": 1512, "height": 982}
+        viewport_size: ViewportSize = {"width": 1512, "height": 982}
         await page.set_viewport_size(viewport_size)
         print(f"\nOpened browser and set viewport size to `{viewport_size}`")
 
@@ -139,7 +139,7 @@ def find_all_html_pages(repo_dir: str) -> list[str]:
 
 
 @handle_exceptions(raise_on_error=True)
-def get_target_paths(file_changes: list[dict[str, str]], repo_dir: str = None):
+def get_target_paths(file_changes: list[dict[str, str]], repo_dir: str | None = None):
     has_css_changes = any(
         change.get("filename", "").endswith((".css", ".scss", ".sass", ".less"))
         for change in file_changes
@@ -326,7 +326,13 @@ async def handle_screenshot_comparison(payload: dict) -> None:
 
             # Create comparison comment
             comment_body = f"""Path: {path}\n\n{table_header}| <img src="{prod_url}?t={timestamp}" width="400" referrerpolicy="no-referrer"/> | <img src="{local_url}?t={timestamp}" width="400" referrerpolicy="no-referrer"/> |"""
-            create_comment(body=comment_body, base_args=base_args)
+            create_comment(
+                owner=owner,
+                repo=repo,
+                token=token,
+                issue_number=pull_number,
+                body=comment_body,
+            )
             print(f"Created comparison comment for {path}")
 
     finally:

--- a/services/webhook/test_merge_handler.py
+++ b/services/webhook/test_merge_handler.py
@@ -73,8 +73,12 @@ def test_handle_pr_merged_success(
     # Verify create_issue was called with correct parameters
     mock_create_issue.assert_called_once()
     call_kwargs = mock_create_issue.call_args.kwargs
+    assert call_kwargs["owner"] == "test-owner"
+    assert call_kwargs["repo"] == "test-repo"
+    assert call_kwargs["token"] == "test-token"
     assert call_kwargs["title"] == "Test Issue Title"
     assert call_kwargs["body"] == "Test issue body content"
+    assert call_kwargs["assignees"] == ["pr-creator"]
 
     # Verify success notification was sent
     success_calls = [
@@ -154,8 +158,15 @@ def test_handle_pr_merged_410_issues_disabled(
     # Verify
     assert result is None  # Function returns None
 
-    # Verify create_issue was called
+    # Verify create_issue was called with correct parameters
     mock_create_issue.assert_called_once()
+    call_kwargs = mock_create_issue.call_args.kwargs
+    assert call_kwargs["owner"] == "test-owner"
+    assert call_kwargs["repo"] == "test-repo"
+    assert call_kwargs["token"] == "test-token"
+    assert call_kwargs["title"] == "Test Issue Title"
+    assert call_kwargs["body"] == "Test issue body content"
+    assert call_kwargs["assignees"] == ["pr-creator"]
 
     # Verify repository was updated to disable merge trigger
     mock_update_repository.assert_called_once_with(
@@ -246,8 +257,15 @@ def test_handle_pr_merged_other_error(
     # Verify
     assert result is None  # Function returns None
 
-    # Verify create_issue was called
+    # Verify create_issue was called with correct parameters
     mock_create_issue.assert_called_once()
+    call_kwargs = mock_create_issue.call_args.kwargs
+    assert call_kwargs["owner"] == "test-owner"
+    assert call_kwargs["repo"] == "test-repo"
+    assert call_kwargs["token"] == "test-token"
+    assert call_kwargs["title"] == "Test Issue Title"
+    assert call_kwargs["body"] == "Test issue body content"
+    assert call_kwargs["assignees"] == ["pr-creator"]
 
     # Verify failure notification was sent (not success)
     failure_calls = [

--- a/utils/issue_templates/schedule.py
+++ b/utils/issue_templates/schedule.py
@@ -2,8 +2,9 @@ from constants.messages import SETTINGS_LINKS
 from constants.urls import GH_BASE_URL
 
 
-def get_issue_title(file_path: str):
-    return f"Schedule: Add unit tests to {file_path}"
+def get_issue_title(file_path: str, has_existing_tests: bool = False):
+    action = "Increase test coverage for" if has_existing_tests else "Add unit tests to"
+    return f"Schedule: {action} {file_path}"
 
 
 def get_issue_body(


### PR DESCRIPTION
…iles

- Check for open PRs via GitHub API instead of database to prevent duplicates
- Prioritize files with 0% coverage over files with partial coverage
- Refactor create_issue() and create_comment() to use keyword-only parameters
- Update all call sites to use direct variables instead of base_args extraction
- Fix insert_coverages to wrap TypedDict with dict() for library compatibility
- Fix all pyright errors in modified files
- Update all tests to use new signatures