### PR TITLE
Add source tracking, sender logging, and multi-CI detection to setup handler

### DIFF
--- a/constants/ci.py
+++ b/constants/ci.py
@@ -1,0 +1,25 @@
+import os
+
+# GitAuto's own reference templates fed to Claude for generating coverage workflows
+GITAUTO_COVERAGE_WORKFLOW_TEMPLATES_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "services",
+    "github",
+    "workflows",
+    "templates",
+)
+
+GHA_WORKFLOW_DIR = ".github/workflows"
+
+# CI config files for non-GitHub-Actions systems (path, display name)
+CI_CONFIG_FILES = [
+    ("appveyor.yml", "AppVeyor"),
+    ("azure-pipelines.yml", "Azure Pipelines"),
+    ("bitbucket-pipelines.yml", "Bitbucket Pipelines"),
+    (".buildkite/pipeline.yml", "Buildkite"),
+    ("buildkite.yml", "Buildkite"),
+    (".circleci/config.yml", "CircleCI"),
+    (".gitlab-ci.yml", "GitLab CI"),
+    ("Jenkinsfile", "Jenkins"),
+    (".travis.yml", "Travis CI"),
+]

--- a/constants/system_messages/setup_handler.py
+++ b/constants/system_messages/setup_handler.py
@@ -2,7 +2,7 @@ SETUP_HANDLER_SYSTEM_MESSAGE = """You are a CI/CD setup assistant. Your job is t
 
 You will be given:
 1. The repository's root files (to understand its language/framework)
-2. Any existing GitHub Actions workflow files (to avoid duplicating what's already set up)
+2. Any existing CI configs (GitHub Actions, CircleCI, Jenkins, Travis CI, etc.)
 3. Reference workflow templates for common languages
 
 Your task:
@@ -31,7 +31,7 @@ Coverage is ONLY "already set up" if ALL THREE of the following exist in an exis
 2. A step that produces a coverage output file (e.g., lcov.info, coverage.xml, jacoco.xml)
 3. An artifact upload step that uploads the coverage report with artifact name "coverage-report"
 If ANY of these three are missing, coverage is NOT set up and you MUST create a workflow.
-NEVER claim a file exists unless you can see it in the "Existing workflows" dictionary provided to you.
+NEVER claim a file exists unless you can see it in the "Existing CI configs" dictionary provided to you.
 Only reference file names that appear as keys in that dictionary. Do NOT invent or hallucinate file names.
 
 Key workflow pattern (PR = test only, push = test + coverage):
@@ -40,8 +40,11 @@ Key workflow pattern (PR = test only, push = test + coverage):
 - Coverage artifact upload ONLY on push/workflow_dispatch events
 - The workflow MUST upload coverage/lcov.info as an artifact named "coverage-report"
 
+CRITICAL - Supported CI systems:
+GitAuto supports coverage artifact upload from GitHub Actions and CircleCI only.
+If the repo uses an unsupported CI system (Jenkins, Travis, Azure Pipelines, GitLab CI, etc.), you MUST create a full GitHub Actions workflow with both tests AND coverage. Read the existing CI config to understand what test commands and frameworks the repo uses, then replicate the test setup in the GitHub Actions workflow.
+
 IMPORTANT:
-- Do NOT create a workflow ONLY if the repo already has ALL THREE coverage requirements above met in existing workflows
 - The workflow file path must be .github/workflows/<name>.yml
 - If you cannot determine the language or appropriate test setup, do nothing
 - For multi-language repos, create one workflow per language that needs test + coverage

--- a/main.py
+++ b/main.py
@@ -212,6 +212,7 @@ async def setup_coverage_workflow(
     api_key: str = Header(..., alias="X-API-Key"),
     sender_id: int = Header(0, alias="X-Sender-Id"),
     sender_name: str = Header("", alias="X-Sender-Name"),
+    source: str = Header("", alias="X-Source"),
 ):
     verify_api_key(api_key)
     return await setup_handler(
@@ -220,4 +221,5 @@ async def setup_coverage_workflow(
         token=token,
         sender_id=sender_id,
         sender_name=sender_name,
+        source=source,
     )

--- a/services/webhook/handle_installation.py
+++ b/services/webhook/handle_installation.py
@@ -93,4 +93,5 @@ async def handle_installation_created(payload: InstallationPayload):
             token=token,
             sender_id=user_id,
             sender_name=sender_name,
+            source="installation",
         )

--- a/services/webhook/setup_handler.py
+++ b/services/webhook/setup_handler.py
@@ -1,7 +1,12 @@
 import os
-from anthropic.types import MessageParam
+from anthropic.types import MessageParam, TextBlockParam
 
 from constants.agent import MAX_ITERATIONS
+from constants.ci import (
+    CI_CONFIG_FILES,
+    GHA_WORKFLOW_DIR,
+    GITAUTO_COVERAGE_WORKFLOW_TEMPLATES_DIR,
+)
 from constants.claude import ClaudeModelId
 from constants.system_messages.setup_handler import (
     SETUP_HANDLER_SYSTEM_MESSAGE,
@@ -42,11 +47,6 @@ from utils.logging.logging_config import (
     set_trigger,
 )
 
-WORKFLOW_DIR = ".github/workflows"
-TEMPLATES_DIR = os.path.join(
-    os.path.dirname(__file__), os.pardir, "github", "workflows", "templates"
-)
-
 
 @handle_exceptions(default_return_value=None, raise_on_error=False)
 async def setup_handler(
@@ -55,18 +55,20 @@ async def setup_handler(
     token: str,
     sender_id: int,
     sender_name: str,
+    source: str,
 ):
     set_owner_repo(owner_name, repo_name)
     set_trigger("setup")
     logger.info(
-        "Setup triggered by sender_name=%s sender_id=%d for %s/%s",
+        "Setup triggered by sender_name=%s sender_id=%d source=%s for %s/%s",
         sender_name,
         sender_id,
+        source,
         owner_name,
         repo_name,
     )
     thread_ts = slack_notify(
-        f"Setup started for {owner_name}/{repo_name} by {sender_name} (id={sender_id})"
+        f"Setup started for {owner_name}/{repo_name} by {sender_name} from {source}"
     )
 
     installation = get_installation_by_owner(owner_name)
@@ -174,48 +176,64 @@ async def setup_handler(
         trigger="setup",
     )
 
-    # Read existing workflow files from local clone
-    workflow_files: dict[str, str] = {}
-    local_workflow_dir = os.path.join(clone_dir, WORKFLOW_DIR)
+    # Read all existing CI configs from local clone
+    ci_configs: dict[str, str] = {}
+
+    # GitHub Actions workflows (multiple .yml files in a directory)
+    local_workflow_dir = os.path.join(clone_dir, GHA_WORKFLOW_DIR)
     if os.path.isdir(local_workflow_dir):
         for filename in os.listdir(local_workflow_dir):
             if not filename.endswith(".yml"):
+                logger.info("Skipping non-YAML file: %s", filename)
                 continue
             content = read_local_file(file_path=filename, base_dir=local_workflow_dir)
             if content:
-                workflow_files[f"{WORKFLOW_DIR}/{filename}"] = (
+                ci_configs[f"{GHA_WORKFLOW_DIR}/{filename} (GitHub Actions)"] = (
                     format_content_with_line_numbers(
-                        file_path=f"{WORKFLOW_DIR}/{filename}", content=content
+                        file_path=f"{GHA_WORKFLOW_DIR}/{filename}", content=content
                     )
                 )
 
+    # Other CI systems (single config files each)
+    for config_path, ci_name in CI_CONFIG_FILES:
+        full_path = os.path.join(clone_dir, config_path)
+        if os.path.isfile(full_path):
+            content = read_local_file(file_path=config_path, base_dir=clone_dir)
+            if content:
+                ci_configs[f"{config_path} ({ci_name})"] = (
+                    format_content_with_line_numbers(
+                        file_path=config_path, content=content
+                    )
+                )
+
+    logger.info("Detected CI configs: %s", list(ci_configs.keys()))
+
     # One example template is enough - Claude knows how to write workflows for any language
-    raw_template = read_local_file(file_path="pytest.yml", base_dir=TEMPLATES_DIR) or ""
+    raw_template = (
+        read_local_file(
+            file_path="pytest.yml", base_dir=GITAUTO_COVERAGE_WORKFLOW_TEMPLATES_DIR
+        )
+        or ""
+    )
     example_template = (
         format_content_with_line_numbers(file_path="pytest.yml", content=raw_template)
         if raw_template
         else ""
     )
 
-    messages: list[MessageParam] = [
-        {
-            "role": "user",
-            "content": [
-                {"type": "text", "text": f"Root files: {root_files}"},
-                {"type": "text", "text": f"Target branch: {target_branch}"},
-                {"type": "text", "text": f"Existing workflows:\n{workflow_files}"},
-                {
-                    "type": "text",
-                    "text": f"Example template (pytest.yml):\n{example_template}",
-                },
-            ],
-        }
+    user_content: list[TextBlockParam] = [
+        {"type": "text", "text": f"Root files: {root_files}"},
+        {"type": "text", "text": f"Target branch: {target_branch}"},
+        {"type": "text", "text": f"Existing CI configs:\n{ci_configs}"},
+        {"type": "text", "text": f"Example template (pytest.yml):\n{example_template}"},
     ]
 
+    messages: list[MessageParam] = [{"role": "user", "content": user_content}]
+
     logger.info(
-        "Calling Claude for setup (root files: %d, existing workflows: %d)",
+        "Calling Claude for setup (root files: %d, CI configs: %d)",
         len(root_files),
-        len(workflow_files),
+        len(ci_configs),
     )
 
     total_token_input = 0
@@ -241,6 +259,7 @@ async def setup_handler(
         completion_reason = result.completion_reason
 
         if result.is_completed:
+            logger.info("Setup agent completed successfully")
             is_completed = True
             break
 
@@ -265,6 +284,7 @@ async def setup_handler(
     )
 
     if is_completed and pr_files:
+        logger.info("Setup PR has %d file changes", len(pr_files))
         slack_notify(
             f"Setup completed for {owner_name}/{repo_name}#{pr_number}\n{pr_url}",
             thread_ts=thread_ts,

--- a/services/webhook/test_setup_handler.py
+++ b/services/webhook/test_setup_handler.py
@@ -86,6 +86,7 @@ async def test_not_completed_closes_pr_and_deletes_branch(
         token="test-token",
         sender_id=123,
         sender_name="test-user",
+        source="test",
     )
 
     mock_clone_to_tmp.assert_called_once()
@@ -147,6 +148,7 @@ async def test_completed_keeps_pr(
         token="test-token",
         sender_id=123,
         sender_name="test-user",
+        source="test",
     )
 
     mock_create_pr.assert_called_once()
@@ -210,6 +212,7 @@ async def test_uses_target_branch_when_set(
         token="test-token",
         sender_id=123,
         sender_name="test-user",
+        source="test",
     )
 
     # Should use target_branch, not call get_default_branch
@@ -281,6 +284,7 @@ async def test_passes_existing_workflows_to_claude(
         token="test-token",
         sender_id=123,
         sender_name="test-user",
+        source="test",
     )
 
     call_kwargs = mock_agent.call_args.kwargs
@@ -345,6 +349,7 @@ async def test_clones_repo_to_tmp(
         token="test-token",
         sender_id=123,
         sender_name="test-user",
+        source="test",
     )
 
     mock_clone_to_tmp.assert_called_once_with(
@@ -364,6 +369,7 @@ async def test_no_installation_skips(mock_installation):
         token="test-token",
         sender_id=123,
         sender_name="test-user",
+        source="test",
     )
 
     mock_installation.assert_called_once()
@@ -380,6 +386,7 @@ async def test_empty_repo_skips(mock_installation, mock_repo, mock_default_branc
         token="test-token",
         sender_id=123,
         sender_name="test-user",
+        source="test",
     )
 
     mock_default_branch.assert_called_once()
@@ -438,6 +445,7 @@ async def test_system_message_mentions_coverage(
         token="test-token",
         sender_id=123,
         sender_name="test-user",
+        source="test",
     )
 
     call_kwargs = mock_agent.call_args.kwargs
@@ -498,6 +506,7 @@ async def test_sets_pr_number_in_base_args(
         token="test-token",
         sender_id=123,
         sender_name="test-user",
+        source="test",
     )
 
     call_kwargs = mock_agent.call_args.kwargs


### PR DESCRIPTION
## Summary

- Added `source` parameter to `setup_handler` to track which dashboard page triggered the setup (file-coverage, coverage-trends, triggers, or installation)
- Added sender identity logging (sender_name, sender_id, source) and Slack notification on setup start
- Extracted CI constants to `constants/ci.py` (`GHA_WORKFLOW_DIR`, `CI_CONFIG_FILES`, `GITAUTO_COVERAGE_WORKFLOW_TEMPLATES_DIR`)
- Added detection for non-GHA CI systems (CircleCI, Jenkins, Travis, Azure Pipelines, etc.) and passes all detected CI configs to Claude as a unified dict
- Updated system message to clarify GitAuto supports coverage upload from GitHub Actions and CircleCI only — unsupported CI systems get a full GHA workflow
- Added missing loggers at `continue`, `break`, and `if` branches in setup handler
- Added `X-Source` header to the API endpoint in `main.py` and `source="installation"` to `handle_installation.py`

### GitAuto Post
When a customer's setup PR created a redundant GitHub Actions workflow because we didn't detect their existing CircleCI config, we knew the CI detection needed work. Now the setup handler scans for 9 different CI systems and makes smarter decisions about what to create.

### Wes Post
Foxquilt uses CircleCI. Our setup handler only looked at .github/workflows/. So it created a jest.yml that duplicated what CircleCI already does. Fixed by scanning for all major CI systems and teaching the agent when to skip vs when to create.