### PR TITLE
Low Test Coverage: services/supabase/check_suites/insert_check_suite.py

### DIFF
--- a/services/supabase/check_suites/test_insert_check_suite.py
+++ b/services/supabase/check_suites/test_insert_check_suite.py
@@ -2,8 +2,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from postgrest.exceptions import APIError
-
-from services.supabase.check_suites.insert_check_suite import insert_check_suite
+from services.supabase.check_suites.insert_check_suite import \
+    insert_check_suite
 
 
 @pytest.fixture
@@ -60,5 +60,19 @@ def test_insert_check_suite_exception_returns_false(mock_supabase_client):
     )
 
     result = insert_check_suite(check_suite_id=12345)
+
+    assert result is False
+
+
+def test_insert_check_suite_non_duplicate_api_error_reraises(mock_supabase_client):
+    # APIError with a non-23505 code should re-raise (line 23), which the
+    # handle_exceptions decorator catches and returns False.
+    mock, _ = mock_supabase_client
+    api_error = APIError(
+        {"code": "42501", "message": "permission denied for table check_suites"}
+    )
+    mock.table.return_value.insert.return_value.execute.side_effect = api_error
+
+    result = insert_check_suite(check_suite_id=99999)
 
     assert result is False

--- a/services/supabase/check_suites/test_insert_check_suite.py
+++ b/services/supabase/check_suites/test_insert_check_suite.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name, unused-argument
 from unittest.mock import MagicMock, patch
 
 import pytest


### PR DESCRIPTION
## File: [services/supabase/check_suites/insert_check_suite.py](https://github.com/gitautoai/gitauto/blob/HEAD/services/supabase/check_suites/insert_check_suite.py)

- Line Coverage: 92% (Uncovered Lines: 23)
- Statement Coverage: 92%
- Function Coverage: 100% 
- Branch Coverage: 75% (Uncovered Branches: line 21, block 0, if branch: 21 -> 23)

Last Updated: 4/7/2026, 5:37:17 AM

Aim to achieve 100% coverage with minimal code changes. Focus on covering the uncovered areas, including both happy paths, error cases, edge cases, and corner cases. Add to existing test file if available, or create a new one.

## Coverage Dashboard

View full coverage details in the [Coverage Dashboard](https://gitauto.ai/dashboard/file-coverage?utm_source=github&utm_medium=referral)

## Test these changes locally

```
git fetch origin
git checkout gitauto/dashboard-20260407-053742-3214
git pull origin gitauto/dashboard-20260407-053742-3214
```