### PR TITLE
Low Test Coverage: services/duckduckgo/search_urls.py

### DIFF
--- a/services/duckduckgo/test_search_urls.py
+++ b/services/duckduckgo/test_search_urls.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
 from services.duckduckgo.search_urls import (DDG_URL, NUM_RESULTS_DEFAULT,
                                              search_urls)
 

--- a/services/duckduckgo/test_search_urls.py
+++ b/services/duckduckgo/test_search_urls.py
@@ -1,4 +1,4 @@
-# pylint: disable=unused-argument
+# pylint: disable=redefined-outer-name, unused-argument
 # pyright: reportUnusedVariable=false
 from unittest.mock import Mock, patch
 

--- a/services/duckduckgo/test_search_urls.py
+++ b/services/duckduckgo/test_search_urls.py
@@ -3,8 +3,8 @@
 from unittest.mock import Mock, patch
 
 import pytest
-
-from services.duckduckgo.search_urls import DDG_URL, NUM_RESULTS_DEFAULT, search_urls
+from services.duckduckgo.search_urls import (DDG_URL, NUM_RESULTS_DEFAULT,
+                                             search_urls)
 
 
 @pytest.mark.skip(
@@ -79,3 +79,229 @@ class TestConstants:
 
     def test_num_results_default(self):
         assert NUM_RESULTS_DEFAULT == 10
+
+
+class TestSearchUrlsUnit:
+    """Unit tests for search_urls with mocked HTTP requests."""
+
+    @patch("services.duckduckgo.search_urls.requests.get")
+    def test_happy_path_with_ddg_redirect_urls(self, mock_get):
+        # Verifies full parsing: DDG redirect extraction, title, description, and URL
+        mock_response = Mock()
+        mock_response.text = """
+        <html><body>
+            <div class="result">
+                <h2 class="result__title">
+                    <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpage&amp;rut=x">
+                        Example Page
+                    </a>
+                </h2>
+                <a class="result__snippet">A description of the page.</a>
+            </div>
+            <div class="result">
+                <h2 class="result__title">
+                    <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fother.com&amp;rut=y">
+                        Other Page
+                    </a>
+                </h2>
+                <a class="result__snippet">Another description.</a>
+            </div>
+        </body></html>
+        """
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = search_urls("test query")
+
+        assert len(result) == 2
+        assert result[0]["title"] == "Example Page"
+        assert result[0]["url"] == "https://example.com/page"
+        assert result[0]["description"] == "A description of the page."
+        assert result[1]["title"] == "Other Page"
+        assert result[1]["url"] == "https://other.com"
+        assert result[1]["description"] == "Another description."
+
+    @patch("services.duckduckgo.search_urls.requests.get")
+    def test_no_results_returns_empty_list(self, mock_get):
+        # When DDG returns HTML with no result links, should return empty list
+        mock_response = Mock()
+        mock_response.text = "<html><body><div>No results found</div></body></html>"
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = search_urls("xyznonexistentquery12345")
+
+        assert result == []
+
+    @patch("services.duckduckgo.search_urls.requests.get")
+    def test_direct_href_without_ddg_redirect(self, mock_get):
+        # When href doesn't contain DDG redirect, use href as-is (branch: line 33 → 38)
+        mock_response = Mock()
+        mock_response.text = """
+        <html><body>
+            <div class="result">
+                <h2 class="result__title">
+                    <a class="result__a" href="https://direct-link.com/page">
+                        Direct Link
+                    </a>
+                </h2>
+            </div>
+        </body></html>
+        """
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = search_urls("direct query")
+
+        assert len(result) == 1
+        assert result[0]["url"] == "https://direct-link.com/page"
+        assert result[0]["title"] == "Direct Link"
+        assert result[0]["description"] == ""
+
+    @patch("services.duckduckgo.search_urls.requests.get")
+    def test_ddg_redirect_without_uddg_param(self, mock_get):
+        # When DDG redirect URL lacks uddg param, href stays as original (branch: line 36 → 38)
+        mock_response = Mock()
+        mock_response.text = """
+        <html><body>
+            <div class="result">
+                <h2 class="result__title">
+                    <a class="result__a" href="//duckduckgo.com/l/?rut=abc">
+                        No Uddg Param
+                    </a>
+                </h2>
+            </div>
+        </body></html>
+        """
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = search_urls("no uddg")
+
+        assert len(result) == 1
+        assert result[0]["url"] == "//duckduckgo.com/l/?rut=abc"
+        assert result[0]["title"] == "No Uddg Param"
+
+    @patch("services.duckduckgo.search_urls.requests.get")
+    def test_no_snippet_tag_parent(self, mock_get):
+        # When link has no parent h2, description should be empty (branch: line 42 → 46)
+        mock_response = Mock()
+        mock_response.text = """
+        <html><body>
+            <a class="result__a" href="https://orphan-link.com">Orphan Link</a>
+        </body></html>
+        """
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = search_urls("orphan")
+
+        assert len(result) == 1
+        assert result[0]["title"] == "Orphan Link"
+        assert result[0]["description"] == ""
+        assert result[0]["url"] == "https://orphan-link.com"
+
+    @patch("services.duckduckgo.search_urls.requests.get")
+    def test_snippet_tag_without_sibling_snippet(self, mock_get):
+        # When h2 parent exists but no result__snippet sibling (branch: line 44 → 46)
+        mock_response = Mock()
+        mock_response.text = """
+        <html><body>
+            <div class="result">
+                <h2 class="result__title">
+                    <a class="result__a" href="https://no-snippet.com">No Snippet</a>
+                </h2>
+                <div class="other_class">Not a snippet</div>
+            </div>
+        </body></html>
+        """
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = search_urls("no snippet")
+
+        assert len(result) == 1
+        assert result[0]["title"] == "No Snippet"
+        assert result[0]["description"] == ""
+
+    @patch("services.duckduckgo.search_urls.requests.get")
+    def test_exception_returns_empty_list(self, mock_get):
+        # handle_exceptions decorator catches errors and returns default []
+        mock_get.side_effect = Exception("Connection timeout")
+
+        result = search_urls("failing query")
+
+        assert result == []
+
+    @patch("services.duckduckgo.search_urls.requests.get")
+    def test_http_error_returns_empty_list(self, mock_get):
+        # HTTP errors (e.g., 500) are caught by decorator and return []
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = requests.HTTPError(
+            response=Mock(status_code=500, reason="Server Error", text="Internal Server Error")
+        )
+        mock_get.return_value = mock_response
+
+        result = search_urls("server error query")
+
+        assert result == []
+
+    @patch("services.duckduckgo.search_urls.requests.get")
+    def test_results_capped_at_num_results_default(self, mock_get):
+        # Verify only NUM_RESULTS_DEFAULT results are returned even if more links exist
+        links_html = ""
+        for i in range(15):
+            links_html += f"""
+            <div class="result">
+                <h2 class="result__title">
+                    <a class="result__a" href="https://example{i}.com">Title {i}</a>
+                </h2>
+            </div>
+            """
+        mock_response = Mock()
+        mock_response.text = f"<html><body>{links_html}</body></html>"
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = search_urls("many results")
+
+        assert len(result) == NUM_RESULTS_DEFAULT
+
+    @patch("services.duckduckgo.search_urls.requests.get")
+    def test_request_params_are_correct(self, mock_get):
+        # Verify the HTTP request is made with correct URL, headers, params, and timeout
+        mock_response = Mock()
+        mock_response.text = "<html><body></body></html>"
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        search_urls("verify params")
+
+        mock_get.assert_called_once_with(
+            DDG_URL,
+            headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"},
+            params={"q": "verify params", "kl": "us-en"},
+            timeout=120,
+        )
+
+    @patch("services.duckduckgo.search_urls.requests.get")
+    def test_link_with_empty_href(self, mock_get):
+        # When link has no href attribute, should use empty string as URL
+        mock_response = Mock()
+        mock_response.text = """
+        <html><body>
+            <div class="result">
+                <h2 class="result__title">
+                    <a class="result__a">No Href Link</a>
+                </h2>
+            </div>
+        </body></html>
+        """
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = search_urls("no href")
+
+        assert len(result) == 1
+        assert result[0]["url"] == ""
+        assert result[0]["title"] == "No Href Link"


### PR DESCRIPTION
## File: [services/duckduckgo/search_urls.py](https://github.com/gitautoai/gitauto/blob/HEAD/services/duckduckgo/search_urls.py)

- Line Coverage: 32% (Uncovered Lines: 19, 25, 27, 28, 29, 30, 31, 33, 34, 35, 36, 37, 38, 40, 41, 42, 43, 44, 45, 46, 48)
- Statement Coverage: 32%
- Function Coverage: 0% (Uncovered Functions: L17-48:search_urls)
- Branch Coverage: 0% (Uncovered Branches: line 30, block 0, if branch: 30 -> 31, line 30, block 0, if branch: 30 -> 48, line 33, block 0, if branch: 33 -> 34, line 33, block 0, if branch: 33 -> 38, line 36, block 0, if branch: 36 -> 37, line 36, block 0, if branch: 36 -> 38, line 42, block 0, if branch: 42 -> 43, line 42, block 0, if branch: 42 -> 46, line 44, block 0, if branch: 44 -> 45, line 44, block 0, if branch: 44 -> 46)

Last Updated: 4/1/2026, 6:51:31 AM

Aim to achieve 100% coverage with minimal code changes. Focus on covering the uncovered areas, including both happy paths, error cases, edge cases, and corner cases. Add to existing test file if available, or create a new one.

## Coverage Dashboard

View full coverage details in the [Coverage Dashboard](https://gitauto.ai/dashboard/file-coverage?utm_source=github&utm_medium=referral)

## Test these changes locally

```
git fetch origin
git checkout gitauto/dashboard-20260401-171602-ufti
git pull origin gitauto/dashboard-20260401-171602-ufti
```