### PR TITLE
Fix CFN errors and add cfn-lint to pre-commit

### DIFF
--- a/infrastructure/deploy-lambda-with-vpc-efs.yml
+++ b/infrastructure/deploy-lambda-with-vpc-efs.yml
@@ -30,6 +30,7 @@ Resources:
   ECRRepository:
     Type: AWS::ECR::Repository
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       RepositoryName: !Ref LambdaFunctionName
       ImageScanningConfiguration:
@@ -99,7 +100,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:GetObject
-                  - s3:HeadObject
                   - s3:PutObject
                   - s3:DeleteObject
                   - s3:ListBucket
@@ -136,6 +136,7 @@ Resources:
   LambdaFunction:
     Type: AWS::Lambda::Function
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     DependsOn: LogGroup
     Properties:
       FunctionName: !Ref LambdaFunctionName

--- a/infrastructure/setup-vpc-nat-efs.yml
+++ b/infrastructure/setup-vpc-nat-efs.yml
@@ -48,6 +48,10 @@ Resources:
 
   PublicSubnet:
     Type: AWS::EC2::Subnet
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [W3010] # Intentional: us-west-1 only has 2 AZs (a, c)
     Properties:
       VpcId: !Ref VPC
       CidrBlock: 10.0.1.0/24
@@ -60,6 +64,10 @@ Resources:
   # Private subnets (for Lambda + EFS)
   PrivateSubnet1:
     Type: AWS::EC2::Subnet
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [W3010] # Intentional: us-west-1 only has 2 AZs (a, c)
     Properties:
       VpcId: !Ref VPC
       CidrBlock: 10.0.11.0/24
@@ -70,6 +78,10 @@ Resources:
 
   PrivateSubnet2:
     Type: AWS::EC2::Subnet
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks: [W3010] # Intentional: us-west-1 only has 2 AZs (a, c)
     Properties:
       VpcId: !Ref VPC
       CidrBlock: 10.0.12.0/24
@@ -315,13 +327,13 @@ Resources:
   DependencyCacheBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain # Keep bucket if stack is deleted
+    UpdateReplacePolicy: Retain
     Properties:
       BucketName: gitauto-dependency-cache
       BucketEncryption: # Encrypt at rest (free)
         ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionRule:
-              ServerSideEncryptionByDefault:
-                SSEAlgorithm: AES256
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
       PublicAccessBlockConfiguration: # No public access
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -332,8 +344,6 @@ Resources:
           - Id: ExpireOldTarballs
             Status: Enabled
             ExpirationInDays: 30
-            Filter:
-              Prefix: "" # Apply to all objects
 
   # =============================================================================
   # CodeBuild - AWS managed build service (serverless containers, not EC2)
@@ -417,7 +427,6 @@ Resources:
                 Action:
                   - s3:GetObject
                   - s3:PutObject
-                  - s3:HeadObject
                 Resource: !Sub '${DependencyCacheBucket.Arn}/*'
       Tags:
         - Key: Name

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,10 @@ annotated-types==0.7.0
 anthropic==0.77.0
 anyio==4.4.0
 astroid==3.2.4
+attrs==26.1.0
 autoflake==2.3.1
 autopep8==2.3.2
+aws-sam-translator==1.108.0
 aws_lambda_powertools==3.24.0
 backoff==2.2.1
 beautifulsoup4==4.12.3
@@ -16,6 +18,7 @@ botocore-stubs==1.38.46
 certifi==2024.7.4
 cffi==2.0.0
 cfgv==3.4.0
+cfn-lint==1.48.1
 chardet==5.2.0
 charset-normalizer==3.3.2
 click==8.3.1
@@ -61,12 +64,17 @@ Jinja2==3.1.6
 jiter==0.8.2
 jmespath==1.0.1
 json-with-comments==1.2.10
+jsonpatch==1.33
+jsonpointer==3.1.1
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
 lxml==6.0.2
 mangum==0.17.0
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mccabe==0.7.0
 mdurl==0.1.2
+mpmath==1.3.0
 multidict==6.1.0
 mypy-boto3-codebuild==1.42.3
 mypy-boto3-ec2==1.42.38
@@ -75,6 +83,7 @@ mypy-boto3-logs==1.42.10
 mypy-boto3-s3==1.42.80
 mypy-boto3-scheduler==1.42.3
 mypy-extensions==1.0.0
+networkx==3.6.1
 nodeenv==1.9.1
 openai==1.107.3
 orjson==3.10.15
@@ -91,8 +100,8 @@ psutil==7.0.0
 psycopg2-binary==2.9.10
 pycodestyle==2.14.0
 pycparser==2.22
-pydantic==2.8.2
-pydantic_core==2.20.1
+pydantic==2.12.5
+pydantic_core==2.41.5
 pyee==12.1.1
 pyflakes==3.4.0
 PyGithub==2.3.0
@@ -110,11 +119,13 @@ python-dotenv==1.0.1
 python-multipart==0.0.20
 PyYAML==6.0.2
 realtime==1.0.6
+referencing==0.37.0
 regex==2024.11.6
 requests==2.32.4
 requests-toolbelt==1.0.0
 resend==2.11.0
 rich==13.7.1
+rpds-py==0.30.0
 ruff==0.12.1
 s3transfer==0.16.0
 sentry-sdk==2.12.0
@@ -129,6 +140,7 @@ StrEnum==0.4.15
 stripe==14.1.0
 supabase==2.6.0
 supafunc==0.5.1
+sympy==1.14.0
 tiktoken==0.11.0
 toml==0.10.2
 tomlkit==0.13.0
@@ -140,6 +152,7 @@ types-html5lib==1.1.11.20251117
 types-psycopg2==2.9.21.20250516
 types-s3transfer==0.13.0
 types-webencodings==0.5.0.20251108
+typing-inspection==0.4.2
 typing_extensions==4.14.1
 ujson==5.10.0
 urllib3==2.6.3

--- a/scripts/git/pre_commit_hook.sh
+++ b/scripts/git/pre_commit_hook.sh
@@ -39,19 +39,15 @@ if [ -n "$STAGED_MD_FILES" ]; then
     fi
 fi
 
-# CloudFormation template validation for staged infrastructure files
+# CloudFormation (CFN) template validation for staged infrastructure files (errors only, ignore warnings)
 STAGED_CFN_FILES=$(git diff --cached --name-only --diff-filter=d -- 'infrastructure/*.yml')
 if [ -n "$STAGED_CFN_FILES" ]; then
-    echo "--- CloudFormation validation ---"
-    for cfn_file in $STAGED_CFN_FILES; do
-        if aws cloudformation validate-template --template-body "file://$cfn_file" --region us-west-1 > /dev/null 2>&1; then
-            echo "  $cfn_file: OK"
-        else
-            echo "FAILED: $cfn_file failed CloudFormation validation."
-            aws cloudformation validate-template --template-body "file://$cfn_file" --region us-west-1
-            exit 1
-        fi
-    done
+    echo "--- cfn-lint (CloudFormation) ---"
+    # shellcheck disable=SC2086
+    if ! cfn-lint -- $STAGED_CFN_FILES; then
+        echo "FAILED: Fix cfn-lint errors before committing."
+        exit 1
+    fi
 fi
 
 # Print statement check (whole repo, excluding dirs)


### PR DESCRIPTION
CloudFormation deploy was failing with AWS::EarlyValidation::PropertyValidation. Root causes found via cfn-lint: (1) S3 BucketEncryption had extra ServerSideEncryptionRule nesting, (2) s3:HeadObject is not a valid IAM action (s3:GetObject covers it). Also added cfn-lint to pre-commit hook and UpdateReplacePolicy to resources with DeletionPolicy.