### PR TITLE
Low Test Coverage: services/sentry/before_send.py

### DIFF
--- a/services/sentry/before_send.py
+++ b/services/sentry/before_send.py
@@ -1,13 +1,12 @@
-from __future__ import (
-    annotations,
-)  # Sentry SDK exposes Event/Hint types only for type checkers, not at runtime
+from __future__ import \
+    annotations  # Sentry SDK exposes Event/Hint types only for type checkers, not at runtime
 
 from typing import TYPE_CHECKING
 
 from utils.error.handle_exceptions import handle_exceptions
 from utils.error.is_server_error import is_server_error
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from sentry_sdk._types import Event, Hint
 
 

--- a/services/sentry/before_send.py
+++ b/services/sentry/before_send.py
@@ -1,5 +1,6 @@
-from __future__ import \
-    annotations  # Sentry SDK exposes Event/Hint types only for type checkers, not at runtime
+from __future__ import (
+    annotations,
+)  # Sentry SDK exposes Event/Hint types only for type checkers, not at runtime
 
 from typing import TYPE_CHECKING
 
@@ -7,7 +8,7 @@ from utils.error.handle_exceptions import handle_exceptions
 from utils.error.is_server_error import is_server_error
 
 if TYPE_CHECKING:
-    from sentry_sdk._types import Event, Hint  # pragma: no cover
+    from sentry_sdk._types import Event, Hint
 
 
 @handle_exceptions(default_return_value=None, raise_on_error=False)

--- a/services/sentry/before_send.py
+++ b/services/sentry/before_send.py
@@ -1,6 +1,5 @@
-from __future__ import (
-    annotations,
-)  # Sentry SDK exposes Event/Hint types only for type checkers, not at runtime
+from __future__ import \
+    annotations  # Sentry SDK exposes Event/Hint types only for type checkers, not at runtime
 
 from typing import TYPE_CHECKING
 
@@ -8,7 +7,7 @@ from utils.error.handle_exceptions import handle_exceptions
 from utils.error.is_server_error import is_server_error
 
 if TYPE_CHECKING:
-    from sentry_sdk._types import Event, Hint
+    from sentry_sdk._types import Event, Hint  # pragma: no cover
 
 
 @handle_exceptions(default_return_value=None, raise_on_error=False)

--- a/services/sentry/test_before_send.py
+++ b/services/sentry/test_before_send.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 import requests
-
 from services.sentry.before_send import before_send
 
 if TYPE_CHECKING:
@@ -42,3 +41,90 @@ def test_passes_when_no_exc_info():
     """Events without exc_info should pass through."""
     event = cast("Event", {"message": "some log"})
     assert before_send(event, {}) == event
+
+
+def test_drops_500_internal_server_error():
+    # 500 is the lowest 5xx code; verify it's dropped like 502
+    response = requests.models.Response()
+    response.status_code = 500
+    exc = requests.exceptions.HTTPError(response=response)
+    hint = {"exc_info": (type(exc), exc, None)}
+    event = cast("Event", {"exception": {"values": [{"type": "HTTPError"}]}})
+    assert before_send(event, hint) is None
+
+
+def test_drops_503_service_unavailable():
+    # 503 is another common transient server error; confirm it's dropped
+    response = requests.models.Response()
+    response.status_code = 503
+    exc = requests.exceptions.HTTPError(response=response)
+    hint = {"exc_info": (type(exc), exc, None)}
+    event = cast("Event", {"exception": {"values": [{"type": "HTTPError"}]}})
+    assert before_send(event, hint) is None
+
+
+def test_passes_499_boundary():
+    # 499 is just below the 5xx threshold; must NOT be dropped
+    response = requests.models.Response()
+    response.status_code = 499
+    exc = requests.exceptions.HTTPError(response=response)
+    hint = {"exc_info": (type(exc), exc, None)}
+    event = cast("Event", {"exception": {"values": [{"type": "HTTPError"}]}})
+    assert before_send(event, hint) == event
+
+
+def test_passes_when_exc_info_is_none_tuple():
+    # exc_info present but exception element is None (e.g., manually constructed hint)
+    hint = {"exc_info": (None, None, None)}
+    event = cast("Event", {"message": "manual event"})
+    assert before_send(event, hint) == event
+
+
+def test_passes_when_hint_has_unrelated_keys():
+    # hint dict has keys but no exc_info; should pass through
+    hint = {"mechanism": {"type": "generic"}, "log_record": "something"}
+    event = cast("Event", {"level": "info"})
+    assert before_send(event, hint) == event
+
+
+def test_drops_server_error_with_status_code_attr():
+    # Anthropic/OpenAI SDK errors use a status_code attribute directly on the exception
+    exc = Exception("API error")
+    exc.status_code = 502  # type: ignore[attr-defined]
+    hint = {"exc_info": (type(exc), exc, None)}
+    event = cast("Event", {"exception": {"values": [{"type": "Exception"}]}})
+    assert before_send(event, hint) is None
+
+
+def test_drops_server_error_with_http_status_attr():
+    # Stripe SDK errors use http_status attribute
+    exc = Exception("Stripe error")
+    exc.http_status = 500  # type: ignore[attr-defined]
+    hint = {"exc_info": (type(exc), exc, None)}
+    event = cast("Event", {"exception": {"values": [{"type": "Exception"}]}})
+    assert before_send(event, hint) is None
+
+
+def test_drops_server_error_with_status_attr():
+    # PyGithub GithubException uses .status attribute
+    exc = Exception("GitHub error")
+    exc.status = 500  # type: ignore[attr-defined]
+    hint = {"exc_info": (type(exc), exc, None)}
+    event = cast("Event", {"exception": {"values": [{"type": "Exception"}]}})
+    assert before_send(event, hint) is None
+
+
+def test_passes_non_server_error_with_status_code_attr():
+    # 400-level status_code on exception should NOT be dropped
+    exc = Exception("Client error")
+    exc.status_code = 400  # type: ignore[attr-defined]
+    hint = {"exc_info": (type(exc), exc, None)}
+    event = cast("Event", {"exception": {"values": [{"type": "Exception"}]}})
+    assert before_send(event, hint) == event
+
+
+def test_passes_empty_event():
+    # Minimal empty event dict should pass through when no exception in hint
+    hint: dict = {}
+    event = cast("Event", {})
+    assert before_send(event, hint) == event

--- a/services/sentry/test_before_send.py
+++ b/services/sentry/test_before_send.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name, unused-argument
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast


### PR DESCRIPTION
## File: [services/sentry/before_send.py](https://github.com/gitautoai/gitauto/blob/HEAD/services/sentry/before_send.py)

- Line Coverage: 91% (Uncovered Lines: 11)
- Statement Coverage: 91%
- Function Coverage: 100% 
- Branch Coverage: 75% (Uncovered Branches: line 10, block 0, if branch: 10 -> 11)

Last Updated: 4/7/2026, 12:29:25 AM

Aim to achieve 100% coverage with minimal code changes. Focus on covering the uncovered areas, including both happy paths, error cases, edge cases, and corner cases. Add to existing test file if available, or create a new one.

## Coverage Dashboard

View full coverage details in the [Coverage Dashboard](https://gitauto.ai/dashboard/file-coverage?utm_source=github&utm_medium=referral)

## Test these changes locally

```
git fetch origin
git checkout gitauto/dashboard-20260407-003245-zs5v
git pull origin gitauto/dashboard-20260407-003245-zs5v
```