### PR TITLE
Hardcode GIT_CONFIG_GLOBAL in CloudFormation

### DIFF
--- a/infrastructure/deploy-lambda-with-vpc-efs.yml
+++ b/infrastructure/deploy-lambda-with-vpc-efs.yml
@@ -155,7 +155,7 @@ Resources:
           GH_PRIVATE_KEY: '{{resolve:ssm:/gitauto/GH_PRIVATE_KEY}}'
           GH_WEBHOOK_SECRET: '{{resolve:ssm:/gitauto/GH_WEBHOOK_SECRET}}'
           GITAUTO_API_KEY: '{{resolve:ssm:/gitauto/GITAUTO_API_KEY}}'
-          GIT_CONFIG_GLOBAL: '{{resolve:ssm:/gitauto/GIT_CONFIG_GLOBAL}}'
+          GIT_CONFIG_GLOBAL: '/tmp/.gitconfig'
           GIT_PYTHON_REFRESH: '{{resolve:ssm:/gitauto/GIT_PYTHON_REFRESH}}'
           OPENAI_API_KEY: '{{resolve:ssm:/gitauto/OPENAI_API_KEY}}'
           OPENAI_ORG_ID: '{{resolve:ssm:/gitauto/OPENAI_ORG_ID}}'

--- a/services/git/git_clone_to_efs.py
+++ b/services/git/git_clone_to_efs.py
@@ -12,10 +12,6 @@ def git_clone_to_efs(efs_dir: str, clone_url: str, branch: str):
     logger.info("Cloning base to EFS: branch=%s dir=%s", branch, efs_dir)
     os.makedirs(efs_dir, exist_ok=True)
 
-    # Lambda /var/task is read-only; redirect git config to /tmp
-    # GIT_CONFIG_GLOBAL only affects git, unlike HOME which affects all tools
-    os.environ["GIT_CONFIG_GLOBAL"] = "/tmp/.gitconfig"
-
     # EFS directories may be owned by different Lambda instances; mark as safe
     run_subprocess(
         ["git", "config", "--global", "--add", "safe.directory", efs_dir], efs_dir


### PR DESCRIPTION
## Summary
- Replace `{{resolve:ssm:/gitauto/GIT_CONFIG_GLOBAL}}` with hardcoded `/tmp/.gitconfig` in Lambda env vars
- Deleted the SSM parameter — it's just a static path, not a secret or environment-specific value