### PR TITLE
Restore CloudWatch Logs permissions after VPC removal

### DIFF
--- a/infrastructure/deploy-lambda.yml
+++ b/infrastructure/deploy-lambda.yml
@@ -67,6 +67,8 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
         # CodeBuild - trigger package installations (npm install, pip install, etc.)
         - PolicyName: CodeBuildAccess


### PR DESCRIPTION
## Summary
- Commit d213dbed removed `AWSLambdaVPCAccessExecutionRole` when removing VPC config, which silently also removed CloudWatch Logs permissions (they were a side effect of that managed policy)
- Lambda stopped writing logs after the next deployment, making all debugging blind
- Added `AWSLambdaBasicExecutionRole` managed policy to explicitly grant CloudWatch Logs permissions
