### PR TITLE
Detect customer Node version instead of hardcoding Node 24

### DIFF
--- a/infrastructure/setup-infra.yml
+++ b/infrastructure/setup-infra.yml
@@ -308,6 +308,10 @@ Resources:
                 Resource: '*'
               - Effect: Allow
                 Action:
+                  - s3:ListBucket
+                Resource: !GetAtt DependencyCacheBucket.Arn
+              - Effect: Allow
+                Action:
                   - s3:GetObject
                   - s3:PutObject
                 Resource: !Sub '${DependencyCacheBucket.Arn}/*'
@@ -341,8 +345,9 @@ Resources:
           version: 0.2
           phases:
             install:
-              runtime-versions:
-                nodejs: 24
+              commands:
+                - n "$NODE_VERSION"
+                - echo "Using Node.js $(node --version)"
             build:
               commands:
                 - echo "Installing packages for $S3_KEY_PREFIX using $PKG_MANAGER"

--- a/services/aws/run_install_via_codebuild.py
+++ b/services/aws/run_install_via_codebuild.py
@@ -3,6 +3,7 @@ from mypy_boto3_codebuild.type_defs import EnvironmentVariableTypeDef
 from constants.aws import S3_DEPENDENCY_BUCKET
 from constants.general import IS_PRD
 from services.aws.clients import codebuild_client
+from services.node.detect_node_version import DEFAULT_NODE_VERSION
 from services.supabase.npm_tokens.get_npm_token import get_npm_token
 from utils.error.handle_exceptions import handle_exceptions
 from utils.logging.logging_config import logger
@@ -13,6 +14,7 @@ def run_install_via_codebuild(
     s3_key_prefix: str,  # e.g. "Foxquilt/foxcom-forms" — S3 path for manifests and tarballs
     owner_id: int,
     pkg_manager: str,
+    node_version: str = DEFAULT_NODE_VERSION,
 ):
     if not IS_PRD:
         logger.info("codebuild: Skipping in non-prod environment")
@@ -22,6 +24,7 @@ def run_install_via_codebuild(
         {"name": "S3_BUCKET", "value": S3_DEPENDENCY_BUCKET, "type": "PLAINTEXT"},
         {"name": "S3_KEY_PREFIX", "value": s3_key_prefix, "type": "PLAINTEXT"},
         {"name": "PKG_MANAGER", "value": pkg_manager, "type": "PLAINTEXT"},
+        {"name": "NODE_VERSION", "value": node_version, "type": "PLAINTEXT"},
     ]
 
     npm_token = get_npm_token(owner_id)

--- a/services/aws/s3/check_s3_dep_freshness_and_trigger_install.py
+++ b/services/aws/s3/check_s3_dep_freshness_and_trigger_install.py
@@ -3,6 +3,7 @@ from botocore.exceptions import ClientError
 from config import UTF8
 from constants.aws import S3_DEPENDENCY_BUCKET
 from services.aws.clients import s3_client
+from services.node.detect_node_version import DEFAULT_NODE_VERSION
 from services.aws.run_install_via_codebuild import run_install_via_codebuild
 from utils.error.handle_exceptions import handle_exceptions
 from utils.logging.logging_config import logger
@@ -18,6 +19,7 @@ def check_s3_dep_freshness_and_trigger_install(
     manifest_hash: str,
     manifest_files: dict[str, str],  # filename -> content, uploaded to S3 for CodeBuild
     log_prefix: str,  # e.g. "node" or "php"
+    node_version: str = DEFAULT_NODE_VERSION,
 ):
     """Check S3 tarball freshness and trigger CodeBuild if stale. Returns True if fresh."""
     # Check S3 tarball freshness via HeadObject metadata
@@ -67,7 +69,10 @@ def check_s3_dep_freshness_and_trigger_install(
     # Trigger CodeBuild install (fire and forget, bypasses Lambda 15-min timeout)
     s3_key_prefix = f"{owner_name}/{repo_name}"
     run_install_via_codebuild(
-        s3_key_prefix=s3_key_prefix, owner_id=owner_id, pkg_manager=pkg_manager
+        s3_key_prefix=s3_key_prefix,
+        owner_id=owner_id,
+        pkg_manager=pkg_manager,
+        node_version=node_version,
     )
     logger.info(
         "%s: Triggered CodeBuild install for %s/%s", log_prefix, owner_name, repo_name

--- a/services/node/detect_node_version.py
+++ b/services/node/detect_node_version.py
@@ -1,0 +1,52 @@
+import json
+
+from utils.error.handle_exceptions import handle_exceptions
+from utils.files.read_local_file import read_local_file
+from utils.logging.logging_config import logger
+from utils.versions.extract_max_major_from_constraint import (
+    extract_max_major_from_constraint,
+)
+from utils.versions.parse_major_version import parse_major_version
+
+DEFAULT_NODE_VERSION = "22"
+
+
+@handle_exceptions(default_return_value=DEFAULT_NODE_VERSION, raise_on_error=False)
+def detect_node_version(clone_dir: str):
+    """Detect the Node.js major version from repo config files. Returns e.g. '22'."""
+    # 1. Check .nvmrc
+    nvmrc = read_local_file(".nvmrc", base_dir=clone_dir)
+    if isinstance(nvmrc, str):
+        parsed = parse_major_version(nvmrc.strip())
+        if parsed:
+            logger.info("node: Detected Node %s from .nvmrc", parsed)
+            return parsed
+
+    # 2. Check .node-version
+    node_version_file = read_local_file(".node-version", base_dir=clone_dir)
+    if isinstance(node_version_file, str):
+        parsed = parse_major_version(node_version_file.strip())
+        if parsed:
+            logger.info("node: Detected Node %s from .node-version", parsed)
+            return parsed
+
+    # 3. Check package.json engines.node
+    package_json = read_local_file("package.json", base_dir=clone_dir)
+    if isinstance(package_json, str):
+        try:
+            data = json.loads(package_json)
+        except (json.JSONDecodeError, TypeError):
+            data = None
+
+        engines = data.get("engines") if isinstance(data, dict) else None
+        node_constraint = engines.get("node") if isinstance(engines, dict) else None
+        if isinstance(node_constraint, str):
+            parsed = extract_max_major_from_constraint(node_constraint)
+            if parsed:
+                logger.info("node: Detected Node %s from package.json engines", parsed)
+                return parsed
+
+    logger.info(
+        "node: No Node version specified, defaulting to %s", DEFAULT_NODE_VERSION
+    )
+    return DEFAULT_NODE_VERSION

--- a/services/node/ensure_node_packages.py
+++ b/services/node/ensure_node_packages.py
@@ -2,6 +2,7 @@ from services.aws.s3.check_s3_dep_freshness_and_trigger_install import (
     check_s3_dep_freshness_and_trigger_install,
 )
 from services.aws.s3.get_dep_manifest_hash import get_dep_manifest_hash
+from services.node.detect_node_version import detect_node_version
 from services.node.detect_package_manager import detect_package_manager
 from utils.error.handle_exceptions import handle_exceptions
 from utils.files.read_local_file import read_local_file
@@ -23,10 +24,13 @@ def ensure_node_packages(
 
     npmrc_content = read_local_file(".npmrc", base_dir=clone_dir)
 
+    node_version = detect_node_version(clone_dir)
+
     pkg_manager, lock_file_name, lock_file_content = detect_package_manager(clone_dir)
 
+    # Include node_version in hash so version changes invalidate the cache
     manifest_hash = get_dep_manifest_hash(
-        [package_json_content, lock_file_content, npmrc_content]
+        [package_json_content, lock_file_content, npmrc_content, node_version]
     )
 
     # Build manifest files to upload to S3 for CodeBuild
@@ -41,6 +45,15 @@ def ensure_node_packages(
     if lock_file_name and lock_file_content:
         manifest_files[lock_file_name] = lock_file_content
 
+    # Upload version files so CodeBuild can see them
+    nvmrc_content = read_local_file(".nvmrc", base_dir=clone_dir)
+    if nvmrc_content:
+        manifest_files[".nvmrc"] = nvmrc_content
+
+    node_version_content = read_local_file(".node-version", base_dir=clone_dir)
+    if node_version_content:
+        manifest_files[".node-version"] = node_version_content
+
     return check_s3_dep_freshness_and_trigger_install(
         owner_name=owner_name,
         repo_name=repo_name,
@@ -50,4 +63,5 @@ def ensure_node_packages(
         manifest_hash=manifest_hash,
         manifest_files=manifest_files,
         log_prefix="node",
+        node_version=node_version,
     )

--- a/services/node/test_detect_node_version.py
+++ b/services/node/test_detect_node_version.py
@@ -1,0 +1,102 @@
+import os
+
+import pytest
+
+from services.node.detect_node_version import DEFAULT_NODE_VERSION, detect_node_version
+
+REPOS_ROOT = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+
+
+@pytest.fixture
+def repo_dir(tmp_path):
+    return str(tmp_path)
+
+
+# Real repos at ../website, ../Foxquilt/*, ../posthog, etc.
+# Skipped in CI where these repos don't exist
+@pytest.mark.integration
+class TestRealRepos:
+    def test_website_engines_22x(self):
+        # ../website/package.json has engines.node = "22.x"
+        repo = os.path.join(REPOS_ROOT, "website")
+        if not os.path.isdir(repo):
+            pytest.skip("website repo not cloned")
+        assert detect_node_version(repo) == "22"
+
+    def test_posthog_nvmrc_18(self):
+        # ../posthog/.nvmrc = "18", engines.node = ">=18 <19"
+        # .nvmrc takes precedence
+        repo = os.path.join(REPOS_ROOT, "posthog")
+        if not os.path.isdir(repo):
+            pytest.skip("posthog repo not cloned")
+        assert detect_node_version(repo) == "18"
+
+    def test_ghostwriter_engines_gte_22(self):
+        # ../ghostwriter/package.json has engines.node = ">=22.0.0"
+        repo = os.path.join(REPOS_ROOT, "ghostwriter")
+        if not os.path.isdir(repo):
+            pytest.skip("ghostwriter repo not cloned")
+        assert detect_node_version(repo) == "22"
+
+    def test_slackgpt3_engines_22(self):
+        # ../slackgpt3/package.json has engines.node = "22"
+        repo = os.path.join(REPOS_ROOT, "slackgpt3")
+        if not os.path.isdir(repo):
+            pytest.skip("slackgpt3 repo not cloned")
+        assert detect_node_version(repo) == "22"
+
+    def test_foxcom_forms_no_version_defaults_to_22(self):
+        # Fox repos have no .nvmrc, no .node-version, no engines.node
+        repo = os.path.join(REPOS_ROOT, "Foxquilt", "foxcom-forms")
+        if not os.path.isdir(repo):
+            pytest.skip("foxcom-forms repo not cloned")
+        assert detect_node_version(repo) == DEFAULT_NODE_VERSION
+
+    def test_foxden_admin_portal_backend_no_version_defaults_to_22(self):
+        # This is the repo that failed with Node 24 - should default to 22
+        repo = os.path.join(REPOS_ROOT, "Foxquilt", "foxden-admin-portal-backend")
+        if not os.path.isdir(repo):
+            pytest.skip("foxden-admin-portal-backend repo not cloned")
+        assert detect_node_version(repo) == DEFAULT_NODE_VERSION
+
+
+# Solitary tests with tmp_path fixtures
+class TestNvmrc:
+    def test_major_only(self, repo_dir: str):
+        with open(os.path.join(repo_dir, ".nvmrc"), "w", encoding="utf-8") as f:
+            f.write("18\n")
+        assert detect_node_version(repo_dir) == "18"
+
+    def test_full_version(self, repo_dir: str):
+        with open(os.path.join(repo_dir, ".nvmrc"), "w", encoding="utf-8") as f:
+            f.write("v20.11.0\n")
+        assert detect_node_version(repo_dir) == "20"
+
+    def test_v_prefix(self, repo_dir: str):
+        with open(os.path.join(repo_dir, ".nvmrc"), "w", encoding="utf-8") as f:
+            f.write("v22\n")
+        assert detect_node_version(repo_dir) == "22"
+
+    def test_lts_falls_through_to_default(self, repo_dir: str):
+        with open(os.path.join(repo_dir, ".nvmrc"), "w", encoding="utf-8") as f:
+            f.write("lts/*\n")
+        assert detect_node_version(repo_dir) == DEFAULT_NODE_VERSION
+
+
+class TestNodeVersionFile:
+    def test_node_version_file(self, repo_dir: str):
+        with open(os.path.join(repo_dir, ".node-version"), "w", encoding="utf-8") as f:
+            f.write("20.10.0\n")
+        assert detect_node_version(repo_dir) == "20"
+
+    def test_nvmrc_takes_precedence(self, repo_dir: str):
+        with open(os.path.join(repo_dir, ".nvmrc"), "w", encoding="utf-8") as f:
+            f.write("22\n")
+        with open(os.path.join(repo_dir, ".node-version"), "w", encoding="utf-8") as f:
+            f.write("20\n")
+        assert detect_node_version(repo_dir) == "22"
+
+
+class TestDefault:
+    def test_empty_dir_returns_default(self, repo_dir: str):
+        assert detect_node_version(repo_dir) == DEFAULT_NODE_VERSION

--- a/services/node/test_detect_node_version.py
+++ b/services/node/test_detect_node_version.py
@@ -12,51 +12,40 @@ def repo_dir(tmp_path):
     return str(tmp_path)
 
 
+def real_repo(path: str):
+    """Skip if the repo directory doesn't exist (CI doesn't have local clones)."""
+    if not os.path.isdir(path):
+        pytest.skip(f"{os.path.basename(path)} repo not cloned")
+    return path
+
+
 # Real repos at ../website, ../Foxquilt/*, ../posthog, etc.
-# Skipped in CI where these repos don't exist
 @pytest.mark.integration
 class TestRealRepos:
     def test_website_engines_22x(self):
-        # ../website/package.json has engines.node = "22.x"
-        repo = os.path.join(REPOS_ROOT, "website")
-        if not os.path.isdir(repo):
-            pytest.skip("website repo not cloned")
+        repo = real_repo(os.path.join(REPOS_ROOT, "website"))
         assert detect_node_version(repo) == "22"
 
     def test_posthog_nvmrc_18(self):
-        # ../posthog/.nvmrc = "18", engines.node = ">=18 <19"
-        # .nvmrc takes precedence
-        repo = os.path.join(REPOS_ROOT, "posthog")
-        if not os.path.isdir(repo):
-            pytest.skip("posthog repo not cloned")
+        repo = real_repo(os.path.join(REPOS_ROOT, "posthog"))
         assert detect_node_version(repo) == "18"
 
     def test_ghostwriter_engines_gte_22(self):
-        # ../ghostwriter/package.json has engines.node = ">=22.0.0"
-        repo = os.path.join(REPOS_ROOT, "ghostwriter")
-        if not os.path.isdir(repo):
-            pytest.skip("ghostwriter repo not cloned")
+        repo = real_repo(os.path.join(REPOS_ROOT, "ghostwriter"))
         assert detect_node_version(repo) == "22"
 
     def test_slackgpt3_engines_22(self):
-        # ../slackgpt3/package.json has engines.node = "22"
-        repo = os.path.join(REPOS_ROOT, "slackgpt3")
-        if not os.path.isdir(repo):
-            pytest.skip("slackgpt3 repo not cloned")
+        repo = real_repo(os.path.join(REPOS_ROOT, "slackgpt3"))
         assert detect_node_version(repo) == "22"
 
     def test_foxcom_forms_no_version_defaults_to_22(self):
-        # Fox repos have no .nvmrc, no .node-version, no engines.node
-        repo = os.path.join(REPOS_ROOT, "Foxquilt", "foxcom-forms")
-        if not os.path.isdir(repo):
-            pytest.skip("foxcom-forms repo not cloned")
+        repo = real_repo(os.path.join(REPOS_ROOT, "Foxquilt", "foxcom-forms"))
         assert detect_node_version(repo) == DEFAULT_NODE_VERSION
 
     def test_foxden_admin_portal_backend_no_version_defaults_to_22(self):
-        # This is the repo that failed with Node 24 - should default to 22
-        repo = os.path.join(REPOS_ROOT, "Foxquilt", "foxden-admin-portal-backend")
-        if not os.path.isdir(repo):
-            pytest.skip("foxden-admin-portal-backend repo not cloned")
+        repo = real_repo(
+            os.path.join(REPOS_ROOT, "Foxquilt", "foxden-admin-portal-backend")
+        )
         assert detect_node_version(repo) == DEFAULT_NODE_VERSION
 
 

--- a/services/node/test_ensure_node_packages.py
+++ b/services/node/test_ensure_node_packages.py
@@ -22,61 +22,70 @@ def test_returns_false_when_no_package_json():
 
 def test_calls_shared_function_with_correct_args():
     with patch(f"{MODULE}.read_local_file") as mock_get:
-        mock_get.side_effect = ['{"name": "test"}', None]
-        with patch(
-            f"{MODULE}.detect_package_manager",
-            return_value=("npm", "package-lock.json", "lock-content"),
-        ):
-            with patch(f"{MODULE}.get_dep_manifest_hash", return_value="abc123"):
-                with patch(
-                    f"{MODULE}.check_s3_dep_freshness_and_trigger_install",
-                    return_value=True,
-                ) as mock_check:
-                    result = ensure_node_packages(
-                        owner_id=123,
-                        clone_dir="/tmp/clone",
-                        owner_name="owner",
-                        repo_name="repo",
-                    )
+        # read_local_file calls: package.json, .npmrc, .nvmrc, .node-version
+        mock_get.side_effect = ['{"name": "test"}', None, None, None]
+        with patch(f"{MODULE}.detect_node_version", return_value="22"):
+            with patch(
+                f"{MODULE}.detect_package_manager",
+                return_value=("npm", "package-lock.json", "lock-content"),
+            ):
+                with patch(f"{MODULE}.get_dep_manifest_hash", return_value="abc123"):
+                    with patch(
+                        f"{MODULE}.check_s3_dep_freshness_and_trigger_install",
+                        return_value=True,
+                    ) as mock_check:
+                        result = ensure_node_packages(
+                            owner_id=123,
+                            clone_dir="/tmp/clone",
+                            owner_name="owner",
+                            repo_name="repo",
+                        )
 
-                    assert result is True
-                    mock_check.assert_called_once_with(
-                        owner_name="owner",
-                        repo_name="repo",
-                        owner_id=123,
-                        pkg_manager="npm",
-                        tarball_name="node_modules.tar.gz",
-                        manifest_hash="abc123",
-                        manifest_files={
-                            "package.json": '{"name": "test"}',
-                            "package-lock.json": "lock-content",
-                        },
-                        log_prefix="node",
-                    )
+                        assert result is True
+                        mock_check.assert_called_once_with(
+                            owner_name="owner",
+                            repo_name="repo",
+                            owner_id=123,
+                            pkg_manager="npm",
+                            tarball_name="node_modules.tar.gz",
+                            manifest_hash="abc123",
+                            manifest_files={
+                                "package.json": '{"name": "test"}',
+                                "package-lock.json": "lock-content",
+                            },
+                            log_prefix="node",
+                            node_version="22",
+                        )
 
 
 def test_sanitizes_http_to_https_in_npmrc():
     with patch(f"{MODULE}.read_local_file") as mock_get:
+        # read_local_file calls: package.json, .npmrc, .nvmrc, .node-version
         mock_get.side_effect = [
             '{"name": "test"}',
             "registry=http://registry.npmjs.org/",
+            None,
+            None,
         ]
-        with patch(
-            f"{MODULE}.detect_package_manager",
-            return_value=("npm", None, None),
-        ):
-            with patch(f"{MODULE}.get_dep_manifest_hash", return_value="abc123"):
-                with patch(
-                    f"{MODULE}.check_s3_dep_freshness_and_trigger_install",
-                    return_value=False,
-                ) as mock_check:
-                    ensure_node_packages(
-                        owner_id=123,
-                        clone_dir="/tmp/clone",
-                        owner_name="owner",
-                        repo_name="repo",
-                    )
+        with patch(f"{MODULE}.detect_node_version", return_value="22"):
+            with patch(
+                f"{MODULE}.detect_package_manager",
+                return_value=("npm", None, None),
+            ):
+                with patch(f"{MODULE}.get_dep_manifest_hash", return_value="abc123"):
+                    with patch(
+                        f"{MODULE}.check_s3_dep_freshness_and_trigger_install",
+                        return_value=False,
+                    ) as mock_check:
+                        ensure_node_packages(
+                            owner_id=123,
+                            clone_dir="/tmp/clone",
+                            owner_name="owner",
+                            repo_name="repo",
+                        )
 
-                    manifest_files = mock_check.call_args.kwargs["manifest_files"]
-                    assert "https://registry.npmjs.org/" in manifest_files[".npmrc"]
-                    assert "http://registry.npmjs.org/" not in manifest_files[".npmrc"]
+                        manifest_files = mock_check.call_args.kwargs["manifest_files"]
+                        assert "https://registry.npmjs.org/" in manifest_files[".npmrc"]
+                        assert (
+                            "http://registry.npmjs.org/" not in manifest_files[".npmrc"]
+                        )

--- a/utils/versions/extract_max_major_from_constraint.py
+++ b/utils/versions/extract_max_major_from_constraint.py
@@ -1,0 +1,31 @@
+import re
+
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=None, raise_on_error=False)
+def extract_max_major_from_constraint(constraint: str):
+    """Extract the highest major version from a version constraint string.
+
+    Examples:
+        ">=18"              -> "18"
+        "^18 || ^20"        -> "20"
+        ">=16 <23"          -> "22"  (max mentioned is 23, but <23 means 22)
+        "18.x"              -> "18"
+        "^18 || ^20 || ^22" -> "22"
+    """
+    # Match version-like patterns (e.g. "18", "22.0.0", "20.10.0") and extract only
+    # the leading major number. This skips minor/patch without hardcoding valid ranges.
+    majors: list[int] = []
+    for match in re.finditer(r"(\d+)(?:\.\d+)*", constraint):
+        majors.append(int(match.group(1)))
+
+    if not majors:
+        return None
+
+    # Exclusive upper bounds like "<23" — the usable version is one below
+    max_major = max(majors)
+    if re.search(rf"<\s*{max_major}(?!\d)", constraint):
+        max_major -= 1
+
+    return str(max_major)

--- a/utils/versions/parse_major_version.py
+++ b/utils/versions/parse_major_version.py
@@ -1,0 +1,19 @@
+import re
+
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=None, raise_on_error=False)
+def parse_major_version(text: str):
+    """Extract major version from strings like 'v18.17.0', '18', 'lts/hydrogen', '22.1'."""
+    text = text.lstrip("vV")
+
+    # lts/* or lts/name — can't determine version
+    if text.startswith("lts"):
+        return None
+
+    match = re.match(r"(\d+)", text)
+    if match:
+        return str(match.group(1))
+
+    return None

--- a/utils/versions/test_extract_max_major_from_constraint.py
+++ b/utils/versions/test_extract_max_major_from_constraint.py
@@ -1,0 +1,47 @@
+from utils.versions.extract_max_major_from_constraint import (
+    extract_max_major_from_constraint,
+)
+
+
+# Real engines.node values from cloned repos
+class TestRealNodeConstraints:
+    def test_website_22x(self):
+        # ../website/package.json engines.node
+        assert extract_max_major_from_constraint("22.x") == "22"
+
+    def test_posthog_gte18_lt19(self):
+        # ../posthog/package.json engines.node
+        assert extract_max_major_from_constraint(">=18 <19") == "18"
+
+    def test_ghostwriter_gte22(self):
+        # ../ghostwriter/package.json engines.node
+        assert extract_max_major_from_constraint(">=22.0.0") == "22"
+
+    def test_slackgpt3_22(self):
+        # ../slackgpt3/package.json engines.node
+        assert extract_max_major_from_constraint("22") == "22"
+
+
+# Real require.php values from cloned repos
+class TestRealPhpConstraints:
+    def test_spiderplus_web_gte56(self):
+        # ../SPIDERPLUS/SPIDERPLUS-web/composer.json require.php
+        assert extract_max_major_from_constraint(">=5.6") == "5"
+
+
+class TestSyntheticConstraints:
+    def test_caret(self):
+        assert extract_max_major_from_constraint("^18") == "18"
+
+    def test_multiple_or(self):
+        assert extract_max_major_from_constraint("^18 || ^20 || ^22") == "22"
+
+    def test_tilde(self):
+        assert extract_max_major_from_constraint("~20.10.0") == "20"
+
+    def test_python3(self):
+        # Python major version 3 — must not be filtered out
+        assert extract_max_major_from_constraint(">=3.12") == "3"
+
+    def test_no_numbers(self):
+        assert extract_max_major_from_constraint("latest") is None

--- a/utils/versions/test_parse_major_version.py
+++ b/utils/versions/test_parse_major_version.py
@@ -1,0 +1,22 @@
+from utils.versions.parse_major_version import parse_major_version
+
+
+# Real .nvmrc / .node-version values from cloned repos
+class TestRealVersionStrings:
+    def test_posthog_nvmrc_18(self):
+        # ../posthog/.nvmrc = "18"
+        assert parse_major_version("18") == "18"
+
+
+class TestSyntheticVersionStrings:
+    def test_v_prefix_full(self):
+        assert parse_major_version("v22.1.0") == "22"
+
+    def test_v_prefix_major_only(self):
+        assert parse_major_version("v20") == "20"
+
+    def test_lts_returns_none(self):
+        assert parse_major_version("lts/hydrogen") is None
+
+    def test_empty_string(self):
+        assert parse_major_version("") is None


### PR DESCRIPTION
## Summary
- CodeBuild was hardcoding `nodejs: 24` for all repos. `foxden-admin-portal-backend` failed because `express-oauth2-jwt-bearer` requires Node ≤22.
- Added Node version detection from `.nvmrc`, `.node-version`, and `package.json` `engines.node` field. Defaults to Node 22 (current LTS) when no version is specified.
- Pass detected version as `NODE_VERSION` env var to CodeBuild, which uses `n` to install the requested version.
- Version is included in the manifest hash so Node version changes invalidate the S3 dependency cache.
- Generic version parsing utilities (`parse_major_version`, `extract_max_major_from_constraint`) live in `utils/versions/` for reuse across Node and PHP.

## Social Media Posts

### GitAuto
CodeBuild was hardcoding Node 24 for every repo. One customer's dependencies required Node ≤22 and installs started failing. Now we detect the project's Node version from .nvmrc, .node-version, or package.json engines and pass it to the build. No version specified? Defaults to 22 LTS.

### Wes
Had a customer repo failing yarn install. Root cause: we were forcing Node 24 on every CodeBuild run, but one of their deps pins to Node ≤22. Built detection for .nvmrc, .node-version, and package.json engines - checks in that order, falls back to 22. Tested against six real repos. The version parsing is generic enough to handle PHP and Python constraints too.