### PR TITLE
Fix CloudFormation deploy: delete orphaned S3 bucket, revert immutable SG description

### DIFF
--- a/infrastructure/setup-vpc-nat-s3.yml
+++ b/infrastructure/setup-vpc-nat-s3.yml
@@ -347,7 +347,7 @@ Resources:
   CodeBuildSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Security group for CodeBuild (VPC access for private npm registries)
+      GroupDescription: Security group for CodeBuild to access EFS
       VpcId: !Ref VPC
       SecurityGroupEgress:
         - IpProtocol: -1


### PR DESCRIPTION
## Summary
- Reverted CodeBuild SecurityGroup GroupDescription change — SG descriptions are immutable in AWS, changing them forces resource replacement which cascades
- Deleted orphaned S3 bucket `gitauto-dependency-cache` that was retained from a previous rolled-back deployment (DeletionPolicy: Retain), blocking CloudFormation from creating it

## Context
The S3 bucket was created in a prior failed deploy, then retained during rollback. Subsequent deploys fail with `ResourceExistenceCheck` because CloudFormation tries to create a bucket that already exists. Bucket was empty so safe to delete.