### PR TITLE
Add git_revert_file tool for agent file recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,7 @@ When the user explicitly says "LGTM", execute this workflow:
       - No internal names (function names, variable names, component names like "schedule handler", "new_pr_handler", etc.) - describe behavior in plain language
       - When there's a real failure, tell the honest story
       - Sound human. Vary openers every time - check `scripts/git/recent_social_posts.sh wes` first.
+      - **No small numbers** - Don't expose specific dollar amounts or metrics that look trivial to readers (e.g. "$76/mo savings"). Use relative language instead ("biggest line item", "most of our costs"). Only include numbers that would impress the audience.
 11. If fixing a Sentry issue, resolve related issues:
     - `python3 scripts/sentry/get_issue.py AGENT-XXX` to check related
     - `python3 scripts/sentry/resolve_issue.py AGENT-XXX AGENT-YYY ...` to resolve

--- a/services/claude/tools/tools.py
+++ b/services/claude/tools/tools.py
@@ -17,6 +17,7 @@ from services.git.apply_diff_to_file import (
 )
 from services.git.create_directory import CREATE_DIRECTORY, create_directory
 from services.git.delete_file import DELETE_FILE, delete_file
+from services.git.git_revert_file import GIT_REVERT_FILE, git_revert_file
 from services.git.search_and_replace import (
     SEARCH_AND_REPLACE,
     search_and_replace,
@@ -59,6 +60,7 @@ _TOOLS_BASE: list[ToolUnionParam] = [
     CREATE_COMMENT,
     CREATE_DIRECTORY,
     DELETE_FILE,
+    GIT_REVERT_FILE,
     SEARCH_AND_REPLACE,
     FETCH_URL,
     GET_LOCAL_FILE_TREE,
@@ -107,6 +109,7 @@ tools_to_call: dict[str, Any] = {
     "create_directory": create_directory,
     "delete_file": delete_file,
     "fetch_url": fetch_url,
+    "git_revert_file": git_revert_file,
     "get_local_file_content": get_local_file_content,
     "get_local_file_tree": get_local_file_tree,
     "move_file": move_file,

--- a/services/git/git_clone_to_tmp.py
+++ b/services/git/git_clone_to_tmp.py
@@ -30,6 +30,8 @@ def git_clone_to_tmp(clone_dir: str, clone_url: str, branch: str):
         return clone_dir
 
     # Fresh clone — single git command, no intermediate steps
+    # Benchmark on Lambda (3072MB, us-west-1): SPIDERPLUS-web (13,618 files, 1.1GB) cloned in 17s
+    # GitHub tarball API was 2x slower (37s) — git pack protocol is more efficient
     logger.info("Shallow cloning: branch=%s dir=%s", branch, clone_dir)
     os.makedirs(clone_dir, exist_ok=True)
     # --depth 1: shallow clone (latest commit only), -b: checkout this branch

--- a/services/git/git_revert_file.py
+++ b/services/git/git_revert_file.py
@@ -1,0 +1,67 @@
+# Third party imports
+from anthropic.types import ToolUnionParam
+
+# Local imports
+from services.claude.tools.file_modify_result import FileWriteResult
+from services.claude.tools.properties import FILE_PATH
+from services.git.git_commit_and_push import git_commit_and_push
+from services.types.base_args import BaseArgs
+from utils.command.run_subprocess import run_subprocess
+from utils.error.handle_exceptions import handle_exceptions
+from utils.files.read_local_file import read_local_file
+from utils.logging.logging_config import logger
+
+GIT_REVERT_FILE: ToolUnionParam = {
+    "name": "git_revert_file",
+    "description": "Reverts a single file to its state before the agent started making changes. Use this when you've gotten lost or your changes to a file are too broken to fix - this lets you start over for that file. Only affects the specified file - other files are untouched.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "file_path": FILE_PATH,
+        },
+        "required": ["file_path"],
+        "additionalProperties": False,
+    },
+    "strict": True,
+}
+
+
+@handle_exceptions(
+    default_return_value=lambda file_path, base_args, **_kwargs: FileWriteResult(
+        success=False,
+        message="git_revert_file failed.",
+        file_path=file_path,
+        content=read_local_file(file_path, base_args["clone_dir"]) or "",
+    ),
+    raise_on_error=False,
+)
+def git_revert_file(file_path: str, base_args: BaseArgs, **_kwargs):
+    clone_dir = base_args["clone_dir"]
+    # Use the commit SHA from before the agent started (check_suite/review handlers),
+    # falling back to base_branch for new_pr_handler where no prior commits exist
+    latest_sha = base_args.get("latest_commit_sha")
+    base_branch = base_args["base_branch"]
+    revert_ref = latest_sha or base_branch
+
+    run_subprocess(["git", "checkout", revert_ref, "--", file_path], clone_dir)
+    logger.info("git_revert_file: reverted %s to %s", file_path, revert_ref)
+
+    if latest_sha:
+        description = (
+            f"{file_path} to the version before agent started ({latest_sha[:7]})"
+        )
+    else:
+        description = f"{file_path} to {base_branch}"
+    git_commit_and_push(
+        base_args=base_args,
+        message=f"Revert {description}",
+        files=[file_path],
+    )
+
+    content = read_local_file(file_path, clone_dir) or ""
+    return FileWriteResult(
+        success=True,
+        message=f"Reverted {description}",
+        file_path=file_path,
+        content=content,
+    )

--- a/services/git/test_git_revert_file.py
+++ b/services/git/test_git_revert_file.py
@@ -1,0 +1,265 @@
+# pylint: disable=redefined-outer-name
+import os
+import subprocess
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from services.git.git_clone_to_tmp import git_clone_to_tmp
+from services.git.git_revert_file import git_revert_file
+
+
+@pytest.fixture
+def base_args():
+    return {
+        "owner_type": "Organization",
+        "owner_id": 1,
+        "owner": "test-owner",
+        "repo_id": 1,
+        "repo": "test-repo",
+        "clone_url": "https://x-access-token:tok@github.com/test-owner/test-repo.git",
+        "is_fork": False,
+        "base_branch": "main",
+        "new_branch": "feature-branch",
+        "installation_id": 1,
+        "token": "tok",
+        "sender_id": 1,
+        "sender_name": "bot",
+        "sender_email": None,
+        "sender_display_name": "Bot",
+        "reviewers": [],
+        "github_urls": [],
+        "other_urls": [],
+        "clone_dir": "/tmp/test-repo",
+        "pr_number": 42,
+        "pr_title": "Test PR",
+        "pr_body": "",
+        "pr_comments": [],
+        "pr_creator": "bot",
+    }
+
+
+@patch("services.git.git_revert_file.read_local_file", return_value="reverted content")
+@patch("services.git.git_revert_file.git_commit_and_push")
+@patch("services.git.git_revert_file.run_subprocess")
+def test_falls_back_to_base_branch_without_commit_sha(
+    mock_subprocess, mock_commit, _mock_read, base_args
+):
+    """Without latest_commit_sha (new_pr_handler), reverts to base_branch."""
+    result = git_revert_file(file_path="test/index.test.tsx", base_args=base_args)
+
+    assert result.success is True
+    assert "Reverted test/index.test.tsx to main" == result.message
+    assert result.content == "reverted content"
+    mock_subprocess.assert_called_once_with(
+        ["git", "checkout", "main", "--", "test/index.test.tsx"],
+        "/tmp/test-repo",
+    )
+    mock_commit.assert_called_once_with(
+        base_args=base_args,
+        message="Revert test/index.test.tsx to main",
+        files=["test/index.test.tsx"],
+    )
+
+
+@patch("services.git.git_revert_file.read_local_file", return_value="sha content")
+@patch("services.git.git_revert_file.git_commit_and_push")
+@patch("services.git.git_revert_file.run_subprocess")
+def test_uses_latest_commit_sha_when_available(
+    mock_subprocess, _mock_commit, _mock_read, base_args
+):
+    """With latest_commit_sha (check_suite/review handlers), reverts to that SHA."""
+    base_args["latest_commit_sha"] = "abc123def456"
+
+    result = git_revert_file(file_path="src/app.ts", base_args=base_args)
+
+    assert result.success is True
+    assert "abc123d" in result.message
+    assert result.content == "sha content"
+    mock_subprocess.assert_called_once_with(
+        ["git", "checkout", "abc123def456", "--", "src/app.ts"],
+        "/tmp/test-repo",
+    )
+
+
+@patch("services.git.git_revert_file.read_local_file", return_value="unchanged content")
+@patch(
+    "services.git.git_revert_file.run_subprocess",
+    side_effect=ValueError("git checkout failed"),
+)
+def test_returns_current_content_on_failure(_mock_subprocess, _mock_read, base_args):
+    """On failure, returns current file content so agent knows what it's working with."""
+    result = git_revert_file(file_path="src/broken.ts", base_args=base_args)
+
+    assert result.success is False
+    assert result.file_path == "src/broken.ts"
+    assert result.content == "unchanged content"
+
+
+@pytest.mark.integration
+def test_git_revert_file_falls_back_to_base(local_repo, create_test_base_args):
+    """Sociable (new_pr case): no latest_commit_sha, reverts to base_branch."""
+    bare_url, _work_dir = local_repo
+
+    with tempfile.TemporaryDirectory() as clone_dir:
+        git_clone_to_tmp(clone_dir, bare_url, "main")
+
+        readme_path = os.path.join(clone_dir, "README.md")
+        with open(readme_path, encoding="utf-8") as f:
+            original = f.read()
+
+        # Create feature branch and modify README (simulates agent creating PR)
+        subprocess.run(
+            ["git", "checkout", "-b", "feature/revert-test"],
+            cwd=clone_dir,
+            check=True,
+            capture_output=True,
+        )
+        with open(readme_path, "w", encoding="utf-8") as f:
+            f.write("# Modified\n")
+        subprocess.run(
+            ["git", "add", "README.md"],
+            cwd=clone_dir,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=test",
+                "-c",
+                "user.email=test@test.com",
+                "commit",
+                "-m",
+                "modify readme",
+            ],
+            cwd=clone_dir,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "push", "origin", "HEAD:refs/heads/feature/revert-test"],
+            cwd=clone_dir,
+            check=True,
+            capture_output=True,
+        )
+
+        base_args = create_test_base_args(
+            clone_dir=clone_dir,
+            clone_url=bare_url,
+            new_branch="feature/revert-test",
+            base_branch="main",
+            latest_commit_sha="",
+        )
+
+        result = git_revert_file(file_path="README.md", base_args=base_args)
+
+        assert result.success is True
+        assert "Reverted README.md to main" == result.message
+        assert result.content == original
+        with open(readme_path, encoding="utf-8") as f:
+            assert f.read() == original
+
+
+@pytest.mark.integration
+def test_git_revert_file_uses_commit_sha(local_repo, create_test_base_args):
+    """Sociable (check_suite case): latest_commit_sha set, reverts to that SHA."""
+    bare_url, _work_dir = local_repo
+
+    with tempfile.TemporaryDirectory() as clone_dir:
+        git_clone_to_tmp(clone_dir, bare_url, "main")
+
+        # Create feature branch with PR author's change
+        subprocess.run(
+            ["git", "checkout", "-b", "feature/revert-sha"],
+            cwd=clone_dir,
+            check=True,
+            capture_output=True,
+        )
+        readme_path = os.path.join(clone_dir, "README.md")
+        with open(readme_path, "w", encoding="utf-8") as f:
+            f.write("# PR author change\n")
+        subprocess.run(
+            ["git", "add", "README.md"],
+            cwd=clone_dir,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=test",
+                "-c",
+                "user.email=test@test.com",
+                "commit",
+                "-m",
+                "PR author change",
+            ],
+            cwd=clone_dir,
+            check=True,
+            capture_output=True,
+        )
+        # This SHA is the "before agent started" point
+        pr_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=clone_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "push", "origin", "HEAD:refs/heads/feature/revert-sha"],
+            cwd=clone_dir,
+            check=True,
+            capture_output=True,
+        )
+
+        # Agent modifies the file further
+        with open(readme_path, "w", encoding="utf-8") as f:
+            f.write("# Agent broke this\n")
+        subprocess.run(
+            ["git", "add", "README.md"],
+            cwd=clone_dir,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=test",
+                "-c",
+                "user.email=test@test.com",
+                "commit",
+                "-m",
+                "agent change",
+            ],
+            cwd=clone_dir,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "push", "origin", "HEAD:refs/heads/feature/revert-sha"],
+            cwd=clone_dir,
+            check=True,
+            capture_output=True,
+        )
+
+        base_args = create_test_base_args(
+            clone_dir=clone_dir,
+            clone_url=bare_url,
+            new_branch="feature/revert-sha",
+            base_branch="main",
+            latest_commit_sha=pr_sha,
+        )
+
+        result = git_revert_file(file_path="README.md", base_args=base_args)
+
+        assert result.success is True
+        assert pr_sha[:7] in result.message
+        assert result.content == "# PR author change\n"
+        with open(readme_path, encoding="utf-8") as f:
+            assert f.read() == "# PR author change\n"


### PR DESCRIPTION
## Summary
- Add `git_revert_file` as a new agent tool that reverts a single file to its state before the agent started
- Returns `FileWriteResult` with file content (consistent with other edit tools like `apply_diff`, `search_and_replace`)
- On failure, returns current file content so the agent knows its working state
- Benchmark `git clone --depth 1` on Lambda: SPIDERPLUS-web (13k files, 1.1GB) clones in 17s - well within 900s timeout
- GitHub tarball API was 2x slower (37s) than git's pack protocol
- Add CLAUDE.md guideline for social media posts

## Social Media Posts

### GitAuto Post
Our AI agent can now undo its own changes to a single file and start over. If it gets stuck on a broken edit, it resets just that file while keeping everything else intact - then gets the restored content back so it can try a different approach immediately.

### Wes Post
Added a file-level undo for our coding agent. The tricky part wasn't the git checkout - it was making sure the agent gets the file content back after reverting so it can keep working, and getting the right content back even when the revert itself fails.