### PR TITLE
Force clear CodeBuild FileSystemLocations left by rollback

### DIFF
--- a/infrastructure/setup-infra.yml
+++ b/infrastructure/setup-infra.yml
@@ -327,7 +327,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL # 3GB RAM, 2 vCPU, ~$0.005/min
         Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0 # Has Node.js 24
-        PrivilegedMode: false
+        PrivilegedMode: true # Must be true until FileSystemLocations is cleared from live state
         EnvironmentVariables:
           - Name: S3_BUCKET
             Value: !Ref DependencyCacheBucket
@@ -335,6 +335,7 @@ Resources:
             Value: placeholder
           - Name: PKG_MANAGER
             Value: yarn
+      FileSystemLocations: [] # Explicitly clear EFS mount from live state (was left by rollback)
       Source:
         Type: NO_SOURCE
         BuildSpec: |


### PR DESCRIPTION
## Summary
- CloudFormation rollback from PR #2466 left `FileSystemLocations` on the live CodeBuild project, but CFN's internal state thinks it's already removed (empty changeset)
- Explicitly set `FileSystemLocations: []` to force CFN to update the live resource
- Keep `PrivilegedMode: true` — must stay true until FileSystemLocations is actually gone from live state

## Follow-up (after this deploys)
- Set `PrivilegedMode: false` and remove `FileSystemLocations: []`