### PR TITLE
Fix Slack notification text copy for PR info

### DIFF
--- a/services/webhook/new_pr_handler.py
+++ b/services/webhook/new_pr_handler.py
@@ -108,7 +108,7 @@ async def handle_new_pr(
     sender_name = base_args["sender_name"]
 
     # Start notification
-    start_msg = f"PR handler started: `{trigger}` by `{sender_name}` for `{pr_number}:{pr_title}` in `{owner_name}/{repo_name}`"
+    start_msg = f"PR handler started: `{trigger}` by `{sender_name}` for {pr_number}:{pr_title} in `{owner_name}/{repo_name}`"
     thread_ts = slack_notify(start_msg)
 
     # Create a comment to track progress


### PR DESCRIPTION
## Summary
- Remove backticks around `pr_number:pr_title` in Slack start message so copying text doesn't include formatting artifacts