### PR TITLE
Check trigger_on_review_comment before and during review handler execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,7 @@ When the user explicitly says "LGTM", execute this workflow:
     - **Title MUST vary**: (1) check `ls ../website/app/blog/posts/ | tail -10`, (2) verify no duplicate: `ls ../website/app/blog/posts/ | grep "your-slug-without-date"`
     - **No customer names**: Customer repo names, org names, and identifiable details are private. Use generic descriptions ("a React app", "~400 files") instead of specific names ("foxcom-forms", "SPIDERPLUS-web"). Approximate numbers instead of exact counts that could identify repos.
     - **Tone**: Honest, transparent, technical. Written for developers.
+    - **Be specific about model names**: When referring to "the agent" or "the model", always specify the exact model (e.g., "Claude Opus 4.6") at least on first mention. Don't just say "an LLM" or "the agent" - readers want to know which model exhibited the behavior.
     - **MDX header format**:
 
       ```javascript

--- a/services/webhook/check_suite_handler.py
+++ b/services/webhook/check_suite_handler.py
@@ -683,6 +683,7 @@ async def handle_check_suite(
     total_token_input = 0
     total_token_output = 0
     is_completed = False
+    completion_reason = ""
 
     system_message = create_system_message(
         trigger=trigger, repo_settings=repo_settings, clone_dir=clone_dir
@@ -702,7 +703,9 @@ async def handle_check_suite(
         if not refreshed_settings or not refreshed_settings.get(
             "trigger_on_test_failure"
         ):
-            logger.info("trigger_on_test_failure disabled during execution, stopping")
+            is_completed = True
+            completion_reason = "Stopped because the test failure trigger was disabled during execution."
+            logger.info(completion_reason)
             break
 
         # Safety check: Stop if older active request exists (race condition prevention)
@@ -760,20 +763,24 @@ async def handle_check_suite(
         final_result = await verify_task_is_complete(base_args=base_args)
         is_completed = final_result.success
 
-    # Trigger final test workflows with an empty commit
-    comment_body = "Creating final empty commit to trigger workflows..."
-    update_comment(body=comment_body, base_args=base_args)
-    create_empty_commit(base_args=base_args)
-
-    # Update final comment. Do NOT include CHECK_RUN_FAILED_MESSAGE here — that marker
-    # is a concurrency lock set at line 317 when processing starts. Clearing it here
-    # releases the lock so the next check_suite webhook can proceed. The error hash
-    # dedup at line 557 prevents re-attempting the same error.
-    if is_completed:
-        final_msg = f"Created an empty commit to re-trigger the `{check_run_name}` CI. Waiting for results."
+    # If stopped due to trigger being disabled, post reason and skip empty commit
+    if completion_reason:
+        update_comment(body=completion_reason, base_args=base_args)
     else:
-        final_msg = f"I tried to fix `{check_run_name}` but verification still shows errors. Please review the changes."
-    update_comment(body=final_msg, base_args=base_args)
+        # Trigger final test workflows with an empty commit
+        comment_body = "Creating final empty commit to trigger workflows..."
+        update_comment(body=comment_body, base_args=base_args)
+        create_empty_commit(base_args=base_args)
+
+        # Update final comment. Do NOT include CHECK_RUN_FAILED_MESSAGE here — that marker
+        # is a concurrency lock set at line 317 when processing starts. Clearing it here
+        # releases the lock so the next check_suite webhook can proceed. The error hash
+        # dedup at line 557 prevents re-attempting the same error.
+        if is_completed:
+            final_msg = f"Created an empty commit to re-trigger the `{check_run_name}` CI. Waiting for results."
+        else:
+            final_msg = f"I tried to fix `{check_run_name}` but verification still shows errors. Please review the changes."
+        update_comment(body=final_msg, base_args=base_args)
 
     # Update usage record
     end_time = time.time()

--- a/services/webhook/review_run_handler.py
+++ b/services/webhook/review_run_handler.py
@@ -395,6 +395,16 @@ async def handle_review_run(
         ):
             break
 
+        # Re-check trigger_on_review_comment in case it was disabled during execution
+        refreshed_settings = get_repository(owner_id=owner_id, repo_id=repo_id)
+        if not refreshed_settings or not refreshed_settings.get(
+            "trigger_on_review_comment"
+        ):
+            is_completed = True
+            completion_reason = "Stopped because the review comment trigger was disabled during execution."
+            logger.info(completion_reason)
+            break
+
         # Check if the review thread was resolved while we were working (no thread for PR comments)
         if review_path:
             thread_check = get_review_thread_comments(

--- a/utils/logs/test_normalize_log_for_hashing.py
+++ b/utils/logs/test_normalize_log_for_hashing.py
@@ -1,6 +1,6 @@
 from utils.logs.normalize_log_for_hashing import normalize_log_for_hashing
 
-# Two real raw error logs from nebula-crm PR #1 (usage IDs 14971 and 14972). Same underlying error (missing UX evidence file) but different commit SHAs because GA created empty commits between runs.
+# Two real raw error logs from nebula-crm PR #1 (usage IDs 14971 and 14972). Same underlying error (missing UX evidence file) but different commit SHAs because GitAuto created empty commits between runs.
 RAW_LOG_RUN_A = """```GitHub Check Run Log: frontend-ui/3_Validate frontend UX evidence.txt
  ##[group]Run set -euo pipefail
 set -euo pipefail


### PR DESCRIPTION
## Summary
- The `trigger_on_review_comment` DB setting was never checked - all review comments on GitAuto PRs were processed regardless of the setting
- Added the check at entry in `review_run_handler.py` (after confirming it's a GitAuto PR and not from GA itself, before any expensive work)
- Added re-check during the iteration loop, matching the pattern in `check_suite_handler.py`
- Fixed both handlers (`review_run_handler` and `check_suite_handler`) to set `is_completed = True` and an accurate `completion_reason` when the trigger is disabled mid-execution, instead of falling through to misleading "hit MAX_ITERATIONS" logs and "I was unable to complete this task" messages

## GitAuto post
Users could disable the review comment trigger in settings, but we never actually checked it. Every review comment still fired the full agent - cloning, installing deps, running Claude. Now we check the flag early and also re-check during execution so users can stop a running agent by toggling settings.

## Wes post
Had a user report that disabling review triggers didn't work. Traced it and found... we never read the setting. The DB column existed, the UI toggle existed, but the webhook handler just skipped straight to processing. Classic case of building the off switch but forgetting to wire it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)