### PR TITLE
Add daily billing consistency check across GitHub PRs, usage, and credits

### DIFF
--- a/.github/workflows/check-billing-consistency.yml
+++ b/.github/workflows/check-billing-consistency.yml
@@ -1,0 +1,63 @@
+name: Check Billing Consistency
+
+on:
+  schedule:
+    # Run daily at 10 AM PT (5 PM UTC)
+    - cron: "0 17 * * *"
+  workflow_dispatch:
+    inputs:
+      start_date:
+        description: "Start date (YYYY-MM-DD), default: 30 days ago"
+        required: false
+      end_date:
+        description: "End date (YYYY-MM-DD), default: tomorrow"
+        required: false
+      owner:
+        description: "Check specific owner only (default: all credit owners)"
+        required: false
+
+env:
+  ENV: github-actions
+  GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
+  SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
+
+jobs:
+  check-consistency:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install requests supabase python-dotenv
+
+      - name: Run billing consistency check
+        run: |
+          ARGS=""
+          if [ -n "${{ github.event.inputs.start_date }}" ]; then
+            ARGS="$ARGS --start ${{ github.event.inputs.start_date }}"
+          fi
+          if [ -n "${{ github.event.inputs.end_date }}" ]; then
+            ARGS="$ARGS --end ${{ github.event.inputs.end_date }}"
+          fi
+          if [ -n "${{ github.event.inputs.owner }}" ]; then
+            ARGS="$ARGS --owner ${{ github.event.inputs.owner }}"
+          fi
+          python3 scripts/supabase/check_billing_consistency.py $ARGS
+
+      - name: Notify Slack on failure
+        if: failure()
+        run: |
+          curl -s -X POST \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"channel\":\"C08PHH352S3\",\"text\":\"<!channel> Billing consistency check failed! Check workflow logs.\"}" \
+            https://slack.com/api/chat.postMessage

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,12 @@ __pycache__
 !/scripts/git/list_changed_files.sh
 !/scripts/git/pre_commit_hook.sh
 !/scripts/git/recent_social_posts.sh
+!/scripts/aws/
+/scripts/aws/*
+!/scripts/aws/trigger_schedule.py
 !/scripts/lint/
 !/scripts/sentry/
+!/scripts/supabase/
 coverage.*
 coverage/
 infrastructure/lambda-env-backup.json

--- a/constants/slack.py
+++ b/constants/slack.py
@@ -1,0 +1,2 @@
+# Notification channel
+SLACK_CHANNEL_ID = "C08PHH352S3"

--- a/scripts/supabase/check_billing_consistency.py
+++ b/scripts/supabase/check_billing_consistency.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# flake8: noqa: E402
+# pylint: disable=wrong-import-position
+"""Check billing consistency between GitHub PRs, usage table, and credits table.
+
+Source of truth: GitHub PRs created by gitauto-ai[bot].
+All three MUST perfectly match - any mismatch means we missed charging.
+Targets all owners who have purchased credits. Accepts date range, default 1 month based on created_at.
+
+Usage:
+  python3 scripts/supabase/check_billing_consistency.py
+  python3 scripts/supabase/check_billing_consistency.py --start 2026-03-01 --end 2026-04-01
+  python3 scripts/supabase/check_billing_consistency.py --owner Foxquilt
+"""
+
+import argparse
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+import requests
+
+# Add repo root to Python path so imports work
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from scripts.github.get_installation_token import get_installation_token
+from scripts.supabase.compare_billing_records import compare_billing_records
+from scripts.supabase.format_billing_report import format_billing_report
+from scripts.supabase.get_github_prs_by_owner import get_github_prs_by_owner
+from services.slack.slack_notify import slack_notify
+from services.supabase.credits.get_credit_records_by_owner import (
+    get_credit_records_by_owner,
+)
+from services.supabase.usage.get_usage_records_by_owner import (
+    get_usage_records_by_owner,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check billing consistency for credit-based owners"
+    )
+    now = datetime.now(tz=timezone.utc)
+    default_start = (now - timedelta(days=30)).strftime("%Y-%m-%d")
+    default_end = (now + timedelta(days=1)).strftime("%Y-%m-%d")
+
+    parser.add_argument(
+        "--start", default=default_start, help=f"Start date (default: {default_start})"
+    )
+    parser.add_argument(
+        "--end", default=default_end, help=f"End date (default: {default_end})"
+    )
+    parser.add_argument(
+        "--owner",
+        default=None,
+        help="Check specific owner only (default: all credit owners)",
+    )
+    args = parser.parse_args()
+
+    print(f"Checking billing consistency from {args.start} to {args.end}")
+
+    # Credit-based owners and their repos (hardcoded for now)
+    all_owners = [
+        {
+            "owner_id": 28540514,
+            "owner_name": "Foxquilt",
+            "repos": [
+                "foxcom-forms",
+                "foxcom-forms-backend",
+                "foxcom-payment-backend",
+                "foxcom-payment-frontend",
+                "foxden-admin-portal",
+                "foxden-admin-portal-backend",
+                "foxden-auth-service",
+                "foxden-billing",
+                "foxden-policy-document-backend",
+                "foxden-rating-quoting-backend",
+                "foxden-shared-lib",
+                "foxden-tools",
+                "foxden-version-controller",
+                "foxden-version-controller-client",
+            ],
+        },
+    ]
+
+    if args.owner:
+        owners = [o for o in all_owners if o["owner_name"] == args.owner]
+        if not owners:
+            print(f"Error: Owner '{args.owner}' not in hardcoded list")
+            sys.exit(1)
+    else:
+        owners = all_owners
+
+    print(f"Owners to check: {', '.join(o['owner_name'] for o in owners)}")
+
+    all_reports = []
+    has_mismatches = False
+
+    for owner in owners:
+        owner_name = owner["owner_name"]
+        owner_id = owner["owner_id"]
+        print(f"\n--- {owner_name} (owner_id={owner_id}) ---")
+
+        # Get GitHub token for this owner
+        try:
+            token = get_installation_token(owner_name)
+        except (ValueError, requests.HTTPError) as e:
+            print(f"  Skipping {owner_name}: {e}")
+            continue
+
+        repos = owner["repos"]
+
+        # Query all three data sources
+        github_prs_by_repo = get_github_prs_by_owner(
+            token, owner_name, repos, args.start, args.end
+        )
+        usage_records = get_usage_records_by_owner(owner_name, args.start, args.end)
+        credit_records = get_credit_records_by_owner(owner_id, args.start, args.end)
+        print(f"  Usage: {len(usage_records)}, Credits: {len(credit_records)}")
+
+        # Compare and report
+        mismatches = compare_billing_records(
+            github_prs_by_repo, usage_records, credit_records
+        )
+        report = format_billing_report(
+            owner_name,
+            repos,
+            github_prs_by_repo,
+            usage_records,
+            credit_records,
+            mismatches,
+            args.start,
+            args.end,
+        )
+        print("\n" + report)
+        all_reports.append(report)
+
+        if mismatches:
+            has_mismatches = True
+
+    # Slack notification with combined report
+    full_report = "\n\n".join(all_reports)
+    slack_notify(text=full_report)
+
+    if has_mismatches:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/supabase/compare_billing_records.py
+++ b/scripts/supabase/compare_billing_records.py
@@ -1,0 +1,133 @@
+from utils.error.handle_exceptions import handle_exceptions
+
+# Billable triggers that incur a credit charge
+BILLABLE_TRIGGERS = {
+    "issue_label",
+    "unknown",
+    "schedule",
+    "dashboard",
+    "manual",
+    "issue_comment",
+}
+
+
+@handle_exceptions(default_return_value=[], raise_on_error=False)
+def compare_billing_records(
+    github_prs_by_repo: dict[str, list[dict]],
+    usage_records: list[dict],
+    credit_records: list[dict],
+):
+    """Cross-reference GitHub PRs (source of truth), usage, and credits.
+    Every GitHub PR MUST have a usage record and a credit record unless trigger is free.
+    Any mismatch means we missed charging. Returns list of mismatches."""
+    mismatches = []
+
+    # Build lookups
+    usage_by_repo_pr: dict[tuple[str, int | None], list[dict]] = {}
+    for u in usage_records:
+        key = (u["repo_name"], u["pr_number"])
+        if key not in usage_by_repo_pr:
+            usage_by_repo_pr[key] = []
+        usage_by_repo_pr[key].append(u)
+
+    billable_usage_ids = {
+        u["id"] for u in usage_records if u["trigger"] in BILLABLE_TRIGGERS
+    }
+    all_usage_ids = {u["id"] for u in usage_records}
+    credit_usage_ids = {c["usage_id"] for c in credit_records if c["usage_id"]}
+
+    github_pr_keys = set()
+    for repo, prs in github_prs_by_repo.items():
+        for pr in prs:
+            github_pr_keys.add((repo, pr["number"]))
+
+    # Build set of (repo, pr) that have credits via usage_id
+    credited_repo_prs: set[tuple[str, int | None]] = set()
+    for c in credit_records:
+        if c["usage_id"]:
+            for u in usage_records:
+                if u["id"] == c["usage_id"]:
+                    credited_repo_prs.add((u["repo_name"], u["pr_number"]))
+                    break
+
+    # Check 1: GitHub PR without any usage record
+    for repo, prs in github_prs_by_repo.items():
+        for pr in prs:
+            key = (repo, pr["number"])
+            if key not in usage_by_repo_pr:
+                mismatches.append(
+                    {
+                        "type": "PR_NO_USAGE",
+                        "detail": f"GitHub PR #{pr['number']} in {repo} has no usage record",
+                    }
+                )
+
+    # Check 2: GitHub PR has billable usage but no credit (MISSED CHARGE)
+    for repo, prs in github_prs_by_repo.items():
+        for pr in prs:
+            key = (repo, pr["number"])
+            pr_usages = usage_by_repo_pr.get(key, [])
+            has_billable = any(u["trigger"] in BILLABLE_TRIGGERS for u in pr_usages)
+            if has_billable and key not in credited_repo_prs:
+                triggers = {u["trigger"] for u in pr_usages}
+                mismatches.append(
+                    {
+                        "type": "PR_NO_CREDIT",
+                        "detail": f"GitHub PR #{pr['number']} in {repo} (triggers: {triggers}) has no credit - MISSED CHARGE",
+                    }
+                )
+
+    # Check 3: Billable usage without matching GitHub PR
+    seen_repo_pr: set[tuple[str, int | None]] = set()
+    for u in usage_records:
+        if u["trigger"] not in BILLABLE_TRIGGERS:
+            continue
+        key = (u["repo_name"], u["pr_number"])
+        if key in seen_repo_pr:
+            continue
+        seen_repo_pr.add(key)
+        if key not in github_pr_keys and u["pr_number"]:
+            mismatches.append(
+                {
+                    "type": "USAGE_NO_PR",
+                    "detail": f"Usage #{u['id']} ({u['repo_name']} PR #{u['pr_number']}, trigger={u['trigger']}) has no GitHub PR",
+                }
+            )
+
+    # Check 4: Billable usage without credit (MISSED CHARGE)
+    for uid in billable_usage_ids:
+        if uid not in credit_usage_ids:
+            u = next(r for r in usage_records if r["id"] == uid)
+            mismatches.append(
+                {
+                    "type": "USAGE_NO_CREDIT",
+                    "detail": f"Usage #{uid} ({u['trigger']}, {u['repo_name']} PR #{u['pr_number']}) has no credit - MISSED CHARGE",
+                }
+            )
+
+    # Check 5: Credits pointing to non-existent usage (orphaned credit)
+    for c in credit_records:
+        if c["usage_id"] and c["usage_id"] not in all_usage_ids:
+            mismatches.append(
+                {
+                    "type": "CREDIT_NO_USAGE",
+                    "detail": f"Credit #{c['id']} points to usage #{c['usage_id']} which doesn't exist in range",
+                }
+            )
+
+    # Check 6: Credits linked to free trigger usage (unexpected charge)
+    for c in credit_records:
+        if (
+            c["usage_id"]
+            and c["usage_id"] in all_usage_ids
+            and c["usage_id"] not in billable_usage_ids
+        ):
+            u = next(r for r in usage_records if r["id"] == c["usage_id"])
+            mismatches.append(
+                {
+                    "type": "CREDIT_FREE_TRIGGER",
+                    "detail": f"Credit #{c['id']} linked to free trigger usage #{c['usage_id']} (trigger={u['trigger']})",
+                }
+            )
+
+    return mismatches

--- a/scripts/supabase/format_billing_report.py
+++ b/scripts/supabase/format_billing_report.py
@@ -1,0 +1,50 @@
+from scripts.supabase.compare_billing_records import BILLABLE_TRIGGERS
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value="", raise_on_error=False)
+def format_billing_report(
+    owner: str,
+    repos: list[str],
+    github_prs_by_repo: dict[str, list[dict]],
+    usage_records: list[dict],
+    credit_records: list[dict],
+    mismatches: list[dict],
+    start: str,
+    end: str,
+):
+    """Format the billing consistency check report for Slack/stdout."""
+    total_github_prs = sum(len(prs) for prs in github_prs_by_repo.values())
+    billable_usage = [u for u in usage_records if u["trigger"] in BILLABLE_TRIGGERS]
+    free_usage = [u for u in usage_records if u["trigger"] not in BILLABLE_TRIGGERS]
+    total_credits = len(credit_records)
+
+    lines = [
+        f"{owner} Billing Consistency ({start} to {end})",
+        f"GitHub PRs: {total_github_prs} | Billable usage: {len(billable_usage)} | Free usage: {len(free_usage)} | Credits: {total_credits}",
+        "",
+    ]
+
+    if not mismatches:
+        lines.append("All records match.")
+    else:
+        lines.append(f"{len(mismatches)} mismatch(es) found:")
+        for m in mismatches:
+            lines.append(f"  - [{m['type']}] {m['detail']}")
+
+    lines.append("")
+    lines.append("Per-repo breakdown:")
+    for repo in sorted(repos):
+        gh_count = len(github_prs_by_repo.get(repo, []))
+        repo_usages = [u for u in usage_records if u["repo_name"] == repo]
+        billable = len([u for u in repo_usages if u["trigger"] in BILLABLE_TRIGGERS])
+        repo_usage_ids = {u["id"] for u in repo_usages}
+        credits_count = len(
+            [c for c in credit_records if c["usage_id"] in repo_usage_ids]
+        )
+        status = "OK" if billable == credits_count else "MISMATCH"
+        lines.append(
+            f"  {repo}: GH={gh_count} billable={billable} credits={credits_count} total_usage={len(repo_usages)} [{status}]"
+        )
+
+    return "\n".join(lines)

--- a/scripts/supabase/get_github_prs_by_owner.py
+++ b/scripts/supabase/get_github_prs_by_owner.py
@@ -1,0 +1,54 @@
+import requests
+
+from config import GITHUB_API_URL, TIMEOUT
+from services.github.utils.create_headers import create_headers
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value={}, raise_on_error=False)
+def get_github_prs_by_owner(token, owner, repos, start, end):
+    """Get all GitAuto PRs across repos for an owner in date range. Returns dict of repo -> list of PRs."""
+    headers = create_headers(token=token)
+    prs_by_repo = {}
+
+    for repo in sorted(repos):
+        repo_prs = []
+        for state in ["open", "closed"]:
+            response = requests.get(
+                f"{GITHUB_API_URL}/repos/{owner}/{repo}/pulls",
+                headers=headers,
+                params={
+                    "state": state,
+                    "per_page": 100,
+                    "sort": "created",
+                    "direction": "desc",
+                },
+                timeout=TIMEOUT,
+            )
+            if response.status_code != 200:
+                print(
+                    f"  GitHub API error for {repo} ({state}): {response.status_code}"
+                )
+                continue
+            data = response.json()
+            if not isinstance(data, list):
+                continue
+            for pr in data:
+                if pr["user"]["login"] != "gitauto-ai[bot]":
+                    continue
+                created = pr["created_at"][:10]
+                if created < start or created > end:
+                    continue
+                repo_prs.append(
+                    {
+                        "number": pr["number"],
+                        "state": pr["state"],
+                        "created_at": pr["created_at"],
+                        "title": pr["title"],
+                    }
+                )
+        if repo_prs:
+            prs_by_repo[repo] = repo_prs
+        print(f"  {repo}: {len(repo_prs)} PRs")
+
+    return prs_by_repo

--- a/services/slack/slack_notify.py
+++ b/services/slack/slack_notify.py
@@ -6,6 +6,7 @@ import requests
 
 # Local imports
 from config import TIMEOUT
+from constants.slack import SLACK_CHANNEL_ID
 from constants.general import IS_PRD
 from utils.error.handle_exceptions import handle_exceptions
 from utils.logging.logging_config import logger
@@ -25,7 +26,7 @@ def slack_notify(text: str, thread_ts: str | None = None):
         "Content-Type": "application/json",
     }
 
-    payload = {"channel": "C08PHH352S3", "text": text}
+    payload = {"channel": SLACK_CHANNEL_ID, "text": text}
 
     if thread_ts:
         payload["thread_ts"] = thread_ts

--- a/services/supabase/credits/get_credit_records_by_owner.py
+++ b/services/supabase/credits/get_credit_records_by_owner.py
@@ -1,0 +1,18 @@
+from services.supabase.client import supabase
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=[], raise_on_error=False)
+def get_credit_records_by_owner(owner_id, start, end):
+    """Get credit deduction records for an owner in date range."""
+    result = (
+        supabase.table("credits")
+        .select("id, usage_id, amount_usd, transaction_type, created_at")
+        .eq("owner_id", owner_id)
+        .eq("transaction_type", "usage")
+        .gte("created_at", start)
+        .lt("created_at", end)
+        .order("created_at")
+        .execute()
+    )
+    return result.data

--- a/services/supabase/usage/get_usage_records_by_owner.py
+++ b/services/supabase/usage/get_usage_records_by_owner.py
@@ -1,0 +1,17 @@
+from services.supabase.client import supabase
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=[], raise_on_error=False)
+def get_usage_records_by_owner(owner, start, end):
+    """Get usage records for an owner in date range."""
+    result = (
+        supabase.table("usage")
+        .select("id, repo_name, pr_number, trigger, is_completed, created_at")
+        .eq("owner_name", owner)
+        .gte("created_at", start)
+        .lt("created_at", end)
+        .order("created_at")
+        .execute()
+    )
+    return result.data


### PR DESCRIPTION
## Summary
- Adds a daily GHA workflow that cross-references three data sources: GitHub PRs by gitauto-ai[bot] (source of truth), Supabase usage table, and Supabase credits table
- Detects 6 types of mismatches: PRs without usage, PRs without credits, usage without PRs, billable usage without credits, orphaned credits, and credits on free triggers
- Reports results to Slack via existing `slack_notify` and exits non-zero on mismatches
- Consolidates Slack channel ID into `constants/slack.py`, reuses `create_headers` and `GITHUB_API_URL`/`TIMEOUT` from config

## Social Media Posts

### GitAuto Post
We added a daily billing audit that cross-references GitHub PRs against our usage and credits tables. If a PR was created but never charged, we catch it now. Previously we had no way to detect missed charges until a customer noticed.

### Wes Post
Built a billing reconciliation script today. Source of truth is GitHub PRs created by our bot. For each PR, check: does a usage record exist? Does a credit deduction exist? If not, we missed charging. Runs daily, sends a Slack report. Simple but should have existed from day one.