### PR TITLE
Add LLM-based quality gate for schedule/dashboard PRs

### DIFF
--- a/constants/triggers.py
+++ b/constants/triggers.py
@@ -1,20 +1,21 @@
 from typing import Literal, Union
 
+NewPrTrigger = Literal["dashboard", "schedule"]
+
 ReviewTrigger = Literal["pr_comment", "pr_file_review", "pr_review"]
 
 Trigger = Union[
     Literal[
         "check_suite_completed",
         "cleanup_stale_repos",
-        "dashboard",
         "installation",
         "installation_repositories",
         "pr_merged",
         "push",
-        "schedule",
         "setup",
         "test_failure",
         "workflow_run_completed",
     ],
+    NewPrTrigger,
     ReviewTrigger,
 ]

--- a/services/agents/run_quality_gate.py
+++ b/services/agents/run_quality_gate.py
@@ -1,0 +1,66 @@
+from services.claude.evaluate_quality_checks import evaluate_quality_checks
+from services.types.base_args import BaseArgs
+from utils.error.handle_exceptions import handle_exceptions
+from utils.files.read_local_file import read_local_file
+from utils.logging.logging_config import logger
+
+QUALITY_GATE_MESSAGE = "Evaluate and improve test quality per coding standards."
+
+
+@handle_exceptions(default_return_value="", raise_on_error=False)
+def run_quality_gate(clone_dir: str, impl_file: str, base_args: BaseArgs):
+    """Return error message if quality gate fails, empty string if it passes."""
+    test_file_paths = base_args.get("test_file_paths", []) or []
+    logger.info("Running quality gate for %s", impl_file)
+
+    source_content = read_local_file(file_path=impl_file, base_dir=clone_dir)
+    if not source_content:
+        logger.warning("Could not read source file %s for quality gate", impl_file)
+        return ""
+
+    test_files: list[tuple[str, str]] = []
+    for tp in test_file_paths:
+        content = read_local_file(file_path=tp, base_dir=clone_dir)
+        if content and content.strip():
+            test_files.append((tp, content))
+
+    if not test_files:
+        logger.info("No test files found for %s, quality gate passes", impl_file)
+        return ""
+
+    quality_results = evaluate_quality_checks(
+        source_content=source_content,
+        source_path=impl_file,
+        test_files=test_files,
+    )
+    if quality_results is None:
+        logger.warning("Quality evaluation failed for %s, letting it pass", impl_file)
+        return ""
+
+    # Check for any failing checks
+    failed_categories: list[str] = []
+    for category, checks in quality_results.items():
+        for check_name, check_data in checks.items():
+            if check_data.get("status") == "fail":
+                reason = check_data.get("reason", "")
+                logger.info(
+                    "Quality gate: %s.%s failed for %s: %s",
+                    category,
+                    check_name,
+                    impl_file,
+                    reason,
+                )
+                failed_categories.append(category)
+                break
+
+    if failed_categories:
+        logger.warning(
+            "Quality gate failed for %s: %d categories with failures: %s",
+            impl_file,
+            len(failed_categories),
+            ", ".join(failed_categories),
+        )
+        return f"Quality gate failed for {impl_file}. {QUALITY_GATE_MESSAGE}"
+
+    logger.info("Quality gate passed for %s: all checks pass or N/A", impl_file)
+    return ""

--- a/services/agents/test_verify_task_is_complete.py
+++ b/services/agents/test_verify_task_is_complete.py
@@ -148,12 +148,28 @@ async def test_verify_partial_fix_with_remaining_errors(
 @pytest.mark.asyncio
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
 async def test_verify_task_is_complete_failure_no_changes(mock_get_files, base_args):
+    # Non-schedule PR with no changes should succeed (e.g. setup handler decided no work needed)
     mock_get_files.return_value = []
 
     result = await verify_task_is_complete(base_args)
 
     assert result.success is True
     assert "No changes were needed" in result.message
+
+
+@pytest.mark.asyncio
+@patch("services.agents.verify_task_is_complete.get_pull_request_files")
+async def test_schedule_pr_no_changes_always_fails(mock_get_files, base_args):
+    # Schedule/dashboard PR with 0 changes always fails without LLM call —
+    # the schedule_handler already determined quality is bad when it created the PR
+    mock_get_files.return_value = []
+    base_args["trigger"] = "schedule"
+    base_args["impl_file_to_collect_coverage_from"] = "src/resolvers/foo.ts"
+
+    result = await verify_task_is_complete(base_args)
+
+    assert result.success is False
+    assert "0 changes" in result.message
 
 
 @pytest.mark.asyncio

--- a/services/agents/verify_task_is_complete.py
+++ b/services/agents/verify_task_is_complete.py
@@ -8,6 +8,7 @@ from constants.files import (
     PHP_TEST_FILE_EXTENSIONS,
     TS_TEST_FILE_EXTENSIONS,
 )
+from services.agents.run_quality_gate import QUALITY_GATE_MESSAGE, run_quality_gate
 from services.eslint.ensure_eslint_relaxed_for_tests import (
     ensure_eslint_relaxed_for_tests,
 )
@@ -88,13 +89,35 @@ async def verify_task_is_complete(
         owner=owner, repo=repo, pr_number=pr_number, token=token
     )
 
+    trigger = base_args.get("trigger", "")
+    impl_file = base_args.get("impl_file_to_collect_coverage_from", "")
+
     if not pr_files:
-        logger.info(
-            "No PR file changes found (e.g. setup handler determined no workflows needed), skipping checks"
-        )
+        # 0 changes on a schedule/dashboard PR: fail immediately without LLM call.
+        # The schedule_handler already evaluated quality and found issues (that's why it created the PR). The LLM quality gate only runs after the agent makes changes (bottom of this function) to avoid paying for the same evaluation twice.
+        if trigger in ("schedule", "dashboard") and impl_file:
+            # First 0-change attempt: reject to nudge agent to try.
+            # Second 0-change attempt: agent genuinely can't improve, let it pass.
+            if not base_args.get("quality_gate_retried"):
+                base_args["quality_gate_retried"] = True
+                return VerifyTaskIsCompleteResult(
+                    success=False,
+                    message=f"Task NOT complete. You made 0 changes to the test file for {impl_file}. {QUALITY_GATE_MESSAGE}",
+                )
+
+            logger.info(
+                "Agent retried with 0 changes for %s, allowing completion", impl_file
+            )
+
+        logger.info("No PR file changes found, skipping file checks")
         return VerifyTaskIsCompleteResult(
             success=True, message="Task completed. No changes were needed."
         )
+
+    formatting_applied: list[str] = []
+    remaining_errors: list[str] = []
+    error_files: set[str] = set()
+    modified_files: set[str] = set()
 
     js_test_files = [
         f["filename"]
@@ -102,7 +125,6 @@ async def verify_task_is_complete(
         if f["filename"].endswith(JS_TEST_FILE_EXTENSIONS) and f["status"] != "removed"
     ]
 
-    modified_files: set[str] = set()
     if js_test_files:
         root_files = [
             f
@@ -144,9 +166,6 @@ async def verify_task_is_complete(
     non_removed_files = [f["filename"] for f in pr_files if f["status"] != "removed"]
     js_ts_files = filter_js_ts_files(non_removed_files)
 
-    formatting_applied: list[str] = []
-    remaining_errors: list[str] = []
-    error_files: set[str] = set()
     for file_path in js_ts_files:
         content = read_local_file(file_path=file_path, base_dir=clone_dir)
         if not content:
@@ -287,6 +306,15 @@ async def verify_task_is_complete(
             for err in phpunit_result.errors:
                 remaining_errors.append(f"- phpunit: {err}")
             error_files.update(phpunit_result.error_files)
+
+    # Quality gate for schedule/dashboard PRs: evaluate test quality via Claude.
+    # Runs last to avoid paying for LLM call when lint/test errors will force a retry anyway.
+    if trigger in ("schedule", "dashboard") and impl_file and not remaining_errors:
+        quality_error = run_quality_gate(
+            clone_dir=clone_dir, impl_file=impl_file, base_args=base_args
+        )
+        if quality_error:
+            remaining_errors.append(f"- {quality_error}")
 
     if remaining_errors:
         error_msg = "\n".join(remaining_errors)

--- a/services/types/base_args.py
+++ b/services/types/base_args.py
@@ -1,6 +1,7 @@
 from typing import TypedDict
 from typing_extensions import NotRequired
 
+from constants.triggers import Trigger
 from schemas.supabase.types import OwnerType
 from services.github.types.webhook.review_run_payload import ReviewSubjectType
 
@@ -38,7 +39,10 @@ class BaseArgs(TypedDict):
     latest_commit_sha: NotRequired[str]
     workflow_id: NotRequired[str | int]
     baseline_tsc_errors: NotRequired[set[str]]
+    trigger: NotRequired[Trigger]
     impl_file_to_collect_coverage_from: NotRequired[str]
+    quality_gate_retried: NotRequired[bool]
+    test_file_paths: NotRequired[list[str]]
     review_id: NotRequired[int]
     skip_ci: NotRequired[bool]
 

--- a/services/webhook/check_suite_handler.py
+++ b/services/webhook/check_suite_handler.py
@@ -244,6 +244,7 @@ async def handle_check_suite(
         "clone_dir": clone_dir,
         "workflow_id": circleci_workflow_id if is_circleci else github_run_id,
         "check_run_name": check_run_name,
+        "trigger": trigger,
         "skip_ci": True,
     }
 

--- a/services/webhook/new_pr_handler.py
+++ b/services/webhook/new_pr_handler.py
@@ -10,7 +10,7 @@ from anthropic.types import MessageParam
 # Local imports
 from constants.agent import MAX_ITERATIONS
 from constants.messages import SETTINGS_LINKS
-from constants.triggers import Trigger
+from constants.triggers import NewPrTrigger
 from services.agents.verify_task_is_complete import verify_task_is_complete
 from services.agents.verify_task_is_ready import verify_task_is_ready
 from services.chat_with_agent import chat_with_agent
@@ -82,7 +82,7 @@ from utils.urls.extract_urls import extract_image_urls
 
 async def handle_new_pr(
     payload: PrLabeledPayload,
-    trigger: Trigger,
+    trigger: NewPrTrigger,
     lambda_info: dict[str, str | None] | None = None,
 ) -> None:
     set_trigger(trigger)
@@ -95,6 +95,7 @@ async def handle_new_pr(
     base_args["pr_number"] = pr_number
     pr_url = payload["pull_request"]["html_url"]
 
+    base_args["trigger"] = trigger
     # Ensure skip_ci is set to True for development commits
     base_args["skip_ci"] = True
 
@@ -394,6 +395,7 @@ async def handle_new_pr(
     )
     test_file_paths = find_test_files(impl_file_path, all_file_paths, test_dir_prefixes)
     test_file_paths = prioritize_test_files(test_file_paths, impl_file_path)
+    base_args["test_file_paths"] = test_file_paths
     max_test_files_in_prompt = 5
 
     # Include most relevant test files with contents, rest as paths-only

--- a/services/webhook/review_run_handler.py
+++ b/services/webhook/review_run_handler.py
@@ -219,6 +219,7 @@ async def handle_review_run(
         # "review_position": review_position,
         "review_body": review_body,
         "review_comment": review_comment,
+        "trigger": trigger,
         "skip_ci": True,
     }
 

--- a/services/webhook/setup_handler.py
+++ b/services/webhook/setup_handler.py
@@ -58,7 +58,16 @@ async def setup_handler(
 ):
     set_owner_repo(owner_name, repo_name)
     set_trigger("setup")
-    thread_ts = slack_notify(f"Setup started for {owner_name}/{repo_name}")
+    logger.info(
+        "Setup triggered by sender_name=%s sender_id=%d for %s/%s",
+        sender_name,
+        sender_id,
+        owner_name,
+        repo_name,
+    )
+    thread_ts = slack_notify(
+        f"Setup started for {owner_name}/{repo_name} by {sender_name} (id={sender_id})"
+    )
 
     installation = get_installation_by_owner(owner_name)
     if not installation:

--- a/services/webhook/webhook_handler.py
+++ b/services/webhook/webhook_handler.py
@@ -8,7 +8,7 @@ from config import (
     GITHUB_CHECK_RUN_FAILURES,
     PRODUCT_ID,
 )
-from constants.triggers import Trigger
+from constants.triggers import NewPrTrigger
 from services.github.types.webhook.review_run_payload import ReviewRunPayload
 from services.github.types.github_types import (
     CheckSuiteCompletedPayload,
@@ -156,7 +156,7 @@ async def handle_webhook_event(
             return
 
         suffix = head_ref[len(prefix) :]
-        trigger = cast(Trigger, suffix.split("-")[0])
+        trigger = cast(NewPrTrigger, suffix.split("-")[0])
         await handle_new_pr(
             payload=typed_payload,
             trigger=trigger,

--- a/utils/prompts/coding_standards.xml
+++ b/utils/prompts/coding_standards.xml
@@ -51,6 +51,12 @@
     <rule>If placeTestFilesNextToSourceFiles is True in structured_repository_rules, ALWAYS co-locate new test files next to their source files regardless of the repo's dominant pattern. Otherwise, if the repo has a dominant pattern (80%+ of tests in one location), follow that. If patterns are mixed (no 80%+ majority), prioritize co-location. If no pattern exists, prioritize co-location.</rule>
   </test_file_organization>
 
+  <coverage_is_not_quality>
+    <rule>100% code coverage does NOT mean the task is complete. Coverage measures which lines execute, not whether tests are meaningful. A tautological test (mock returns X, assert output equals X) achieves 100% coverage while proving nothing.</rule>
+    <rule>When a test file already exists with 100% coverage, evaluate test QUALITY before declaring "no changes needed": check for tautological assertions, missing adversarial cases, missing inline comments, and implementation-detail testing instead of behavior testing.</rule>
+    <rule>If existing tests are low quality (tautological, no adversarial cases, no inline comments), REWRITE them to meet coding standards. Do NOT declare the task complete just because coverage is 100%.</rule>
+  </coverage_is_not_quality>
+
   <anti_patterns>
     <rule>Do not over-assert on internal function call parameters when the behavior is what matters</rule>
     <rule>Do not create unnecessarily complex mock chains when testing method chaining - focus on the final result, not each step of the chain</rule>

--- a/utils/prompts/triggers/pr.xml
+++ b/utils/prompts/triggers/pr.xml
@@ -14,11 +14,22 @@
   - Use write_and_commit_file to create the new file (apply_diff_to_file is error-prone for new files because the unified diff /dev/null format requires exact line counts)
   - CRITICAL: Check the "test_naming_convention" field in the user input. It describes the repo's naming pattern with an example. Follow it exactly. Never invent suffixes like ".early.test." - match the repo's existing convention.
 
-  IF TEST FILE ALREADY EXISTS:
+  IF TEST FILE ALREADY EXISTS AND COVERAGE IS BELOW 100%:
   - The issue body specifies EXACTLY which lines, functions, and branches are uncovered
   - Write tests that specifically target those uncovered items (e.g., "Uncovered Lines: 6, 7" means write tests that execute lines 6 and 7)
   - Use apply_diff_to_file to ADD new test cases - do NOT use write_and_commit_file
   - Preserve ALL existing content including headers (eslint-disable, pylint: disable, etc.)
+
+  IF TEST FILE ALREADY EXISTS AND COVERAGE IS ALREADY 100%:
+  - 100% coverage does NOT mean tests are good. You MUST evaluate test quality.
+  - Read EVERY existing test and check for these quality issues:
+    1. Tautological tests: mock returns X, then assert output equals X (proves nothing)
+    2. Missing inline comments: every test MUST have a comment explaining WHAT it tests and WHY
+    3. Missing adversarial tests: null/undefined inputs, empty values, wrong types, boundary values
+    4. Implementation-detail testing: asserting mock call counts instead of behavioral outcomes
+  - If ANY quality issue is found, REWRITE the test file using write_and_commit_file to fix all issues
+  - Do NOT declare "no changes needed" just because coverage is 100% - quality matters
+  - NEVER call verify_task_is_complete without making changes if tests have quality issues
 
   COMMON MISTAKES TO AVOID:
   - Do NOT assume existing tests are "comprehensive" just because they look thorough


### PR DESCRIPTION
## Summary
- Add quality gate that evaluates test quality via Claude when GA runs on schedule/dashboard PRs
- Quality gate runs **last** (after lint, tsc, jest all pass) to avoid wasting LLM cost on retries
- For 0-change schedule PRs, reject immediately without LLM call (schedule_handler already evaluated quality); bail out on second 0-change attempt
- Pass `trigger` and `test_file_paths` through `base_args` instead of re-discovering test files or using indirect field checks
- Add `NewPrTrigger` type for `new_pr_handler` (only accepts "dashboard" | "schedule")
- Add coding standards and prompt rules so the agent knows 100% coverage != quality

## Context
Foxquilt PR #1386: GA saw 100% coverage on a test file with useless assertions (`expect(result).toBeDefined()` on a function that always returns) and declared "no changes needed." Our verification gate had a gap - zero changes meant zero files to check, so everything passed. The quality gate closes this gap.

## Social Media Posts

### GitAuto
100% test coverage doesn't mean your tests are good. We had a gap in our verification gate - zero changes meant zero files to check, so "do nothing" passed every check. Now schedule PRs with weak tests get rejected on the first zero-change attempt, and an LLM evaluates test quality after all other checks pass.

### Wes
Our verification gate had a blind spot. Zero PR changes meant zero files to lint, type-check, or test. Everything passed because there was nothing to fail. The scheduler had already flagged the tests as weak, but the gate didn't know that. Added a quality gate that rejects zero-change completions for quality-focused PRs and runs an LLM evaluation after everything else passes.