### PR TITLE
Fix get_file_tree to use local ref instead of stale origin remote-tracking ref

### DIFF
--- a/services/git/get_file_tree.py
+++ b/services/git/get_file_tree.py
@@ -19,17 +19,11 @@ def get_file_tree(clone_dir: str, ref: str, root_only: bool = False):
         logger.warning("No valid git repo at %s", clone_dir)
         return tree_items
 
-    # Fetch latest refs to ensure we have the requested ref
-    try:
-        run_subprocess(args=["git", "fetch", "origin", ref], cwd=clone_dir)
-    except ValueError:
-        logger.warning("Failed to fetch ref %s, using local data", ref)
-
     # -r: recursive, -l: show size, --full-tree: show full paths
     args = ["git", "ls-tree", "--full-tree", "-l"]
     if not root_only:
         args.append("-r")
-    args.append(f"origin/{ref}")
+    args.append(ref)
 
     try:
         result = run_subprocess(args=args, cwd=clone_dir)

--- a/services/git/test_get_file_tree.py
+++ b/services/git/test_get_file_tree.py
@@ -37,16 +37,17 @@ class TestGetFileTree:
         assert "size" not in items[2]
 
     @patch("os.path.isdir", return_value=True)
-    def test_fetches_before_ls_tree(self, _mock_isdir, mock_run_subprocess):
+    def test_uses_local_ref_directly(self, _mock_isdir, mock_run_subprocess):
         result = MagicMock()
         result.stdout = ""
         mock_run_subprocess.return_value = result
 
         get_file_tree(clone_dir="/mnt/efs/owner/repo", ref="main")
 
-        # First call should be git fetch
-        fetch_call = mock_run_subprocess.call_args_list[0]
-        assert fetch_call[1]["args"] == ["git", "fetch", "origin", "main"]
+        # Should call git ls-tree with local ref, no fetch, no origin/ prefix
+        call = mock_run_subprocess.call_args_list[0]
+        assert call[1]["args"] == ["git", "ls-tree", "--full-tree", "-l", "-r", "main"]
+        assert mock_run_subprocess.call_count == 1
 
     @patch("os.path.isdir", return_value=False)
     def test_returns_empty_for_invalid_clone_dir(
@@ -76,25 +77,16 @@ class TestGetFileTree:
 
         get_file_tree(clone_dir="/mnt/efs/owner/repo", ref="main", root_only=True)
 
-        # ls-tree call should NOT have -r flag
-        ls_tree_call = mock_run_subprocess.call_args_list[1]
-        assert "-r" not in ls_tree_call[1]["args"]
+        call = mock_run_subprocess.call_args_list[0]
+        assert "-r" not in call[1]["args"]
 
     @patch("os.path.isdir", return_value=True)
-    def test_handles_fetch_failure_gracefully(self, _mock_isdir, mock_run_subprocess):
-        def side_effect(args, cwd):
-            if "fetch" in args:
-                raise ValueError("fetch failed")
-            result = MagicMock()
-            result.stdout = "100644 blob abc123    100\tfile.py"
-            return result
-
-        mock_run_subprocess.side_effect = side_effect
+    def test_returns_empty_when_ls_tree_fails(self, _mock_isdir, mock_run_subprocess):
+        mock_run_subprocess.side_effect = ValueError("ref not found")
 
         items = get_file_tree(clone_dir="/mnt/efs/owner/repo", ref="main")
 
-        assert len(items) == 1
-        assert items[0]["path"] == "file.py"
+        assert not items
 
 
 # --- Integration tests (real git, local bare repo) ---


### PR DESCRIPTION
## Summary

- Fixed `get_file_tree` to use the local branch ref (`master`) instead of `origin/master` for `git ls-tree`
- Root cause: `git_clone_to_efs` already fetches and checks out the target branch, so the local ref is always up to date. Using `origin/{ref}` required a successful `git fetch` which fails when the EFS clone's origin URL has an expired GitHub token
- This caused schedule_handler and handle_coverage_report to return "No files found" for repos where the agent hadn't recently refreshed the EFS clone (foxden-admin-portal, foxden-policy-document-backend)

## Social Media Post (GitAuto)

A stale Git remote-tracking ref (origin/master) was silently causing our schedule handler to skip repos. The EFS clone already had a fresh local checkout, but we were fetching from a URL with an expired token. Removed the unnecessary fetch and used the local branch directly.

## Social Media Post (Wes)

Spent the morning tracing why two customer repos stopped getting scheduled PRs. CloudWatch logs showed "git ls-tree failed for ref master" followed by "No files found". The EFS clone had the local branch checked out and current, but the code was doing git ls-tree origin/master which requires a fetch that was failing silently. Removed the fetch, pointed at the local ref. Three lines deleted, two repos unblocked.