### PR TITLE
Cap input tokens at 200K, reject huge file reads, return matching lines in search

### DIFF
--- a/services/claude/chat_with_claude.py
+++ b/services/claude/chat_with_claude.py
@@ -47,7 +47,7 @@ def chat_with_claude(
     buffer = 4096
     context_window = CONTEXT_WINDOW.get(model_id, 200_000)
     max_output = MAX_OUTPUT_TOKENS.get(model_id, 64_000)
-    max_input = context_window - max_output - buffer
+    max_input = min(context_window - max_output - buffer, 200_000)
     messages, token_input = trim_messages_to_token_limit(
         messages=messages, client=claude, model=model_id, max_input=max_input
     )

--- a/utils/files/get_local_file_content.py
+++ b/utils/files/get_local_file_content.py
@@ -20,7 +20,7 @@ from utils.new_lines.detect_new_line import detect_line_break
 # NOTE: No strict=True here because line_number, keyword, start_line, end_line are optional
 GET_LOCAL_FILE_CONTENT: ToolUnionParam = {
     "name": "get_local_file_content",
-    "description": "Reads the content of a file from the local clone. Can read any file on disk including those not tracked by git (e.g., node_modules). IMPORTANT: Always read the FULL file by default - do NOT use start_line/end_line/line_number/keyword to truncate the read. Only use start_line/end_line for files over 2000 lines. Truncating reads causes you to miss critical context like required fields, data structures, and execution order.",
+    "description": "Reads the content of a file from the local clone. Can read any file on disk including those not tracked by git (e.g., node_modules). IMPORTANT: Always read the FULL file by default - do NOT use start_line/end_line/line_number/keyword to truncate the read. Only use start_line/end_line for files over 2000 lines. Truncating reads causes you to miss critical context like required fields, data structures, and execution order. NOTE: For large generated files (lockfiles, bundled output, etc.) over 2000 lines, you MUST use keyword or start_line/end_line to read specific sections. Full reads of such files will be rejected.",
     "input_schema": {
         "type": "object",
         "properties": {
@@ -122,6 +122,15 @@ def get_local_file_content(
         keyword = None
         start_line = None
         end_line = None
+
+    # Reject full reads of huge files — require a filter (keyword or line range)
+    if len(lines) >= 2000 and not has_line_number and not has_keyword and not has_range:
+        logger.info(
+            "Rejected full read of '%s' (%d lines). Requires filter.",
+            file_path,
+            len(lines),
+        )
+        return f"Error: '{file_path}' is {len(lines)} lines — too large to read in full. Use keyword, line_number, or start_line/end_line to read specific sections."
 
     width = len(str(len(lines)))
     numbered_lines = [f"{i + 1:>{width}}:{line}" for i, line in enumerate(lines)]

--- a/utils/files/grep_files.py
+++ b/utils/files/grep_files.py
@@ -6,18 +6,18 @@ from utils.error.handle_exceptions import handle_exceptions
 from utils.logging.logging_config import logger
 
 
-@handle_exceptions(default_return_value=[], raise_on_error=False)
+@handle_exceptions(default_return_value={}, raise_on_error=False)
 def grep_files(query: str, search_dir: str):
-    """Run grep -r -l on search_dir and return matching file paths."""
+    """Run grep -r -n on search_dir and return matching file paths with lines."""
     if not os.path.isdir(search_dir):
         logger.warning("Directory not found: %s", search_dir)
-        return list[str]()
+        return dict[str, list[str]]()
 
     result = subprocess.run(
         [
             "grep",
             "-r",  # Recursive search
-            "-l",  # Filenames only, not matching lines
+            "-n",  # Show line numbers with matching lines
             # Skip binary files (images, compiled files, etc.)
             "--binary-files=without-match",
             *GREP_EXCLUDE_DIRS,
@@ -37,12 +37,23 @@ def grep_files(query: str, search_dir: str):
         logger.warning(
             "grep failed with return code %d: %s", result.returncode, result.stderr
         )
-        return list[str]()
+        return dict[str, list[str]]()
 
     if not result.stdout.strip():
-        return list[str]()
+        return dict[str, list[str]]()
 
-    # grep outputs relative paths (e.g. ./src/main.py) since we use cwd=search_dir
-    return [
-        line.strip().removeprefix("./") for line in result.stdout.strip().split("\n")
-    ]
+    # Parse grep -n output: ./path/to/file:123:matching line content
+    matches: dict[str, list[str]] = {}
+    for line in result.stdout.strip().split("\n"):
+        # Split on first two colons: file_path:line_number:content
+        parts = line.split(":", 2)
+        if len(parts) < 3:
+            continue
+        file_path = parts[0].strip().removeprefix("./")
+        line_num = parts[1]
+        content = parts[2]
+        if file_path not in matches:
+            matches[file_path] = []
+        matches[file_path].append(f"{line_num}:{content}")
+
+    return matches

--- a/utils/files/search_local_file_contents.py
+++ b/utils/files/search_local_file_contents.py
@@ -7,7 +7,7 @@ from utils.logging.logging_config import logger
 
 SEARCH_LOCAL_FILE_CONTENT: ToolUnionParam = {
     "name": "search_local_file_contents",
-    "description": "Search for keywords in the local clone of the repository (PR branch). Use this to find files containing specific variable names, function names, class names, or other identifiers. Especially if you change variable definitions, as they are likely used elsewhere. To reduce bugs, search multiple times from as many angles as possible.",
+    "description": "Search for keywords in the local clone of the repository (PR branch). Returns matching file paths AND the matching lines with line numbers. Use this to find files containing specific variable names, function names, class names, or other identifiers. Especially if you change variable definitions, as they are likely used elsewhere. To reduce bugs, search multiple times from as many angles as possible.",
     "input_schema": {
         "type": "object",
         "properties": {
@@ -22,27 +22,34 @@ SEARCH_LOCAL_FILE_CONTENT: ToolUnionParam = {
     "strict": True,
 }
 
+# Cap matching lines per file to avoid huge outputs from lockfiles etc.
+MAX_LINES_PER_FILE = 10
+
 
 @handle_exceptions(default_return_value="", raise_on_error=False)
 def search_local_file_contents(query: str, base_args: BaseArgs, **_kwargs):
     """Search for a keyword in the local clone directory using grep."""
     clone_dir = base_args["clone_dir"]
-    file_paths = grep_files(query=query, search_dir=clone_dir)
+    matches = grep_files(query=query, search_dir=clone_dir)
 
-    if not file_paths:
+    if not matches:
         msg = f"0 files found for the search query '{query}'.\n"
         logger.info(msg)
         return msg
 
-    # Limit to 20 files to avoid overwhelming the agent
-    total = len(file_paths)
-    file_paths = file_paths[:20]
-
-    msg = f"{total} files found for the search query '{query}':\n- " + "\n- ".join(
-        file_paths
+    total_files = len(matches)
+    items = list(matches.items())[:20]
+    result_lines: list[str] = []
+    for fp, lines in items:
+        for line in lines[:MAX_LINES_PER_FILE]:
+            result_lines.append(f"{fp}:{line}")
+        if len(lines) > MAX_LINES_PER_FILE:
+            result_lines.append(f"{fp}: ... and {len(lines) - MAX_LINES_PER_FILE} more")
+    msg = f"{total_files} files found for the search query '{query}':\n" + "\n".join(
+        result_lines
     )
-    if total > 20:
-        msg += f"\n... and {total - 20} more files"
+    if total_files > 20:
+        msg += f"\n... and {total_files - 20} more files"
     msg += "\n"
     logger.info(msg)
     return msg

--- a/utils/files/test_grep_files.py
+++ b/utils/files/test_grep_files.py
@@ -10,23 +10,24 @@ def _create_file(base: str, rel_path: str, content: str = ""):
         f.write(content)
 
 
-def test_finds_matching_files(tmp_path):
+def test_finds_matching_files_with_lines(tmp_path):
     _create_file(tmp_path, "src/main.py", "def hello_world(): pass")
     _create_file(tmp_path, "src/utils.py", "import os")
     result = grep_files("hello_world", str(tmp_path))
     assert "src/main.py" in result
+    assert result["src/main.py"] == ["1:def hello_world(): pass"]
     assert "src/utils.py" not in result
 
 
 def test_returns_empty_for_no_matches(tmp_path):
     _create_file(tmp_path, "main.py", "def foo(): pass")
     result = grep_files("nonexistent", str(tmp_path))
-    assert result == []
+    assert not result
 
 
 def test_returns_empty_for_missing_dir():
     result = grep_files("query", "/nonexistent/path")
-    assert result == []
+    assert not result
 
 
 def test_excludes_node_modules(tmp_path):
@@ -45,7 +46,7 @@ def test_finds_multiple_files(tmp_path):
     assert len(result) == 3
 
 
-def test_strips_dot_slash_prefix(tmp_path):
-    _create_file(tmp_path, "main.py", "target_func = 1")
-    result = grep_files("target_func", str(tmp_path))
-    assert result == ["main.py"]
+def test_multiple_matches_in_same_file(tmp_path):
+    _create_file(tmp_path, "main.py", "target = 1\nother = 2\ntarget = 3")
+    result = grep_files("target", str(tmp_path))
+    assert result == {"main.py": ["1:target = 1", "3:target = 3"]}

--- a/utils/files/test_search_local_file_contents.py
+++ b/utils/files/test_search_local_file_contents.py
@@ -35,6 +35,7 @@ def test_search_finds_matching_files():
         )
         assert "1 files found" in result
         assert "src/main.py" in result
+        assert "src/main.py:1:def hello_world():" in result
 
 
 def test_search_no_matches():
@@ -122,5 +123,11 @@ def test_search_real_repo():
     )
     assert "files found" in result
     assert "search_local_file_contents.py" in result
-    assert "node_modules" not in result
-    assert "venv" not in result
+    # Verify excluded dirs don't appear as file paths (they may appear in line content)
+    for line in result.split("\n"):
+        if line.startswith("- "):
+            file_path = line[2:].strip()
+            assert not file_path.startswith(
+                "node_modules/"
+            ), f"Should exclude: {file_path}"
+            assert not file_path.startswith("venv/"), f"Should exclude: {file_path}"


### PR DESCRIPTION
## Summary
- **Input token cap**: Hard limit of 200K tokens per API call regardless of model context window. Opus 4.6 was allowing up to 867K, causing conversation bloat where late requests cost $1-2 each as full history was re-sent every turn.
- **Reject huge file reads**: `get_local_file_content` now rejects files >= 2000 lines when no filter (keyword/line_number/start_line/end_line) is provided. Prevents reading entire lockfiles (yarn.lock was 872K chars / 17K lines in one case).
- **Search returns matching lines**: `search_local_file_contents` now returns standard `file:line:content` format instead of filenames only, so the agent can see what matched without needing a follow-up file read. Capped at 10 matches per file.

## Context
Analysis of today's Claude API costs ($74/day) showed:
- 72% of cost came from the second half of agentic runs (conversation bloat)
- One yarn.lock read (872K chars) caused a 14x token jump in a single turn
- Search returning filenames-only forced the agent to read entire files to see content

## Social Media Post (GitAuto)
Three changes to cut Claude API costs: capped input tokens at 200K per call, blocked full reads of huge generated files like lockfiles, and made search return matching lines instead of just filenames. The biggest cost driver was conversation bloat - late-turn requests were hitting 500K+ tokens as full history got re-sent every turn.

## Social Media Post (Wes)
Dug into our Claude API bill today. $74 in one day. Traced it to agentic loops where each turn re-sends the full conversation - and one run read an entire 17K-line yarn.lock into context, ballooning from 38K to 538K tokens in a single turn. Three fixes: hard cap input at 200K, reject unfiltered reads of huge files, and make search return the actual matching lines so the agent doesn't need to read the whole file just to find one version string.