### PR TITLE
Add reset_pr_branch_to_new_base tool for sibling base branch changes

### DIFF
--- a/services/claude/tools/tools.py
+++ b/services/claude/tools/tools.py
@@ -32,9 +32,9 @@ from services.github.comments.reply_to_comment import (
     REPLY_TO_REVIEW_COMMENT,
     reply_to_comment,
 )
-from services.github.pulls.change_pr_base_branch import (
-    CHANGE_PR_BASE_BRANCH,
-    change_pr_base_branch,
+from services.git.reset_pr_branch_to_new_base import (
+    RESET_PR_BRANCH_TO_NEW_BASE,
+    reset_pr_branch_to_new_base,
 )
 from utils.files.get_local_file_content import (
     GET_LOCAL_FILE_CONTENT,
@@ -84,7 +84,7 @@ TOOLS_FOR_PRS: list[ToolUnionParam] = _TOOLS_BASE + [
 
 # Review comment handler adds reply capability
 TOOLS_FOR_REVIEW_COMMENTS: list[ToolUnionParam] = TOOLS_FOR_PRS + [
-    CHANGE_PR_BASE_BRANCH,
+    RESET_PR_BRANCH_TO_NEW_BASE,
     REPLY_TO_REVIEW_COMMENT,
 ]
 
@@ -104,7 +104,7 @@ FILE_EDIT_TOOLS = [
 # Define tools to call
 tools_to_call: dict[str, Any] = {
     "apply_diff_to_file": apply_diff_to_file,
-    "change_pr_base_branch": change_pr_base_branch,
+    "reset_pr_branch_to_new_base": reset_pr_branch_to_new_base,
     "create_comment": create_comment,
     "create_directory": create_directory,
     "delete_file": delete_file,

--- a/services/git/git_commit_and_push.py
+++ b/services/git/git_commit_and_push.py
@@ -11,6 +11,7 @@ def git_commit_and_push(
     base_args: BaseArgs,
     message: str,
     files: list[str],
+    force: bool = False,
 ):
     clone_dir = base_args["clone_dir"]
     clone_url = base_args["clone_url"]
@@ -33,9 +34,11 @@ def git_commit_and_push(
 
     # Update remote URL with fresh token and push
     run_subprocess(["git", "remote", "set-url", "origin", clone_url], clone_dir)
-    run_subprocess(
-        ["git", "push", "origin", f"HEAD:refs/heads/{new_branch}"], clone_dir
-    )
+    push_cmd = ["git", "push"]
+    if force:
+        push_cmd.append("--force-with-lease")
+    push_cmd.extend(["origin", f"HEAD:refs/heads/{new_branch}"])
+    run_subprocess(push_cmd, clone_dir)
 
     logger.info("Committed and pushed: %s", message.split("\n")[0])
     return True

--- a/services/git/reapply_files.py
+++ b/services/git/reapply_files.py
@@ -1,0 +1,36 @@
+import os
+
+from config import UTF8
+from utils.error.handle_exceptions import handle_exceptions
+from utils.logging.logging_config import logger
+
+
+@handle_exceptions(default_return_value=[], raise_on_error=False)
+def reapply_files(
+    clone_dir: str,
+    saved_files: dict[str, str],
+    deleted_files: list[str],
+):
+    """Write saved file contents back to clone_dir after a rebase.
+    Returns list of file paths that were modified (for staging/committing).
+    """
+    files_to_commit: list[str] = []
+    for file_path, content in saved_files.items():
+        full_path = os.path.join(clone_dir, file_path)
+        os.makedirs(os.path.dirname(full_path), exist_ok=True)
+        with open(full_path, "w", encoding=UTF8, newline="") as f:
+            f.write(content)
+        logger.info("Wrote file: %s", file_path)
+        files_to_commit.append(file_path)
+
+    for file_path in deleted_files:
+        full_path = os.path.join(clone_dir, file_path)
+        if os.path.exists(full_path):
+            os.remove(full_path)
+            logger.info("Deleted file: %s", file_path)
+            files_to_commit.append(file_path)
+        else:
+            logger.warning("File to delete not found, skipping: %s", file_path)
+
+    logger.info("Reapplied %d files after rebase", len(files_to_commit))
+    return files_to_commit

--- a/services/git/reset_pr_branch_to_new_base.py
+++ b/services/git/reset_pr_branch_to_new_base.py
@@ -1,0 +1,99 @@
+from anthropic.types import ToolUnionParam
+
+from services.git.git_commit_and_push import git_commit_and_push
+from services.git.git_fetch import git_fetch
+from services.git.git_reset import git_reset
+from services.git.reapply_files import reapply_files
+from services.git.save_pr_files import save_pr_files
+from services.github.pulls.change_pr_base_branch import change_pr_base_branch
+from services.github.pulls.get_pull_request_files import Status, get_pull_request_files
+from services.types.base_args import BaseArgs
+from utils.error.handle_exceptions import handle_exceptions
+from utils.logging.logging_config import logger
+
+RESET_PR_BRANCH_TO_NEW_BASE: ToolUnionParam = {
+    "name": "reset_pr_branch_to_new_base",
+    "description": "Changes the base branch of the current pull request and resets the PR branch onto the new base. Use this when a reviewer requests the PR to target a different branch (e.g., from 'release/20260408' to 'release/20260422').",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "new_base_branch": {
+                "type": "string",
+                "description": "The name of the new base branch to target (e.g., 'release/20260422').",
+            },
+        },
+        "required": ["new_base_branch"],
+        "additionalProperties": False,
+    },
+    "strict": True,
+}
+
+
+@handle_exceptions(default_return_value=None, raise_on_error=False)
+def reset_pr_branch_to_new_base(base_args: BaseArgs, new_base_branch: str, **_kwargs):
+    """Save PR file changes, change the base branch, reset to the new base, and rewrite files.
+    This avoids a diverged diff when the old and new base branches are siblings (e.g. release/20260408 → release/20260422).
+    """
+    owner = base_args["owner"]
+    repo = base_args["repo"]
+    pr_number = base_args["pr_number"]
+    token = base_args["token"]
+    clone_dir = base_args["clone_dir"]
+    clone_url = base_args["clone_url"]
+
+    # 1. Get the list of files changed in this PR
+    logger.info("Getting PR files for %s/%s#%d", owner, repo, pr_number)
+    pr_files = get_pull_request_files(
+        owner=owner, repo=repo, pr_number=pr_number, token=token
+    )
+    if not pr_files:
+        logger.warning("No PR files found, only changing base branch")
+
+    # 2. Save file contents from the current branch before reset
+    logger.info("Saving %d PR file contents before reset", len(pr_files))
+    saved_files, deleted_files = save_pr_files(clone_dir=clone_dir, pr_files=pr_files)
+
+    # 3. Change the base branch on GitHub (metadata only)
+    logger.info("Changing base branch to %s on GitHub", new_base_branch)
+    result = change_pr_base_branch(base_args=base_args, new_base_branch=new_base_branch)
+    if not result:
+        logger.error("Failed to change base branch to %s", new_base_branch)
+        return None
+
+    # 4. Reset local branch to the new base
+    logger.info("Fetching and resetting to %s", new_base_branch)
+    git_fetch(target_dir=clone_dir, clone_url=clone_url, branch=new_base_branch)
+    git_reset(target_dir=clone_dir)
+
+    # 5. Rewrite saved files onto the new base
+    logger.info("Reapplying files onto new base")
+    files_to_commit = reapply_files(
+        clone_dir=clone_dir, saved_files=saved_files, deleted_files=deleted_files
+    )
+    if not files_to_commit:
+        logger.info("No files to rewrite after reset")
+        return result
+
+    # 6. Commit per file and force push (first push forces because local history diverged from remote after reset)
+    base_args["base_branch"] = new_base_branch
+    status_map: dict[str, Status] = {f["filename"]: f["status"] for f in pr_files}
+    for i, file_path in enumerate(files_to_commit):
+        status = status_map[file_path]
+        if status == "removed":
+            verb = "Delete"
+        elif status == "added":
+            verb = "Add"
+        else:
+            verb = "Update"
+        logger.info(
+            "Committing %d/%d: %s %s", i + 1, len(files_to_commit), verb, file_path
+        )
+        git_commit_and_push(
+            base_args=base_args,
+            message=f"{verb} {file_path}",
+            files=[file_path],
+            force=i == 0,
+        )
+
+    logger.info("Reset %d files onto %s", len(files_to_commit), new_base_branch)
+    return f"{result}. Reset {len(files_to_commit)} files onto {new_base_branch}."

--- a/services/git/save_pr_files.py
+++ b/services/git/save_pr_files.py
@@ -1,0 +1,34 @@
+from typing import Sequence
+
+from services.github.pulls.get_pull_request_files import FileChange
+from utils.error.handle_exceptions import handle_exceptions
+from utils.files.read_local_file import read_local_file
+from utils.logging.logging_config import logger
+
+
+@handle_exceptions(default_return_value=({}, []), raise_on_error=False)
+def save_pr_files(clone_dir: str, pr_files: Sequence[FileChange]):
+    """Read PR file contents from clone_dir before a destructive operation like rebase.
+    Returns (saved_files dict, deleted_files list) where saved_files maps file_path -> content.
+    """
+    saved_files: dict[str, str] = {}
+    deleted_files: list[str] = []
+    for file_change in pr_files:
+        file_path = file_change["filename"]
+        if file_change["status"] == "removed":
+            deleted_files.append(file_path)
+            logger.info("Will delete after rebase: %s", file_path)
+            continue
+
+        content = read_local_file(file_path=file_path, base_dir=clone_dir)
+        if content is None:
+            logger.warning("Could not read file, skipping: %s", file_path)
+            continue
+        saved_files[file_path] = content
+
+    logger.info(
+        "Saved %d files and %d deletions from PR",
+        len(saved_files),
+        len(deleted_files),
+    )
+    return (saved_files, deleted_files)

--- a/services/git/test_git_commit_and_push.py
+++ b/services/git/test_git_commit_and_push.py
@@ -147,6 +147,45 @@ def test_git_commit_and_push_stages_specific_files():
         assert "new.py" in add_args_captured
 
 
+def test_git_commit_and_push_force_push():
+    push_args_captured = []
+
+    def mock_run(args, cwd):
+        nonlocal push_args_captured
+        if args[:2] == ["git", "push"]:
+            push_args_captured = args
+        return MagicMock(returncode=0, stdout="")
+
+    with patch("services.git.git_commit_and_push.run_subprocess", side_effect=mock_run):
+        result = git_commit_and_push(
+            base_args=_make_base_args(),
+            message="Rebase onto release/20260422",
+            files=["app.py"],
+            force=True,
+        )
+        assert result is True
+        assert "--force-with-lease" in push_args_captured
+
+
+def test_git_commit_and_push_no_force_by_default():
+    push_args_captured = []
+
+    def mock_run(args, cwd):
+        nonlocal push_args_captured
+        if args[:2] == ["git", "push"]:
+            push_args_captured = args
+        return MagicMock(returncode=0, stdout="")
+
+    with patch("services.git.git_commit_and_push.run_subprocess", side_effect=mock_run):
+        result = git_commit_and_push(
+            base_args=_make_base_args(),
+            message="Normal push",
+            files=["app.py"],
+        )
+        assert result is True
+        assert "--force-with-lease" not in push_args_captured
+
+
 @pytest.mark.integration
 def test_git_commit_and_push_to_local_bare(local_repo, create_test_base_args):
     """Sociable: clone local repo, create file, commit+push, verify in bare repo."""

--- a/services/git/test_reapply_files.py
+++ b/services/git/test_reapply_files.py
@@ -1,0 +1,58 @@
+# pylint: disable=use-implicit-booleaness-not-comparison
+import os
+import tempfile
+
+from services.git.reapply_files import reapply_files
+
+
+def test_reapply_files_writes_saved_content():
+    with tempfile.TemporaryDirectory() as clone_dir:
+        saved_files = {
+            "src/app.py": "print('hello')\n",
+            "README.md": "# Readme\n",
+        }
+        result = reapply_files(
+            clone_dir=clone_dir, saved_files=saved_files, deleted_files=[]
+        )
+        assert set(result) == {"src/app.py", "README.md"}
+        with open(os.path.join(clone_dir, "src/app.py"), "r", encoding="utf-8") as f:
+            assert f.read() == "print('hello')\n"
+        with open(os.path.join(clone_dir, "README.md"), "r", encoding="utf-8") as f:
+            assert f.read() == "# Readme\n"
+
+
+def test_reapply_files_deletes_files():
+    with tempfile.TemporaryDirectory() as clone_dir:
+        target = os.path.join(clone_dir, "old.py")
+        with open(target, "w", encoding="utf-8") as f:
+            f.write("delete me\n")
+
+        result = reapply_files(
+            clone_dir=clone_dir, saved_files={}, deleted_files=["old.py"]
+        )
+        assert result == ["old.py"]
+        assert not os.path.exists(target)
+
+
+def test_reapply_files_skip_delete_nonexistent():
+    with tempfile.TemporaryDirectory() as clone_dir:
+        result = reapply_files(
+            clone_dir=clone_dir, saved_files={}, deleted_files=["missing.py"]
+        )
+        assert result == []
+
+
+def test_reapply_files_creates_subdirectories():
+    with tempfile.TemporaryDirectory() as clone_dir:
+        saved_files = {"deep/nested/dir/file.py": "content\n"}
+        result = reapply_files(
+            clone_dir=clone_dir, saved_files=saved_files, deleted_files=[]
+        )
+        assert result == ["deep/nested/dir/file.py"]
+        assert os.path.exists(os.path.join(clone_dir, "deep/nested/dir/file.py"))
+
+
+def test_reapply_files_empty_input():
+    with tempfile.TemporaryDirectory() as clone_dir:
+        result = reapply_files(clone_dir=clone_dir, saved_files={}, deleted_files=[])
+        assert result == []

--- a/services/git/test_reset_pr_branch_to_new_base.py
+++ b/services/git/test_reset_pr_branch_to_new_base.py
@@ -1,0 +1,115 @@
+# pylint: disable=unused-argument
+# pyright: reportUnusedVariable=false
+from typing import cast
+from unittest.mock import patch
+
+from services.git.reset_pr_branch_to_new_base import reset_pr_branch_to_new_base
+from services.types.base_args import BaseArgs
+
+
+def _make_base_args():
+    return cast(
+        BaseArgs,
+        {
+            "owner": "test-owner",
+            "repo": "test-repo",
+            "pr_number": 123,
+            "token": "test-token",
+            "clone_dir": "/tmp/test-owner/test-repo/pr-123",
+            "clone_url": "https://x-access-token:token@github.com/test-owner/test-repo.git",
+            "base_branch": "release/20260408",
+            "new_branch": "gitauto/schedule-123",
+        },
+    )
+
+
+@patch("services.git.reset_pr_branch_to_new_base.git_commit_and_push")
+@patch(
+    "services.git.reset_pr_branch_to_new_base.reapply_files",
+    return_value=["src/app.py", "src/utils.py"],
+)
+@patch("services.git.reset_pr_branch_to_new_base.git_reset")
+@patch("services.git.reset_pr_branch_to_new_base.git_fetch")
+@patch(
+    "services.git.reset_pr_branch_to_new_base.change_pr_base_branch",
+    return_value="Changed base branch of PR #123 to 'release/20260422'",
+)
+@patch(
+    "services.git.reset_pr_branch_to_new_base.save_pr_files",
+    return_value=({"src/app.py": "code\n", "src/utils.py": "util\n"}, []),
+)
+@patch(
+    "services.git.reset_pr_branch_to_new_base.get_pull_request_files",
+    return_value=[
+        {"filename": "src/app.py", "status": "modified"},
+        {"filename": "src/utils.py", "status": "added"},
+    ],
+)
+def test_reset_pr_branch_commits_per_file(
+    mock_get_pr_files,
+    mock_save,
+    mock_change_base,
+    mock_fetch,
+    mock_reset,
+    mock_reapply,
+    mock_commit_push,
+):
+    result = reset_pr_branch_to_new_base(
+        base_args=_make_base_args(), new_base_branch="release/20260422"
+    )
+    assert result is not None
+    assert "Reset 2 files" in result
+    assert mock_commit_push.call_count == 2
+    # First commit gets force=True, second gets force=False
+    assert mock_commit_push.call_args_list[0].kwargs["force"] is True
+    assert mock_commit_push.call_args_list[1].kwargs["force"] is False
+    # Each commit has exactly one file
+    assert mock_commit_push.call_args_list[0].kwargs["files"] == ["src/app.py"]
+    assert mock_commit_push.call_args_list[1].kwargs["files"] == ["src/utils.py"]
+
+
+@patch("services.git.reset_pr_branch_to_new_base.git_commit_and_push")
+@patch("services.git.reset_pr_branch_to_new_base.reapply_files", return_value=[])
+@patch("services.git.reset_pr_branch_to_new_base.git_reset")
+@patch("services.git.reset_pr_branch_to_new_base.git_fetch")
+@patch(
+    "services.git.reset_pr_branch_to_new_base.change_pr_base_branch",
+    return_value="Changed base branch of PR #123 to 'main'",
+)
+@patch("services.git.reset_pr_branch_to_new_base.save_pr_files", return_value=({}, []))
+@patch(
+    "services.git.reset_pr_branch_to_new_base.get_pull_request_files", return_value=[]
+)
+def test_reset_pr_branch_no_files_skips_commit(
+    mock_get_pr_files,
+    mock_save,
+    mock_change_base,
+    mock_fetch,
+    mock_reset,
+    mock_reapply,
+    mock_commit_push,
+):
+    result = reset_pr_branch_to_new_base(
+        base_args=_make_base_args(), new_base_branch="main"
+    )
+    assert result is not None
+    assert "Changed base branch" in result
+    mock_commit_push.assert_not_called()
+
+
+@patch(
+    "services.git.reset_pr_branch_to_new_base.change_pr_base_branch", return_value=None
+)
+@patch("services.git.reset_pr_branch_to_new_base.save_pr_files", return_value=({}, []))
+@patch(
+    "services.git.reset_pr_branch_to_new_base.get_pull_request_files", return_value=[]
+)
+def test_reset_pr_branch_returns_none_on_api_failure(
+    mock_get_pr_files,
+    mock_save,
+    mock_change_base,
+):
+    result = reset_pr_branch_to_new_base(
+        base_args=_make_base_args(), new_base_branch="main"
+    )
+    assert result is None

--- a/services/git/test_save_pr_files.py
+++ b/services/git/test_save_pr_files.py
@@ -1,0 +1,54 @@
+# pylint: disable=use-implicit-booleaness-not-comparison
+import os
+import tempfile
+
+from services.github.pulls.get_pull_request_files import FileChange
+from services.git.save_pr_files import save_pr_files
+
+
+def test_save_pr_files_reads_existing_files():
+    with tempfile.TemporaryDirectory() as clone_dir:
+        os.makedirs(os.path.join(clone_dir, "src"), exist_ok=True)
+        with open(os.path.join(clone_dir, "src/app.py"), "w", encoding="utf-8") as f:
+            f.write("print('hello')\n")
+        with open(os.path.join(clone_dir, "README.md"), "w", encoding="utf-8") as f:
+            f.write("# Readme\n")
+
+        pr_files: list[FileChange] = [
+            {"filename": "src/app.py", "status": "modified"},
+            {"filename": "README.md", "status": "added"},
+        ]
+        saved, deleted = save_pr_files(clone_dir=clone_dir, pr_files=pr_files)
+        assert saved == {"src/app.py": "print('hello')\n", "README.md": "# Readme\n"}
+        assert deleted == []
+
+
+def test_save_pr_files_handles_removed_files():
+    with tempfile.TemporaryDirectory() as clone_dir:
+        with open(os.path.join(clone_dir, "keep.py"), "w", encoding="utf-8") as f:
+            f.write("keep\n")
+
+        pr_files: list[FileChange] = [
+            {"filename": "keep.py", "status": "modified"},
+            {"filename": "gone.py", "status": "removed"},
+        ]
+        saved, deleted = save_pr_files(clone_dir=clone_dir, pr_files=pr_files)
+        assert saved == {"keep.py": "keep\n"}
+        assert deleted == ["gone.py"]
+
+
+def test_save_pr_files_skips_missing_files():
+    with tempfile.TemporaryDirectory() as clone_dir:
+        pr_files: list[FileChange] = [
+            {"filename": "nonexistent.py", "status": "modified"},
+        ]
+        saved, deleted = save_pr_files(clone_dir=clone_dir, pr_files=pr_files)
+        assert saved == {}
+        assert deleted == []
+
+
+def test_save_pr_files_empty_input():
+    with tempfile.TemporaryDirectory() as clone_dir:
+        saved, deleted = save_pr_files(clone_dir=clone_dir, pr_files=[])
+        assert saved == {}
+        assert deleted == []

--- a/services/github/pulls/change_pr_base_branch.py
+++ b/services/github/pulls/change_pr_base_branch.py
@@ -1,32 +1,13 @@
 import requests
 
-from anthropic.types import ToolUnionParam
-
 from config import GITHUB_API_URL, TIMEOUT
 from services.github.utils.create_headers import create_headers
 from services.types.base_args import BaseArgs
 from utils.error.handle_exceptions import handle_exceptions
 
-CHANGE_PR_BASE_BRANCH: ToolUnionParam = {
-    "name": "change_pr_base_branch",
-    "description": "Changes the base branch of the current pull request. Use this when a reviewer requests the PR to target a different branch (e.g., from 'main' to 'develop').",
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "new_base_branch": {
-                "type": "string",
-                "description": "The name of the new base branch to target (e.g., 'develop', 'staging').",
-            },
-        },
-        "required": ["new_base_branch"],
-        "additionalProperties": False,
-    },
-    "strict": True,
-}
-
 
 @handle_exceptions(default_return_value=None, raise_on_error=False)
-def change_pr_base_branch(base_args: BaseArgs, new_base_branch: str, **_kwargs):
+def change_pr_base_branch(base_args: BaseArgs, new_base_branch: str):
     """A PR's base branch is GitHub metadata (not stored in git). There's no git command to change it - must use the GitHub API.
     https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#update-a-pull-request
     """


### PR DESCRIPTION
## Summary
- When a reviewer asks to retarget a PR to a sibling release branch (e.g. `release/20260408` → `release/20260422`), the old `change_pr_base_branch` only updated GitHub metadata, causing the PR diff to explode with hundreds of unrelated files because sibling branches share no direct ancestry.
- New `reset_pr_branch_to_new_base` tool orchestrates the full flow: save PR file contents → change base on GitHub → fetch and reset to new base → rewrite files → commit per file with correct verb (Add/Update/Delete) → force push first commit only.
- `change_pr_base_branch` stays as a single-op GitHub API call; `git_commit_and_push` gains a `force` parameter using `--force-with-lease`.

## GitAuto Post
Retargeting a PR to a sibling release branch used to blow up the diff with hundreds of unrelated files. Now we save, reset, and rewrite - clean diff every time.

## Wes Post
A customer asked us to change a PR's base from one release branch to another. Simple metadata change, right? The diff exploded to 300+ files because sibling branches don't share ancestry. Fix: save the actual changes, hard reset onto the new base, rewrite. One new tool, zero conflicts.