### PR TITLE
Fix auto-merge to check for `skip ci` in last commit

### DIFF
--- a/services/github/commits/check_commit_has_skip_ci.py
+++ b/services/github/commits/check_commit_has_skip_ci.py
@@ -1,0 +1,21 @@
+import requests
+
+from config import GITHUB_API_URL, TIMEOUT
+from services.github.utils.create_headers import create_headers
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=False, raise_on_error=False)
+def check_commit_has_skip_ci(owner: str, repo: str, commit_sha: str, token: str):
+    headers = create_headers(token)
+
+    response = requests.get(
+        f"{GITHUB_API_URL}/repos/{owner}/{repo}/commits/{commit_sha}",
+        headers=headers,
+        timeout=TIMEOUT,
+    )
+    response.raise_for_status()
+    commit_data = response.json()
+    commit_message = commit_data.get("commit", {}).get("message", "")
+
+    return "[skip ci]" in commit_message

--- a/services/github/commits/test_check_commit_has_skip_ci.py
+++ b/services/github/commits/test_check_commit_has_skip_ci.py
@@ -1,0 +1,63 @@
+from unittest.mock import MagicMock, patch
+
+from services.github.commits.check_commit_has_skip_ci import check_commit_has_skip_ci
+
+
+@patch("services.github.commits.check_commit_has_skip_ci.requests.get")
+def test_check_commit_has_skip_ci_returns_true(mock_get):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "commit": {"message": "Fix bug [skip ci]"},
+        "sha": "abc123",
+    }
+    mock_get.return_value = mock_response
+
+    result = check_commit_has_skip_ci(
+        owner="test-owner", repo="test-repo", commit_sha="abc123", token="test-token"
+    )
+
+    assert result is True
+    mock_get.assert_called_once()
+
+
+@patch("services.github.commits.check_commit_has_skip_ci.requests.get")
+def test_check_commit_has_skip_ci_returns_false(mock_get):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "commit": {"message": "Fix bug"},
+        "sha": "abc123",
+    }
+    mock_get.return_value = mock_response
+
+    result = check_commit_has_skip_ci(
+        owner="test-owner", repo="test-repo", commit_sha="abc123", token="test-token"
+    )
+
+    assert result is False
+    mock_get.assert_called_once()
+
+
+@patch("services.github.commits.check_commit_has_skip_ci.requests.get")
+def test_check_commit_has_skip_ci_with_exception(mock_get):
+    mock_get.side_effect = Exception("API error")
+
+    result = check_commit_has_skip_ci(
+        owner="test-owner", repo="test-repo", commit_sha="abc123", token="test-token"
+    )
+
+    assert result is False
+    mock_get.assert_called_once()
+
+
+@patch("services.github.commits.check_commit_has_skip_ci.requests.get")
+def test_check_commit_has_skip_ci_missing_commit_key(mock_get):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"sha": "abc123"}
+    mock_get.return_value = mock_response
+
+    result = check_commit_has_skip_ci(
+        owner="test-owner", repo="test-repo", commit_sha="abc123", token="test-token"
+    )
+
+    assert result is False
+    mock_get.assert_called_once()

--- a/services/webhook/test_successful_check_suite_handler.py
+++ b/services/webhook/test_successful_check_suite_handler.py
@@ -193,6 +193,7 @@ def test_handle_successful_check_suite_with_exception():
         assert result is None
 
 
+@patch("services.webhook.successful_check_suite_handler.check_commit_has_skip_ci")
 @patch("services.webhook.successful_check_suite_handler.merge_pull_request")
 @patch("services.webhook.successful_check_suite_handler.get_pull_request_files")
 @patch("services.webhook.successful_check_suite_handler.get_installation_access_token")
@@ -204,12 +205,15 @@ def test_auto_merge_success(
     mock_get_token,
     mock_get_files,
     mock_merge_pr,
+    mock_check_skip_ci,
 ):
     payload = {
         "check_suite": {
             "id": 31710113401,
             "name": "test-job",
             "conclusion": "success",
+            "head_sha": "abc123",
+            "head_branch": "feature-branch",
             "pull_requests": [
                 {
                     "url": "https://api.github.com/repos/test-owner/test-repo/pulls/123",
@@ -246,6 +250,7 @@ def test_auto_merge_success(
         "auto_merge_only_test_files": False,
     }
     mock_get_token.return_value = "test-token"
+    mock_check_skip_ci.return_value = False
     mock_get_files.return_value = [
         {"filename": "test_something.py", "status": "modified"}
     ]
@@ -287,18 +292,25 @@ def test_auto_merge_success(
         )
 
 
+@patch("services.webhook.successful_check_suite_handler.check_commit_has_skip_ci")
 @patch("services.webhook.successful_check_suite_handler.merge_pull_request")
 @patch("services.webhook.successful_check_suite_handler.get_pull_request_files")
 @patch("services.webhook.successful_check_suite_handler.get_installation_access_token")
 @patch("services.webhook.successful_check_suite_handler.get_repository_features")
 def test_auto_merge_disabled(
-    mock_get_repo_features, _mock_get_token, _mock_get_files, mock_merge_pr
+    mock_get_repo_features,
+    mock_get_token,
+    mock_get_files,
+    mock_merge_pr,
+    mock_check_skip_ci,
 ):
     payload = {
         "check_suite": {
             "id": 31710113401,
             "name": "test-job",
             "conclusion": "success",
+            "head_sha": "abc123",
+            "head_branch": "feature-branch",
             "pull_requests": [
                 {
                     "url": "https://api.github.com/repos/test-owner/test-repo/pulls/123",
@@ -350,6 +362,7 @@ def test_auto_merge_disabled(
         mock_merge_pr.assert_not_called()
 
 
+@patch("services.webhook.successful_check_suite_handler.check_commit_has_skip_ci")
 @patch("services.webhook.successful_check_suite_handler.merge_pull_request")
 @patch("services.webhook.successful_check_suite_handler.get_pull_request_files")
 @patch("services.webhook.successful_check_suite_handler.get_installation_access_token")
@@ -361,12 +374,15 @@ def test_auto_merge_multiple_test_files_changed(
     mock_get_token,
     mock_get_files,
     mock_merge_pr,
+    mock_check_skip_ci,
 ):
     payload = {
         "check_suite": {
             "id": 31710113401,
             "name": "test-job",
             "conclusion": "success",
+            "head_sha": "abc123",
+            "head_branch": "feature-branch",
             "pull_requests": [
                 {
                     "url": "https://api.github.com/repos/test-owner/test-repo/pulls/123",
@@ -403,6 +419,7 @@ def test_auto_merge_multiple_test_files_changed(
         "auto_merge_only_test_files": True,
     }
     mock_get_token.return_value = "test-token"
+    mock_check_skip_ci.return_value = False
     mock_get_files.return_value = [
         {"filename": "test_something.py", "status": "modified"},
         {"filename": "test_another.py", "status": "modified"},
@@ -521,6 +538,7 @@ def test_auto_merge_mixed_test_and_non_test_files(
         mock_merge_pr.assert_not_called()
 
 
+@patch("services.webhook.successful_check_suite_handler.check_commit_has_skip_ci")
 @patch("services.webhook.successful_check_suite_handler.merge_pull_request")
 @patch("services.webhook.successful_check_suite_handler.get_pull_request_files")
 @patch("services.webhook.successful_check_suite_handler.get_installation_access_token")
@@ -532,12 +550,15 @@ def test_auto_merge_with_non_test_files_allowed(
     mock_get_token,
     mock_get_files,
     mock_merge_pr,
+    mock_check_skip_ci,
 ):
     payload = {
         "check_suite": {
             "id": 31710113401,
             "name": "test-job",
             "conclusion": "success",
+            "head_sha": "abc123",
+            "head_branch": "feature-branch",
             "pull_requests": [
                 {
                     "url": "https://api.github.com/repos/test-owner/test-repo/pulls/123",
@@ -574,6 +595,7 @@ def test_auto_merge_with_non_test_files_allowed(
         "auto_merge_only_test_files": False,
     }
     mock_get_token.return_value = "test-token"
+    mock_check_skip_ci.return_value = False
     mock_get_files.return_value = [
         {"filename": "src/main.py", "status": "modified"},
         {"filename": "src/utils.py", "status": "modified"},
@@ -608,3 +630,92 @@ def test_auto_merge_with_non_test_files_allowed(
         handle_successful_check_suite(cast(CheckSuiteCompletedPayload, payload))
 
         mock_merge_pr.assert_called_once()
+
+
+@patch("services.webhook.successful_check_suite_handler.create_empty_commit")
+@patch("services.webhook.successful_check_suite_handler.create_comment")
+@patch("services.webhook.successful_check_suite_handler.check_commit_has_skip_ci")
+@patch("services.webhook.successful_check_suite_handler.get_installation_access_token")
+@patch("services.webhook.successful_check_suite_handler.get_repository_features")
+def test_auto_merge_blocked_skip_ci(
+    mock_get_repo_features,
+    mock_get_token,
+    mock_check_skip_ci,
+    mock_create_comment,
+    mock_create_empty_commit,
+):
+    payload = {
+        "check_suite": {
+            "id": 31710113401,
+            "name": "test-job",
+            "conclusion": "success",
+            "head_sha": "abc123",
+            "head_branch": "gitauto/issue-456",
+            "pull_requests": [
+                {
+                    "url": "https://api.github.com/repos/test-owner/test-repo/pulls/123",
+                    "id": 2131041354,
+                    "number": 123,
+                }
+            ],
+        },
+        "repository": {
+            "id": 871345449,
+            "name": "test-repo",
+            "owner": {
+                "id": 4620828,
+                "login": "test-owner",
+                "type": "Organization",
+            },
+            "clone_url": "https://github.com/test-owner/test-repo.git",
+            "fork": False,
+        },
+        "installation": {"id": 12345},
+        "sender": {"id": 12345, "login": "test-sender"},
+    }
+
+    mock_get_repo_features.return_value = {"auto_merge": True}
+    mock_get_token.return_value = "test-token"
+    mock_check_skip_ci.return_value = True
+
+    with patch(
+        "services.webhook.successful_check_suite_handler.supabase"
+    ) as mock_supabase:
+        mock_table = MagicMock()
+        mock_select = MagicMock()
+        mock_eq1 = MagicMock()
+        mock_eq2 = MagicMock()
+        mock_eq3 = MagicMock()
+        mock_order = MagicMock()
+        mock_limit = MagicMock()
+
+        mock_supabase.table.return_value = mock_table
+        mock_table.select.return_value = mock_select
+        mock_select.eq.return_value = mock_eq1
+        mock_eq1.eq.return_value = mock_eq2
+        mock_eq2.eq.return_value = mock_eq3
+        mock_eq3.order.return_value = mock_order
+        mock_order.limit.return_value = mock_limit
+        mock_limit.execute.return_value = MagicMock(data=[{"id": 100}])
+
+        mock_update = MagicMock()
+        mock_update_eq = MagicMock()
+        mock_table.update.return_value = mock_update
+        mock_update.eq.return_value = mock_update_eq
+
+        handle_successful_check_suite(cast(CheckSuiteCompletedPayload, payload))
+
+        mock_check_skip_ci.assert_called_once_with(
+            owner="test-owner",
+            repo="test-repo",
+            commit_sha="abc123",
+            token="test-token",
+        )
+        mock_create_comment.assert_called_once_with(
+            owner="test-owner",
+            repo="test-repo",
+            token="test-token",
+            issue_number=123,
+            body="Auto-merge blocked: last commit has [skip ci], triggering tests instead...",
+        )
+        mock_create_empty_commit.assert_called_once()


### PR DESCRIPTION
When CircleCI shows "queued" with 0 runs due to [skip ci] in the last commit, the successful check suite handler was incorrectly proceeding with auto-merge. This fix adds a check for [skip ci] in the last commit and automatically triggers tests by creating an empty commit without [skip ci] instead of proceeding with the merge.

Changes:
- Created check_commit_has_skip_ci() function that uses commit SHA directly from payload (no redundant API calls)
- Updated successful_check_suite_handler to check for [skip ci] before auto-merge
- If detected, creates empty commit to trigger tests and blocks auto-merge
- Added comprehensive test coverage for the new functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)