### PR TITLE
Move diff from message to dedicated FileWriteResult.diff field

### DIFF
--- a/services/chat_with_agent.py
+++ b/services/chat_with_agent.py
@@ -317,9 +317,12 @@ async def chat_with_agent(
                             file_path=tool_result.file_path,
                             content=tool_result.content,
                         )
-                        tool_result_content = (
-                            f"{tool_result.message}\n\n{formatted_content}"
+                        diff_section = (
+                            f"\n\nDiff:\n```\n{tool_result.diff}```"
+                            if tool_result.diff
+                            else ""
                         )
+                        tool_result_content = f"{tool_result.message}{diff_section}\n\n{formatted_content}"
                     else:
                         tool_result_content = tool_result.message
                 elif isinstance(tool_result, FileMoveResult):

--- a/services/claude/tools/file_modify_result.py
+++ b/services/claude/tools/file_modify_result.py
@@ -9,6 +9,7 @@ class FileWriteResult:
     message: str
     file_path: str
     content: str
+    diff: str = ""
     commit_sha: str = ""
 
 

--- a/services/git/search_and_replace.py
+++ b/services/git/search_and_replace.py
@@ -147,10 +147,10 @@ def search_and_replace(
         base_args=base_args, message=f"Update {file_path}", files=[file_path]
     )
 
-    diff_section = f"\n\nDiff:\n```\n{diff_text}```" if diff_text else ""
     return FileWriteResult(
         success=True,
-        message=f"Updated {file_path}.{diff_section}",
+        message=f"Updated {file_path}.",
         file_path=file_path,
         content=new_content,
+        diff=diff_text,
     )

--- a/services/git/test_search_and_replace.py
+++ b/services/git/test_search_and_replace.py
@@ -238,9 +238,9 @@ def test_diff_included_in_message(sample_base_args, tmp_path):
 
     assert isinstance(result, FileWriteResult)
     assert result.success is True
-    assert "Diff:" in result.message
-    assert "-beta" in result.message
-    assert "+delta" in result.message
+    assert "Diff:" not in result.message
+    assert "-beta" in result.diff
+    assert "+delta" in result.diff
 
 
 # ---------------------------------------------------------------------------
@@ -318,9 +318,9 @@ def test_pydecimal_add_method_unique_with_docstring(
     assert len(content.split("\n")) > 6000
     # result.content must match what was written to disk
     assert result.content == content
-    # Diff must be in the message
-    assert "Diff:" in result.message
-    assert "+        NOTE: patched by search_and_replace test." in result.message
+    # Diff must be in the diff field, not in message
+    assert "Diff:" not in result.message
+    assert "+        NOTE: patched by search_and_replace test." in result.diff
 
 
 def test_pydecimal_disambiguate_convert_other_via_method_signature(
@@ -351,8 +351,8 @@ def test_pydecimal_disambiguate_convert_other_via_method_signature(
     assert "raiseit=False" not in sub_block
     # result.content matches disk and diff is present
     assert result.content == content
-    assert "Diff:" in result.message
-    assert "+        other = _convert_other(other, raiseit=False)" in result.message
+    assert "Diff:" not in result.message
+    assert "+        other = _convert_other(other, raiseit=False)" in result.diff
 
 
 # ---------------------------------------------------------------------------
@@ -430,9 +430,9 @@ def test_argparse_help_action_call_unique_with_body(
     assert len(content.split("\n")) > 2500
     # result.content matches disk and diff is present
     assert result.content == content
-    assert "Diff:" in result.message
-    assert "+        parser.print_help(file=None)" in result.message
-    assert "+        parser.exit(status=0)" in result.message
+    assert "Diff:" not in result.message
+    assert "+        parser.print_help(file=None)" in result.diff
+    assert "+        parser.exit(status=0)" in result.diff
 
 
 def test_argparse_disambiguate_call_via_class_context(
@@ -460,8 +460,8 @@ def test_argparse_disambiguate_call_via_class_context(
     assert "class _StoreAction(Action):" in content
     # result.content matches disk and diff is present
     assert result.content == content
-    assert "Diff:" in result.message
-    assert '+    """Display help and exit."""' in result.message
+    assert "Diff:" not in result.message
+    assert '+    """Display help and exit."""' in result.diff
 
 
 # ---------------------------------------------------------------------------
@@ -538,7 +538,8 @@ def test_typing_special_form_class_unique(sample_base_args, tmp_path, typing_sou
     assert len(content.split("\n")) > 3500
     # result.content matches disk and diff is present
     assert result.content == content
-    assert "Diff:" in result.message
+    assert "Diff:" not in result.message
+    assert result.diff
 
 
 # ---------------------------------------------------------------------------

--- a/services/git/test_write_and_commit_file.py
+++ b/services/git/test_write_and_commit_file.py
@@ -193,9 +193,9 @@ def test_diff_included_for_existing_file(sample_base_args, tmp_path):
 
     assert isinstance(result, FileWriteResult)
     assert result.success is True
-    assert "Diff:" in result.message
-    assert "-line " in result.message
-    assert "+replaced " in result.message
+    assert "Diff:" not in result.message
+    assert "-line " in result.diff
+    assert "+replaced " in result.diff
 
 
 def test_diff_included_for_small_change(sample_base_args, tmp_path):
@@ -216,9 +216,9 @@ def test_diff_included_for_small_change(sample_base_args, tmp_path):
 
     assert isinstance(result, FileWriteResult)
     assert result.success is True
-    assert "Diff:" in result.message
-    assert "-line 5" in result.message
-    assert "+modified line 5" in result.message
+    assert "Diff:" not in result.message
+    assert "-line 5" in result.diff
+    assert "+modified line 5" in result.diff
 
 
 def test_no_diff_for_new_files(sample_base_args, tmp_path):
@@ -231,7 +231,7 @@ def test_no_diff_for_new_files(sample_base_args, tmp_path):
 
     assert isinstance(result, FileWriteResult)
     assert result.success is True
-    assert "Diff:" not in result.message
+    assert result.diff == ""
 
 
 def test_tool_definition_structure():

--- a/services/git/write_and_commit_file.py
+++ b/services/git/write_and_commit_file.py
@@ -109,10 +109,10 @@ def write_and_commit_file(
     message = commit_message if commit_message else default_message
     git_commit_and_push(base_args=base_args, message=message, files=[file_path])
 
-    diff_section = f"\n\nDiff:\n```\n{diff_text}```" if diff_text else ""
     return FileWriteResult(
         success=True,
-        message=f"{'Updated' if file_exists else 'Created'} {file_path}.{diff_section}",
+        message=f"{'Updated' if file_exists else 'Created'} {file_path}.",
         file_path=file_path,
         content=file_content,
+        diff=diff_text,
     )


### PR DESCRIPTION
## Summary
- Added `diff: str = ""` field to `FileWriteResult` dataclass
- `write_and_commit_file` and `search_and_replace` now put diff content in the `diff` field instead of embedding it in `message`
- `chat_with_agent` formats the diff into the agent's tool result (agent still sees it) but uses the clean `message` for GitHub PR comments (no more noisy diff blocks in comments)

## Social Media Posts

### GitAuto Post
PR comments from GitAuto used to include raw unified diffs for every file edit. Useful for the AI agent, noisy for humans reviewing. Now diffs stay in the agent's context and comments just say what changed.

### Wes Post
Our PR comments were dumping full unified diffs for every file edit. The AI agent needs them to verify its work, but humans reading the PR comment don't. Separated the two concerns - agent gets the diff in its tool result, GitHub comment stays clean.