### PR TITLE
Fix schedule handler reading file tree before checkout

### DIFF
--- a/services/git/get_file_tree.py
+++ b/services/git/get_file_tree.py
@@ -27,8 +27,8 @@ def get_file_tree(clone_dir: str, ref: str, root_only: bool = False):
 
     try:
         result = run_subprocess(args=args, cwd=clone_dir)
-    except ValueError:
-        logger.warning("git ls-tree failed for ref %s", ref)
+    except ValueError as e:
+        logger.warning("git ls-tree failed for ref %s: %s", ref, e)
         return tree_items
 
     output = result.stdout.strip() if result and result.stdout else ""

--- a/services/webhook/schedule_handler.py
+++ b/services/webhook/schedule_handler.py
@@ -123,13 +123,12 @@ def schedule_handler(event: EventBridgeSchedulerEvent):
             msg = f"Repository {owner_name}/{repo_name} is empty"
             logger.info(msg)
             return {"status": "skipped", "message": msg}
-    tree_items = get_file_tree(clone_dir=efs_dir, ref=target_branch)
-
     # Copy EFS to /tmp for local file reads (EFS is shared, don't operate on it directly)
     clone_dir = get_clone_dir(owner_name, repo_name, pr_number=None)
     copy_repo_from_efs_to_tmp(efs_dir, clone_dir)
     git_fetch(clone_dir, clone_url, target_branch)
     git_checkout(clone_dir, target_branch)
+    tree_items = get_file_tree(clone_dir=clone_dir, ref=target_branch)
 
     # Extract necessary data
     all_files_with_sizes = [

--- a/services/webhook/test_schedule_handler.py
+++ b/services/webhook/test_schedule_handler.py
@@ -1208,3 +1208,74 @@ def test_schedule_handler_partial_none_coverage_omits_none_metric(
     assert "Statement Coverage: 50%" in call_kwargs["body"]
     assert "Function Coverage: 50%" in call_kwargs["body"]
     assert "Branch Coverage:" not in call_kwargs["body"]
+
+
+@patch("services.webhook.schedule_handler.get_all_coverages")
+@patch("services.webhook.schedule_handler.git_checkout")
+@patch("services.webhook.schedule_handler.git_fetch")
+@patch("services.webhook.schedule_handler.copy_repo_from_efs_to_tmp")
+@patch("services.webhook.schedule_handler.get_file_tree")
+@patch("services.webhook.schedule_handler.get_clone_dir")
+@patch("services.webhook.schedule_handler.get_efs_dir")
+@patch("services.webhook.schedule_handler.get_default_branch")
+@patch("services.webhook.schedule_handler.check_availability")
+@patch("services.webhook.schedule_handler.get_repository")
+@patch("services.webhook.schedule_handler.get_schedule_pause")
+@patch("services.webhook.schedule_handler.get_installation_access_token")
+def test_get_file_tree_reads_from_tmp_not_efs(
+    mock_get_token,
+    mock_is_paused,
+    mock_get_repository,
+    mock_check_availability,
+    mock_get_default_branch,
+    mock_get_efs_dir,
+    mock_get_clone_dir,
+    mock_get_file_tree,
+    _mock_copy_repo,
+    _mock_git_fetch,
+    _mock_git_checkout,
+    mock_get_all_coverages,
+    mock_event,
+):
+    """Repo has files but git ls-tree fails on EFS (no local ref before checkout).
+
+    PR #2449 called get_file_tree on efs_dir before fetch/checkout, so git ls-tree
+    returned empty and the handler falsely reported "No files found".
+    The fix: call get_file_tree on clone_dir after checkout where the local ref exists.
+    """
+    mock_get_token.return_value = "test-token"
+    mock_is_paused.return_value = None
+    mock_get_repository.return_value = {"trigger_on_schedule": True}
+    mock_check_availability.return_value = {
+        "can_proceed": True,
+        "billing_type": "exception",
+        "requests_left": None,
+        "credit_balance_usd": 0,
+        "period_end_date": None,
+        "user_message": "",
+        "log_message": "Exception owner - unlimited access.",
+    }
+    mock_get_default_branch.return_value = "master"
+    mock_get_efs_dir.return_value = "/mnt/efs/test-org/test-repo"
+    mock_get_clone_dir.return_value = "/tmp/test-org/test-repo"
+
+    # EFS has no local master ref, /tmp does after checkout
+    def get_file_tree_by_dir(clone_dir, ref):
+        if clone_dir == "/mnt/efs/test-org/test-repo":
+            return []  # git ls-tree master fails on EFS
+        return [
+            {
+                "path": "src/app.ts",
+                "type": "blob",
+                "mode": "100644",
+                "sha": "a1",
+                "size": 50,
+            },
+        ]
+
+    mock_get_file_tree.side_effect = get_file_tree_by_dir
+    mock_get_all_coverages.return_value = []
+
+    result = schedule_handler(mock_event)
+
+    assert result["message"] != "Schedule: No files found"


### PR DESCRIPTION
## Summary
- PR #2449 moved `get_file_tree` from GitHub API to local `git ls-tree`, but it ran on the EFS directory **before** fetch/checkout, so the local `master` ref didn't exist
- Moved `get_file_tree` to after `copy_repo_from_efs_to_tmp` + `git_fetch` + `git_checkout`, and changed it to read from `/tmp` clone dir instead of EFS
- This fixes the "Schedule: No files found" failure for foxden-admin-portal (and any other repo hit by the same timing)

## Social Media Posts

### GitAuto
Our schedule handler was returning "No files found" after a recent refactor. The file tree was being read from the EFS clone before the branch was fetched and checked out - so the local ref didn't exist yet. Moved the read to after checkout. One-line move, repos unblocked.

### Wes
Classic ordering bug. We switched from GitHub API to local git ls-tree for reading file trees, but left the call above the fetch/checkout block. git ls-tree master fails when there's no local master branch yet. Moved it two lines down, after checkout creates the ref. Sometimes the fix is just reading the code top to bottom.