### PR TITLE
Fix S3 bucket name to be globally unique

### DIFF
--- a/constants/aws.py
+++ b/constants/aws.py
@@ -3,7 +3,9 @@ import os
 AWS_REGION = "us-west-1"
 
 # S3 bucket for dependency tarballs (node_modules.tar.gz, vendor.tar.gz)
-S3_DEPENDENCY_BUCKET = os.environ.get("S3_DEPENDENCY_BUCKET", "dependency-cache")
+S3_DEPENDENCY_BUCKET = os.environ.get(
+    "S3_DEPENDENCY_BUCKET", "gitauto-dependency-cache"
+)
 
 # 10 minutes - max time to wait for EFS install and run linters
 EFS_TIMEOUT_SECONDS = 600

--- a/infrastructure/setup-vpc-nat-efs.yml
+++ b/infrastructure/setup-vpc-nat-efs.yml
@@ -316,7 +316,7 @@ Resources:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain # Keep bucket if stack is deleted
     Properties:
-      BucketName: dependency-cache
+      BucketName: gitauto-dependency-cache
       BucketEncryption: # Encrypt at rest (free)
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionRule:

--- a/services/aws/test_run_install_via_codebuild.py
+++ b/services/aws/test_run_install_via_codebuild.py
@@ -40,7 +40,7 @@ def test_run_install_via_codebuild_starts_build():
                 env_vars = call_args.kwargs["environmentVariablesOverride"]
                 assert {
                     "name": "S3_BUCKET",
-                    "value": "dependency-cache",
+                    "value": "gitauto-dependency-cache",
                     "type": "PLAINTEXT",
                 } in env_vars
                 assert {


### PR DESCRIPTION
S3 bucket names must be globally unique across all AWS accounts. `dependency-cache` was already taken, causing CloudFormation deploy failure. Changed to `gitauto-dependency-cache`.