### PR TITLE
Fix ensure_jest_timeout_for_ci: handle wrong values and duplicates

### DIFF
--- a/services/node/ensure_jest_timeout_for_ci.py
+++ b/services/node/ensure_jest_timeout_for_ci.py
@@ -15,6 +15,12 @@ CONFIG_OBJECT_PATTERNS = [
     re.compile(r"merge(?:\.recursive)?\([^{]*\{"),
 ]
 
+CI_TIMEOUT_MS = 180000
+LOCAL_TIMEOUT_MS = 5000
+EXPECTED_TIMEOUT_LINE = (
+    f"testTimeout: process.env.CI ? {CI_TIMEOUT_MS} : {LOCAL_TIMEOUT_MS},"
+)
+
 
 @handle_exceptions(default_return_value=None, raise_on_error=False)
 def ensure_jest_timeout_for_ci(root_files: list[str], base_args: BaseArgs):
@@ -37,34 +43,84 @@ def ensure_jest_timeout_for_ci(root_files: list[str], base_args: BaseArgs):
         )
         return None
 
-    if "testTimeout" in content:
-        logger.info(
-            "ensure_jest_timeout_for_ci: %s already has testTimeout", jest_config_file
+    # Find all testTimeout lines — duplicates cause last-key-wins in JS objects
+    lines = content.splitlines(keepends=True)
+    timeout_line_nums = [
+        i for i, line in enumerate(lines) if re.match(r"\s*testTimeout\s*[:,]", line)
+    ]
+
+    # None — inject one at the top of the config object
+    if len(timeout_line_nums) == 0:
+        match = None
+        for pattern in CONFIG_OBJECT_PATTERNS:
+            match = pattern.search(content)
+            if match:
+                break
+
+        if not match:
+            logger.info(
+                "ensure_jest_timeout_for_ci: Could not find config object pattern in %s",
+                jest_config_file,
+            )
+            return None
+
+        insert_pos = match.end()
+        next_line_match = re.search(r"\n(\s+)", content[insert_pos:])
+        indent = next_line_match.group(1) if next_line_match else "  "
+
+        updated_content = (
+            content[:insert_pos]
+            + f"\n{indent}{EXPECTED_TIMEOUT_LINE}"
+            + content[insert_pos:]
         )
-        return None
 
-    # Find the config object opening brace
-    match = None
-    for pattern in CONFIG_OBJECT_PATTERNS:
-        match = pattern.search(content)
-        if match:
-            break
+    # Exactly one — check if the value is sufficient (>= 180s)
+    elif len(timeout_line_nums) == 1:
+        existing_line = lines[timeout_line_nums[0]]
+        numbers = re.findall(r"\d+", existing_line)
+        if numbers and max(int(n) for n in numbers) >= CI_TIMEOUT_MS:
+            logger.info(
+                "ensure_jest_timeout_for_ci: %s already has sufficient testTimeout",
+                jest_config_file,
+            )
+            return None
 
-    if not match:
+        # Too low (e.g. 10000, 30000, 60000) — replace with our CI-aware value
         logger.info(
-            "ensure_jest_timeout_for_ci: Could not find config object pattern in %s",
+            "ensure_jest_timeout_for_ci: %s has testTimeout below %dms, updating",
             jest_config_file,
+            CI_TIMEOUT_MS,
         )
-        return None
+        indent = re.match(r"(\s*)", existing_line)
+        indent_str = indent.group(1) if indent else "  "
+        lines[timeout_line_nums[0]] = f"{indent_str}{EXPECTED_TIMEOUT_LINE}\n"
+        updated_content = "".join(lines)
 
-    # Detect indentation from the line after the opening brace
-    insert_pos = match.end()
-    next_line_match = re.search(r"\n(\s+)", content[insert_pos:])
-    indent = next_line_match.group(1) if next_line_match else "  "
-
-    # Inject testTimeout as the first property: longer timeout for CI (30s) vs local (5s)
-    injection = f"\n{indent}testTimeout: process.env.CI ? 180000 : 5000,"
-    updated_content = content[:insert_pos] + injection + content[insert_pos:]
+    # Multiple — remove all but the first, then ensure the first has a sufficient value.
+    # Two PRs branching from the same master can each add testTimeout, then both merge — leaving two entries where the last (often lower) value silently wins.
+    else:
+        logger.info(
+            "ensure_jest_timeout_for_ci: %s has %d testTimeout entries, removing duplicates",
+            jest_config_file,
+            len(timeout_line_nums),
+        )
+        lines_to_remove: set[int] = set()
+        for line_num in timeout_line_nums[1:]:
+            lines_to_remove.add(line_num)
+            if line_num > 0 and lines[line_num - 1].strip() == "":
+                lines_to_remove.add(line_num - 1)
+        # Also fix the first entry's value if too low
+        first_line = lines[timeout_line_nums[0]]
+        first_numbers = re.findall(r"\d+", first_line)
+        if not first_numbers or max(int(n) for n in first_numbers) < CI_TIMEOUT_MS:
+            indent = re.match(r"(\s*)", first_line)
+            indent_str = indent.group(1) if indent else "  "
+            lines[timeout_line_nums[0]] = f"{indent_str}{EXPECTED_TIMEOUT_LINE}\n"
+        updated_content = "".join(
+            line for i, line in enumerate(lines) if i not in lines_to_remove
+        )
+        # Fix trailing comma on the line before the removed entry if it was the last property
+        updated_content = re.sub(r",(\s*\n\};)", r"\1", updated_content)
 
     result = write_and_commit_file(
         file_content=updated_content,

--- a/services/node/test_ensure_jest_timeout_for_ci.py
+++ b/services/node/test_ensure_jest_timeout_for_ci.py
@@ -44,7 +44,20 @@ def test_no_jest_config_file(mock_read_local_file: MagicMock):
     mock_read_local_file.assert_not_called()
 
 
-def test_already_has_test_timeout(
+def test_already_has_correct_timeout(
+    mock_read_local_file: MagicMock, mock_write_and_commit: MagicMock
+):
+    mock_read_local_file.return_value = (
+        "module.exports = {\n  testTimeout: process.env.CI ? 180000 : 5000,\n};\n"
+    )
+    result = ensure_jest_timeout_for_ci(
+        root_files=["jest.config.js"], base_args=BASE_ARGS
+    )
+    assert result is None
+    mock_write_and_commit.assert_not_called()
+
+
+def test_updates_wrong_timeout_value(
     mock_read_local_file: MagicMock, mock_write_and_commit: MagicMock
 ):
     mock_read_local_file.return_value = (
@@ -53,8 +66,10 @@ def test_already_has_test_timeout(
     result = ensure_jest_timeout_for_ci(
         root_files=["jest.config.js"], base_args=BASE_ARGS
     )
-    assert result is None
-    mock_write_and_commit.assert_not_called()
+    assert result == "jest.config.js"
+    written = mock_write_and_commit.call_args.kwargs["file_content"]
+    assert "180000" in written
+    assert "10000" not in written
 
 
 def test_empty_content(
@@ -280,15 +295,17 @@ def test_foxden_version_controller_merge_recursive(
     assert written.index("testTimeout") < written.index("clearMocks")
 
 
-def test_foxden_rating_quoting_already_has_timeout(
+def test_foxden_rating_quoting_updates_wrong_timeout(
     mock_read_local_file: MagicMock, mock_write_and_commit: MagicMock
 ):
     mock_read_local_file.return_value = FOXDEN_RATING_QUOTING_CONFIG
     result = ensure_jest_timeout_for_ci(
         root_files=["jest.config.js"], base_args=BASE_ARGS
     )
-    assert result is None
-    mock_write_and_commit.assert_not_called()
+    assert result == "jest.config.js"
+    written = mock_write_and_commit.call_args.kwargs["file_content"]
+    assert "testTimeout: process.env.CI ? 180000 : 5000," in written
+    assert "60000" not in written
 
 
 def test_foxcom_forms_backend(
@@ -315,6 +332,38 @@ def test_foxden_auth_service(
     written = mock_write_and_commit.call_args.kwargs["file_content"]
     assert "testTimeout: process.env.CI ? 180000 : 5000," in written
     assert written.index("testTimeout") < written.index("clearMocks")
+
+
+# Config with duplicate testTimeout (last-key-wins bug from parallel PR merges)
+FOXDEN_ADMIN_PORTAL_DUPLICATE_TIMEOUT = """export default {
+  testTimeout: process.env.CI ? 180000 : 5000,
+  clearMocks: true,
+  coverageDirectory: 'coverage',
+  collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
+  coverageProvider: 'v8',
+  setupFilesAfterEnv: ['<rootDir>/test/setupTests.ts'],
+  testEnvironment: 'jsdom',
+  testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[tj]s?(x)'],
+
+  testTimeout: process.env.CI ? 30000 : 5000
+};
+"""
+
+
+def test_removes_duplicate_test_timeout_keeps_first(
+    mock_read_local_file: MagicMock, mock_write_and_commit: MagicMock
+):
+    mock_read_local_file.return_value = FOXDEN_ADMIN_PORTAL_DUPLICATE_TIMEOUT
+    result = ensure_jest_timeout_for_ci(
+        root_files=["jest.config.ts"], base_args=BASE_ARGS
+    )
+    assert result == "jest.config.ts"
+    written = mock_write_and_commit.call_args.kwargs["file_content"]
+    # Should keep first (180000) and remove second (30000)
+    assert "testTimeout: process.env.CI ? 180000 : 5000," in written
+    assert "testTimeout: process.env.CI ? 30000 : 5000" not in written
+    # Should only have one testTimeout
+    assert written.count("testTimeout") == 1
 
 
 WEBSITE_JEST_CONFIG = """import type { Config } from "jest";


### PR DESCRIPTION
## Summary

- Old logic checked `if "testTimeout" in content: return None` — skipping any config that already had a testTimeout, regardless of value or duplicates
- Two bugs: (1) wrong values like `testTimeout: 10000` or `testTimeout: 60000` were left as-is, (2) duplicate entries from parallel PR merges caused JS last-key-wins where the lower value silently won
- Root cause of the duplicate bug: two PRs branch from the same main (before any testTimeout exists), each independently adds testTimeout via `ensure_jest_timeout_for_ci`, both merge — leaving two entries
- Now handles 3 cases ordered by frequency: 0 entries (inject), 1 entry (check >= 180s, update if too low), multiple entries (deduplicate and fix value)
- Added tests for wrong value replacement, duplicate deduplication, and real-world configs

## Social Media Posts

### GitAuto

Shipped a fix for a subtle race condition. When two PRs branch from the same main and both add `testTimeout` to jest config, the merged result has two entries. In JS objects, last key wins - so the second (lower) value silently overrides the first. Now we detect duplicates, keep the first, and verify the value is >= 180s.

### Wes

JavaScript's "last key wins" behavior with duplicate object keys is a quiet footgun. Two of our PRs independently added `testTimeout` to a customer's jest config. Both merged fine. But the second entry had a lower value - 30s vs 180s - and JS just... uses the last one. Tests timed out in CI. The old code only checked "does testTimeout exist?" and moved on. Now it counts entries, deduplicates, and verifies the value is actually high enough for CI.