### PR TITLE
Fix CloudFormation deploy: keep PrivilegedMode true, fix OOM threshold

### DIFF
--- a/infrastructure/setup-vpc-nat-s3.yml
+++ b/infrastructure/setup-vpc-nat-s3.yml
@@ -343,7 +343,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL # 3GB RAM, 2 vCPU, ~$0.005/min
         Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0 # Has Node.js 24
-        PrivilegedMode: false
+        PrivilegedMode: true # TODO: Set to false after FileSystemLocations is removed from live state
         EnvironmentVariables:
           - Name: S3_BUCKET
             Value: !Ref DependencyCacheBucket

--- a/utils/memory/is_lambda_oom_approaching.py
+++ b/utils/memory/is_lambda_oom_approaching.py
@@ -3,7 +3,7 @@ from utils.error.handle_exceptions import handle_exceptions
 from utils.memory.get_rss_mb import get_rss_mb
 
 # Must match MemorySize in infrastructure/deploy-lambda.yml
-LAMBDA_MEMORY_MB = 2048
+LAMBDA_MEMORY_MB = 3072
 
 
 @handle_exceptions(default_return_value=(False, 0), raise_on_error=False)

--- a/utils/memory/test_is_lambda_oom_approaching.py
+++ b/utils/memory/test_is_lambda_oom_approaching.py
@@ -10,7 +10,7 @@ from utils.memory.is_lambda_oom_approaching import (
     is_lambda_oom_approaching,
 )
 
-# 90% of 2048 = 1843.2 MB
+# 90% of 3072 = 2764.8 MB
 THRESHOLD_MB = LAMBDA_MEMORY_MB * 90 / 100
 
 
@@ -35,12 +35,12 @@ class TestIsLambdaOomApproaching:
     @patch("utils.memory.get_rss_mb._IS_MACOS", False)
     @patch("utils.memory.get_rss_mb.resource")
     def test_above_threshold_linux(self, mock_resource):
-        # 1900 MB in KB (above 1843.2 MB threshold)
-        mock_resource.getrusage.return_value = _mock_rusage(1900 * 1024)
+        # 2800 MB in KB (above 2764.8 MB threshold)
+        mock_resource.getrusage.return_value = _mock_rusage(2800 * 1024)
         mock_resource.RUSAGE_SELF = 0
         is_approaching, used_mb = is_lambda_oom_approaching()
         assert is_approaching is True
-        assert used_mb == 1900.0
+        assert used_mb == 2800.0
 
     @patch("utils.memory.get_rss_mb._IS_MACOS", True)
     @patch("utils.memory.get_rss_mb.resource")
@@ -55,32 +55,32 @@ class TestIsLambdaOomApproaching:
     @patch("utils.memory.get_rss_mb._IS_MACOS", True)
     @patch("utils.memory.get_rss_mb.resource")
     def test_above_threshold_macos(self, mock_resource):
-        # 1900 MB in bytes (macOS units)
-        mock_resource.getrusage.return_value = _mock_rusage(1900 * 1024 * 1024)
+        # 2800 MB in bytes (macOS units)
+        mock_resource.getrusage.return_value = _mock_rusage(2800 * 1024 * 1024)
         mock_resource.RUSAGE_SELF = 0
         is_approaching, used_mb = is_lambda_oom_approaching()
         assert is_approaching is True
-        assert used_mb == 1900.0
+        assert used_mb == 2800.0
 
     @patch("utils.memory.get_rss_mb._IS_MACOS", False)
     @patch("utils.memory.get_rss_mb.resource")
     def test_exact_threshold_not_approaching(self, mock_resource):
-        # Exactly at threshold (1843.2 MB) - use 1843 MB, not greater, so False
-        mock_resource.getrusage.return_value = _mock_rusage(1843 * 1024)
+        # Exactly at threshold (2764.8 MB) - use 2764 MB, not greater, so False
+        mock_resource.getrusage.return_value = _mock_rusage(2764 * 1024)
         mock_resource.RUSAGE_SELF = 0
         is_approaching, used_mb = is_lambda_oom_approaching()
         assert is_approaching is False
-        assert used_mb == 1843.0
+        assert used_mb == 2764.0
 
     @patch("utils.memory.get_rss_mb._IS_MACOS", False)
     @patch("utils.memory.get_rss_mb.resource")
     def test_just_above_threshold(self, mock_resource):
-        # 1844 MB - just above 1843.2 threshold
-        mock_resource.getrusage.return_value = _mock_rusage(1844 * 1024)
+        # 2765 MB - just above 2764.8 threshold
+        mock_resource.getrusage.return_value = _mock_rusage(2765 * 1024)
         mock_resource.RUSAGE_SELF = 0
         is_approaching, used_mb = is_lambda_oom_approaching()
         assert is_approaching is True
-        assert used_mb == 1844.0
+        assert used_mb == 2765.0
 
     @pytest.mark.parametrize(
         "used_kb, expected_approaching",
@@ -88,9 +88,9 @@ class TestIsLambdaOomApproaching:
             (0, False),
             (512 * 1024, False),
             (1024 * 1024, False),
-            (1843 * 1024, False),
-            (1844 * 1024, True),
-            (2048 * 1024, True),
+            (2764 * 1024, False),
+            (2765 * 1024, True),
+            (3072 * 1024, True),
         ],
         ids=["zero", "512mb", "1024mb", "at_threshold", "above_threshold", "at_limit"],
     )
@@ -106,4 +106,4 @@ class TestIsLambdaOomApproaching:
         assert hasattr(is_lambda_oom_approaching, "__wrapped__")
 
     def test_constant_matches_infrastructure(self):
-        assert LAMBDA_MEMORY_MB == 2048
+        assert LAMBDA_MEMORY_MB == 3072


### PR DESCRIPTION
## Summary
- Keep CodeBuild `PrivilegedMode: true` temporarily — AWS rejects setting it to false while the live project still has `FileSystemLocations` (from pre-EFS-removal state). CloudFormation can't atomically remove FileSystemLocations AND change PrivilegedMode in one update.
- Fix `LAMBDA_MEMORY_MB` constant from 2048 to 3072 to match actual `MemorySize` in deploy-lambda.yml. The OOM threshold was checking against stale value.

## Follow-up (after this deploys)
- Set `PrivilegedMode: false` (FileSystemLocations will be gone from live state)
- Remove `LambdaSecurityGroup` + unused VPC/subnet exports (Lambda no longer in VPC)