### PR TITLE
Fix S3 lifecycle rule and add CFN validation to pre-commit

### DIFF
--- a/infrastructure/setup-vpc-nat-efs.yml
+++ b/infrastructure/setup-vpc-nat-efs.yml
@@ -332,6 +332,8 @@ Resources:
           - Id: ExpireOldTarballs
             Status: Enabled
             ExpirationInDays: 30
+            Filter:
+              Prefix: "" # Apply to all objects
 
   # =============================================================================
   # CodeBuild - AWS managed build service (serverless containers, not EC2)

--- a/scripts/git/pre_commit_hook.sh
+++ b/scripts/git/pre_commit_hook.sh
@@ -39,6 +39,21 @@ if [ -n "$STAGED_MD_FILES" ]; then
     fi
 fi
 
+# CloudFormation template validation for staged infrastructure files
+STAGED_CFN_FILES=$(git diff --cached --name-only --diff-filter=d -- 'infrastructure/*.yml')
+if [ -n "$STAGED_CFN_FILES" ]; then
+    echo "--- CloudFormation validation ---"
+    for cfn_file in $STAGED_CFN_FILES; do
+        if aws cloudformation validate-template --template-body "file://$cfn_file" --region us-west-1 > /dev/null 2>&1; then
+            echo "  $cfn_file: OK"
+        else
+            echo "FAILED: $cfn_file failed CloudFormation validation."
+            aws cloudformation validate-template --template-body "file://$cfn_file" --region us-west-1
+            exit 1
+        fi
+    done
+fi
+
 # Print statement check (whole repo, excluding dirs)
 echo "--- ruff T201 print check ---"
 ruff check --select=T201 . --exclude schemas/,venv/,scripts/


### PR DESCRIPTION
CloudFormation deploy failed with AWS::EarlyValidation::PropertyValidation because the S3 lifecycle rule was missing the required Filter property. Added Filter with empty prefix (applies to all objects).