### PR TITLE
Prevent closed-without-merge PRs from canceling deployments

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,7 +13,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: deploy-lambda
+  # Closed-without-merge PRs get a unique group so they can't cancel real deployments
+  group: ${{ github.event.pull_request.merged == true && 'deploy-lambda' || format('deploy-skip-{0}', github.run_id) }}
   cancel-in-progress: true # Cancel older deployments, run only the latest
 
 env:


### PR DESCRIPTION
Closed-without-merge PRs triggered the deployment workflow, entered the same concurrency group, and canceled in-progress real deployments before skipping themselves. Fix: give unmerged PRs a unique concurrency group so only actual deployments can cancel each other.