### PR TITLE
Fix auto-merge KeyError by checking branch name instead of user field

### DIFF
--- a/payloads/github/check_suite/completed_failed_github_actions.json
+++ b/payloads/github/check_suite/completed_failed_github_actions.json
@@ -295,7 +295,7 @@
     "site_admin": false
   },
   "installation": {
-    "id": 603***28,
+    "id": 60328,
     "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uNjAz***Mjg="
   }
 }

--- a/services/github/types/check_suite.py
+++ b/services/github/types/check_suite.py
@@ -1,8 +1,35 @@
-import datetime
 from typing import Optional, TypedDict
 
 from services.github.types.app import App
-from services.github.types.pull_request import PullRequest
+
+
+class SimplifiedRepo(TypedDict):
+    id: int
+    url: str
+    name: str
+
+
+class SimplifiedRef(TypedDict):
+    ref: str
+    sha: str
+    repo: SimplifiedRepo
+
+
+class SimplifiedPullRequest(TypedDict):
+    url: str
+    id: int
+    number: int
+    head: SimplifiedRef
+    base: SimplifiedRef
+
+
+class HeadCommit(TypedDict):
+    id: str
+    tree_id: str
+    message: str
+    timestamp: str
+    author: dict
+    committer: dict
 
 
 class CheckSuite(TypedDict):
@@ -15,7 +42,12 @@ class CheckSuite(TypedDict):
     url: str
     before: str
     after: str
-    pull_requests: list[PullRequest]
+    pull_requests: list[SimplifiedPullRequest]
     app: App
-    created_at: datetime
-    updated_at: datetime
+    created_at: str
+    updated_at: str
+    rerequestable: bool
+    runs_rerequestable: bool
+    latest_check_runs_count: int
+    check_runs_url: str
+    head_commit: HeadCommit


### PR DESCRIPTION
GitHub's check_suite webhook sends simplified PR objects without user field. Changed to check branch name pattern (PRODUCT_ID prefix) instead. Added get_pull_request call to fetch full PR for mergeable_state check. Updated all tests to use real webhook payloads and proper mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)