### PR TITLE
Set PrivilegedMode false, remove LambdaSecurityGroup, rename setup-infra.yml

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           aws cloudformation deploy \
             --stack-name gitauto-vpc-nat-efs \
-            --template-file infrastructure/setup-vpc-nat-s3.yml \
+            --template-file infrastructure/setup-infra.yml \
             --capabilities CAPABILITY_NAMED_IAM \
             --no-fail-on-empty-changeset
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ ssh -i infrastructure/nat-instance-ssh-private-key.pem ec2-user@54.176.165.89
 **CRITICAL**: GitAuto runs on AWS Lambda, not in client environments. Infrastructure is managed via CloudFormation:
 
 - `Dockerfile` - Lambda container image
-- `infrastructure/setup-vpc-nat-s3.yml` - VPC, NAT, S3, CodeBuild project and IAM role
+- `infrastructure/setup-infra.yml` - VPC, NAT, S3, CodeBuild project and IAM role
 - `infrastructure/deploy-lambda.yml` - Lambda function and IAM role
 
 ### Testing Strategy

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -fsSL https://rpm.nodesource.com/setup_24.x | bash - && \
     npm install -g yarn
 
 # Install PHP CLI and Composer for PHPUnit test execution
-# Same packages are also installed in CodeBuild (infrastructure/setup-vpc-nat-s3.yml)
+# Same packages are also installed in CodeBuild (infrastructure/setup-infra.yml)
 # php-cli: PHP command-line interpreter to run PHPUnit
 # php-json: JSON encoding/decoding used by PHPUnit for config and result output
 # php-mbstring: Multibyte string functions required by PHPUnit for string diffing

--- a/infrastructure/deploy-lambda.yml
+++ b/infrastructure/deploy-lambda.yml
@@ -4,8 +4,7 @@ Description: 'Lambda function with IAM role for GitAuto'
 # =============================================================================
 # Deployed via: .github/workflows/deployment.yml
 # Stack name: gitauto-lambda-with-vpc-efs (can't rename without changing Function URL)
-# Depends on: gitauto-vpc-nat-efs (exports VPC, subnets, security groups, S3 bucket)
-# File renamed from deploy-lambda-with-vpc-efs.yml after EFS removal
+# Depends on: gitauto-vpc-nat-efs (exports S3 bucket)
 # =============================================================================
 
 Parameters:

--- a/infrastructure/setup-infra.yml
+++ b/infrastructure/setup-infra.yml
@@ -4,7 +4,6 @@ Description: 'VPC + NAT Instance (~$4/mo) + S3 + CodeBuild for GitAuto'
 # =============================================================================
 # Deployed via: .github/workflows/deployment.yml
 # Stack name: gitauto-vpc-nat-efs (can't rename without recreating all resources)
-# File renamed from setup-vpc-nat-efs.yml after EFS removal
 # =============================================================================
 Resources:
 
@@ -227,21 +226,6 @@ Resources:
       AllocationId: !GetAtt NATEIP.AllocationId
 
   # =============================================================================
-  # Lambda Security Group - only egress needed (Lambda initiates connections, doesn't receive)
-  # =============================================================================
-  LambdaSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Security group for GitAuto Lambda
-      VpcId: !Ref VPC
-      SecurityGroupEgress:
-        - IpProtocol: -1 # All outbound traffic
-          CidrIp: 0.0.0.0/0
-      Tags:
-        - Key: Name
-          Value: gitauto-lambda-sg
-
-  # =============================================================================
   # S3 Bucket - dependency cache
   # Stores node_modules.tar.gz, vendor.tar.gz per repo, and etc.
   # Key structure: {owner}/{repo}/node_modules.tar.gz
@@ -343,7 +327,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL # 3GB RAM, 2 vCPU, ~$0.005/min
         Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0 # Has Node.js 24
-        PrivilegedMode: true # TODO: Set to false after FileSystemLocations is removed from live state
+        PrivilegedMode: false
         EnvironmentVariables:
           - Name: S3_BUCKET
             Value: !Ref DependencyCacheBucket
@@ -422,33 +406,9 @@ Resources:
           Value: gitauto-package-install
 
 # =============================================================================
-# Outputs - values needed to configure Lambda
+# Outputs
 # =============================================================================
 Outputs:
-  VPCId:
-    Description: VPC ID
-    Value: !Ref VPC
-    Export:
-      Name: GitAutoVPCId
-
-  PrivateSubnet1Id:
-    Description: Private Subnet 1 ID (us-west-1a)
-    Value: !Ref PrivateSubnet1
-    Export:
-      Name: GitAutoPrivateSubnet1Id
-
-  PrivateSubnet2Id:
-    Description: Private Subnet 2 ID (us-west-1c)
-    Value: !Ref PrivateSubnet2
-    Export:
-      Name: GitAutoPrivateSubnet2Id
-
-  LambdaSecurityGroupId:
-    Description: Security Group ID for Lambda
-    Value: !Ref LambdaSecurityGroup
-    Export:
-      Name: GitAutoLambdaSecurityGroupId
-
   NATInstanceId:
     Description: NAT Instance ID
     Value: !Ref NATInstance

--- a/utils/files/fixtures/gitauto.txt
+++ b/utils/files/fixtures/gitauto.txt
@@ -44,7 +44,7 @@ constants/website.py
 infrastructure/cloudwatch-alarms-sns.yml
 infrastructure/deploy-lambda.yml
 infrastructure/eventbridge-scheduler.yml
-infrastructure/setup-vpc-nat-s3.yml
+infrastructure/setup-infra.yml
 main.py
 payloads/aws/event_bridge_scheduler/context.json
 payloads/aws/event_bridge_scheduler/event.json


### PR DESCRIPTION
## Summary
- Set CodeBuild `PrivilegedMode: false` — now safe since FileSystemLocations was removed from live state in the previous deploy
- Remove `LambdaSecurityGroup` resource — Lambda is no longer in VPC
- Remove unused exports (VPCId, PrivateSubnet1Id, PrivateSubnet2Id, LambdaSecurityGroupId) — Lambda stack no longer imports them
- Rename `setup-vpc-nat-s3.yml` → `setup-infra.yml` — generic name since the file covers VPC, NAT, S3, and CodeBuild
- Clean up stale "file renamed" comments