### PR TITLE
Set CodeBuild PrivilegedMode false

### DIFF
--- a/infrastructure/setup-infra.yml
+++ b/infrastructure/setup-infra.yml
@@ -327,7 +327,7 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL # 3GB RAM, 2 vCPU, ~$0.005/min
         Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0 # Has Node.js 24
-        PrivilegedMode: true # Must be true until FileSystemLocations is cleared from live state
+        PrivilegedMode: false
         EnvironmentVariables:
           - Name: S3_BUCKET
             Value: !Ref DependencyCacheBucket
@@ -335,7 +335,6 @@ Resources:
             Value: placeholder
           - Name: PKG_MANAGER
             Value: yarn
-      FileSystemLocations: [] # Explicitly clear EFS mount from live state (was left by rollback)
       Source:
         Type: NO_SOURCE
         BuildSpec: |


### PR DESCRIPTION
## Summary
- Set `PrivilegedMode: false` — FileSystemLocations was cleared from live state in the previous deploy
- Remove `FileSystemLocations: []` workaround (no longer needed)
- Also manually deleted 2 stale Lambda ENIs that were blocking LambdaSecurityGroup deletion in the previous deploy