### PR TITLE
Merge base into PR with smart deepen instead of --unshallow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,8 @@ When the user explicitly says "LGTM", execute this workflow:
       ```
 
     - **Body**: `# Title` heading, then: what happened, root cause, the fix, prevention. 300-600 words, use code blocks and bullet points.
+    - **Explain why the model couldn't solve it**: When the post involves a failure by Claude Opus or another model, include a section explaining WHY the model failed. People believe top models can solve anything - explain the specific gap (e.g., models reason about code not environments, models trust config files without verifying which one the runner reads, training data reinforces common patterns over rare config bugs). Position GitAuto's value as the application layer that fills what the model lacks, not as a replacement for the model.
+    - **Language-agnostic framing**: GitAuto is language-agnostic. When writing about a language-specific case (e.g., Jest/React), frame it as one example of a universal pattern and mention parallel examples in other languages (e.g., pytest/tox, JUnit/Maven, RSpec).
 13. **Create or update a documentation page** in `../website/app/docs/`:
     - **Create NEW page** if the fix introduces a new capability not covered by existing docs
     - **Update existing page** if improving documented capability

--- a/services/git/clone_repo_and_install_dependencies.py
+++ b/services/git/clone_repo_and_install_dependencies.py
@@ -19,7 +19,7 @@ def clone_repo_and_install_dependencies(
 ):
     clone_url = get_clone_url(owner, repo, token)
 
-    # Step 1: Clone base branch so it's available locally
+    # Step 1: Clone base branch (also sets git identity)
     git_clone_to_tmp(clone_dir, clone_url, base_branch)
 
     # Step 2: Fetch and checkout PR branch to work on

--- a/services/git/create_empty_commit.py
+++ b/services/git/create_empty_commit.py
@@ -1,3 +1,4 @@
+from services.git.set_git_identity import set_git_identity
 from services.types.base_args import BaseArgs
 from utils.command.run_subprocess import run_subprocess
 from utils.error.handle_exceptions import handle_exceptions
@@ -11,6 +12,9 @@ def create_empty_commit(
     clone_url = base_args["clone_url"]
     branch = base_args["new_branch"]
     clone_dir = base_args["clone_dir"]
+
+    # Ensure git identity is set (may not be if clone path didn't go through git_clone_to_tmp)
+    set_git_identity(clone_dir)
 
     # --no-verify skips pre-commit hooks (e.g. lint-staged) that fail in Lambda sandbox because npm can't mkdir /home/sbx_user1051
     run_subprocess(

--- a/services/git/create_empty_commit.py
+++ b/services/git/create_empty_commit.py
@@ -1,4 +1,3 @@
-from services.git.set_git_identity import set_git_identity
 from services.types.base_args import BaseArgs
 from utils.command.run_subprocess import run_subprocess
 from utils.error.handle_exceptions import handle_exceptions
@@ -12,9 +11,6 @@ def create_empty_commit(
     clone_url = base_args["clone_url"]
     branch = base_args["new_branch"]
     clone_dir = base_args["clone_dir"]
-
-    # Ensure git identity is set (may not be if clone path didn't go through git_clone_to_tmp)
-    set_git_identity(clone_dir)
 
     # --no-verify skips pre-commit hooks (e.g. lint-staged) that fail in Lambda sandbox because npm can't mkdir /home/sbx_user1051
     run_subprocess(

--- a/services/git/create_empty_commit.py
+++ b/services/git/create_empty_commit.py
@@ -1,8 +1,3 @@
-import os
-import shutil
-import tempfile
-
-from config import GITHUB_APP_GIT_EMAIL, GITHUB_APP_USER_NAME
 from services.types.base_args import BaseArgs
 from utils.command.run_subprocess import run_subprocess
 from utils.error.handle_exceptions import handle_exceptions
@@ -17,42 +12,13 @@ def create_empty_commit(
     branch = base_args["new_branch"]
     clone_dir = base_args["clone_dir"]
 
-    # If clone_dir exists and is a git repo, use it directly
-    if clone_dir and os.path.isdir(os.path.join(clone_dir, ".git")):
-        cwd = clone_dir
-        tmp_dir = None
-    else:
-        # Temp shallow clone for callers without a local clone
-        tmp_dir = tempfile.mkdtemp(prefix="gitauto-empty-commit-")
-        run_subprocess(
-            args=[
-                "git",
-                "clone",
-                "--depth",
-                "1",
-                "--branch",
-                branch,
-                clone_url,
-                tmp_dir,
-            ],
-            cwd="/tmp",
-        )
-        cwd = tmp_dir
-
-    try:
-        run_subprocess(["git", "config", "user.name", GITHUB_APP_USER_NAME], cwd)
-        run_subprocess(["git", "config", "user.email", GITHUB_APP_GIT_EMAIL], cwd)
-
-        # --no-verify skips pre-commit hooks (e.g. lint-staged) that fail in Lambda sandbox because npm can't mkdir /home/sbx_user1051
-        run_subprocess(
-            args=["git", "commit", "--allow-empty", "--no-verify", "-m", message],
-            cwd=cwd,
-        )
-        run_subprocess(
-            args=["git", "push", clone_url, f"HEAD:refs/heads/{branch}"],
-            cwd=cwd,
-        )
-        return True
-    finally:
-        if tmp_dir:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
+    # --no-verify skips pre-commit hooks (e.g. lint-staged) that fail in Lambda sandbox because npm can't mkdir /home/sbx_user1051
+    run_subprocess(
+        args=["git", "commit", "--allow-empty", "--no-verify", "-m", message],
+        cwd=clone_dir,
+    )
+    run_subprocess(
+        args=["git", "push", clone_url, f"HEAD:refs/heads/{branch}"],
+        cwd=clone_dir,
+    )
+    return True

--- a/services/git/git_clone_to_tmp.py
+++ b/services/git/git_clone_to_tmp.py
@@ -1,5 +1,6 @@
 import os
 
+from services.git.set_git_identity import set_git_identity
 from utils.command.run_subprocess import run_subprocess
 from utils.error.handle_exceptions import handle_exceptions
 from utils.logging.logging_config import logger
@@ -26,6 +27,7 @@ def git_clone_to_tmp(clone_dir: str, clone_url: str, branch: str):
         # -f: discard local changes, -B: create or reset branch to FETCH_HEAD
         # FETCH_HEAD: ref written by git fetch pointing to the fetched commit (more reliable than origin/branch in shallow clones)
         run_subprocess(["git", "checkout", "-f", "-B", branch, "FETCH_HEAD"], clone_dir)
+        set_git_identity(clone_dir)
         logger.info("Updated clone: %s @ %s", clone_dir, branch)
         return clone_dir
 
@@ -39,5 +41,6 @@ def git_clone_to_tmp(clone_dir: str, clone_url: str, branch: str):
         ["git", "clone", "--depth", "1", "-b", branch, clone_url, clone_dir],
         clone_dir,
     )
+    set_git_identity(clone_dir)
     logger.info("Clone completed: %s @ %s", clone_dir, branch)
     return clone_dir

--- a/services/git/git_commit_and_push.py
+++ b/services/git/git_commit_and_push.py
@@ -1,4 +1,3 @@
-from config import GITHUB_APP_GIT_EMAIL, GITHUB_APP_USER_NAME
 from services.git.format_commit_message import format_commit_message
 from services.types.base_args import BaseArgs
 from utils.command.run_subprocess import run_subprocess
@@ -17,10 +16,6 @@ def git_commit_and_push(
     clone_url = base_args["clone_url"]
     new_branch = base_args["new_branch"]
     skip_ci = base_args.get("skip_ci", False)
-
-    # Set GitAuto's git identity for commit attribution
-    run_subprocess(["git", "config", "user.name", GITHUB_APP_USER_NAME], clone_dir)
-    run_subprocess(["git", "config", "user.email", GITHUB_APP_GIT_EMAIL], clone_dir)
 
     # Stage specified files (handles new, modified, and deleted files)
     run_subprocess(["git", "add"] + files, clone_dir)

--- a/services/git/git_merge_base_into_pr.py
+++ b/services/git/git_merge_base_into_pr.py
@@ -1,0 +1,75 @@
+from utils.command.run_subprocess import run_subprocess
+from utils.error.handle_exceptions import handle_exceptions
+from utils.logging.logging_config import logger
+
+
+@handle_exceptions(default_return_value=False, raise_on_error=False)
+def git_merge_base_into_pr(clone_dir: str, base_branch: str, behind_by: int):
+    # Shallow clones (--depth 1) lack a common ancestor, so git merge fails.
+    # --unshallow fetches full history but is too slow for large repos (e.g. 61K commits = 137s).
+    # Instead, --deepen N fetches only N more commits from the shallow boundary.
+    if behind_by > 0:
+        # behind_by from GitHub Compare API: e.g. PR is 50 commits behind main → deepen 60
+        depth = behind_by + 10
+        logger.info("Deepening by %d (behind_by=%d + buffer)", depth, behind_by)
+        run_subprocess(
+            ["git", "fetch", "--deepen", str(depth), "origin", base_branch], clone_dir
+        )
+    else:
+        # API failed (returned default 0) — exponential deepen: 100 → 500 → 2500 → 12500
+        logger.info("behind_by=0, using exponential deepen fallback")
+        depth = 100
+        while depth <= 12500:
+            logger.info("Deepening by %d", depth)
+            run_subprocess(
+                ["git", "fetch", "--deepen", str(depth), "origin", base_branch],
+                clone_dir,
+            )
+            try:
+                run_subprocess(
+                    ["git", "merge-base", "HEAD", f"origin/{base_branch}"], clone_dir
+                )
+                logger.info("Merge base found at deepen=%d", depth)
+                break
+            except ValueError:
+                logger.info("Merge base not found at deepen=%d", depth)
+                depth *= 5
+        else:
+            # Cumulative depth after loop: 100+500+2500+12500 = 15600 commits wasn't enough
+            logger.warning("Exponential deepen exhausted, falling back to --unshallow")
+            run_subprocess(
+                ["git", "fetch", "--unshallow", "origin", base_branch], clone_dir
+            )
+
+    # Merge base branch into PR branch
+    try:
+        logger.info("Merging origin/%s into PR branch", base_branch)
+        run_subprocess(
+            ["git", "merge", f"origin/{base_branch}", "--no-edit"], clone_dir
+        )
+        logger.info("Clean merge of %s into PR branch", base_branch)
+    except ValueError:
+        # Merge conflict — markers are in working tree, git is in "merging" state.
+        # Commit the markers so git returns to a clean state.
+        # The agent can then fix conflict markers file-by-file with its normal tools.
+        logger.warning(
+            "Merge conflict merging %s into PR branch, committing markers", base_branch
+        )
+        # Get only the conflicted files (auto-merged files are already staged by git)
+        logger.info("Getting conflicted files")
+        result = run_subprocess(
+            ["git", "diff", "--name-only", "--diff-filter=U"], clone_dir
+        )
+        conflicted_files = result.stdout.strip().splitlines()
+        logger.info("Conflicted files: %s", conflicted_files)
+        for f in conflicted_files:
+            logger.info("Staging conflicted file: %s", f)
+            run_subprocess(["git", "add", f], clone_dir)
+        logger.info("Committing conflict markers")
+        run_subprocess(
+            ["git", "commit", "--no-edit", "-m", f"Merge {base_branch} (conflicts)"],
+            clone_dir,
+        )
+
+    logger.info("git_merge_base_into_pr completed: %s", clone_dir)
+    return True

--- a/services/git/initialize_repo.py
+++ b/services/git/initialize_repo.py
@@ -2,11 +2,7 @@
 import os
 
 # Local imports
-from config import (
-    GITHUB_APP_GIT_EMAIL,
-    GITHUB_APP_USER_NAME,
-    UTF8,
-)
+from config import UTF8
 from constants.general import PRODUCT_NAME
 from constants.urls import (
     BLOG_URL,
@@ -16,8 +12,7 @@ from constants.urls import (
     PRODUCT_URL,
     PRODUCT_YOUTUBE_URL,
 )
-
-# Local imports (Utils)
+from services.git.set_git_identity import set_git_identity
 from utils.command.run_subprocess import run_subprocess
 from utils.error.handle_exceptions import handle_exceptions
 from utils.logging.logging_config import logger
@@ -36,8 +31,8 @@ def initialize_repo(repo_path: str, remote_url: str, token: str) -> None:
         f.write(readme_content)
 
     run_subprocess(["git", "init", "-b", "main"], repo_path)
-    run_subprocess(["git", "config", "user.name", GITHUB_APP_USER_NAME], repo_path)
-    run_subprocess(["git", "config", "user.email", GITHUB_APP_GIT_EMAIL], repo_path)
+    # Needed here because initialize_repo creates a fresh repo, not via clone_repo_and_install_dependencies
+    set_git_identity(repo_path)
     run_subprocess(["git", "add", "README.md"], repo_path)
     run_subprocess(["git", "commit", "-m", "Initial commit with README"], repo_path)
 

--- a/services/git/set_git_identity.py
+++ b/services/git/set_git_identity.py
@@ -1,0 +1,10 @@
+from config import GITHUB_APP_GIT_EMAIL, GITHUB_APP_USER_NAME
+from utils.command.run_subprocess import run_subprocess
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=None, raise_on_error=False)
+def set_git_identity(cwd: str):
+    # Set GitAuto's git identity for commit attribution
+    run_subprocess(["git", "config", "user.name", GITHUB_APP_USER_NAME], cwd)
+    run_subprocess(["git", "config", "user.email", GITHUB_APP_GIT_EMAIL], cwd)

--- a/services/git/test_create_empty_commit.py
+++ b/services/git/test_create_empty_commit.py
@@ -28,7 +28,7 @@ def test_create_empty_commit_with_clone_dir(base_args_with_clone):
         clone_dir = "/tmp/test-owner/test-repo/pr-123"
         clone_url = "https://x-access-token:token@github.com/test-owner/test-repo.git"
         calls = mock_subprocess.call_args_list
-        # First call is git commit (identity is set via set_git_identity, not run_subprocess)
+        # First call is git commit (identity is set by git_clone_to_tmp before this function)
         assert calls[0] == call(
             args=[
                 "git",

--- a/services/git/test_create_empty_commit.py
+++ b/services/git/test_create_empty_commit.py
@@ -20,31 +20,16 @@ def base_args_with_clone(create_test_base_args):
     )
 
 
-@pytest.fixture
-def base_args_without_clone(create_test_base_args):
-    return create_test_base_args(
-        clone_url="https://x-access-token:token@github.com/test-owner/test-repo.git",
-        new_branch="feature-branch",
-        clone_dir="",
-    )
-
-
 def test_create_empty_commit_with_clone_dir(base_args_with_clone):
-    with patch(
-        "services.git.create_empty_commit.run_subprocess"
-    ) as mock_subprocess, patch(
-        "services.git.create_empty_commit.os.path.isdir", return_value=True
-    ) as _mock_isdir:  # noqa: F841
+    with patch("services.git.create_empty_commit.run_subprocess") as mock_subprocess:
         result = create_empty_commit(base_args_with_clone)
 
         assert result is True
         clone_dir = "/tmp/test-owner/test-repo/pr-123"
         clone_url = "https://x-access-token:token@github.com/test-owner/test-repo.git"
         calls = mock_subprocess.call_args_list
-        # First two calls are git config (user.name, user.email)
-        assert calls[0][0][0][:3] == ["git", "config", "user.name"]
-        assert calls[1][0][0][:3] == ["git", "config", "user.email"]
-        assert calls[2] == call(
+        # First call is git commit (identity is set via set_git_identity, not run_subprocess)
+        assert calls[0] == call(
             args=[
                 "git",
                 "commit",
@@ -55,68 +40,28 @@ def test_create_empty_commit_with_clone_dir(base_args_with_clone):
             ],
             cwd=clone_dir,
         )
-        assert calls[3] == call(
+        assert calls[1] == call(
             args=["git", "push", clone_url, "HEAD:refs/heads/feature-branch"],
             cwd=clone_dir,
         )
-
-
-def test_create_empty_commit_without_clone_dir(base_args_without_clone):
-    with patch(
-        "services.git.create_empty_commit.run_subprocess"
-    ) as mock_subprocess, patch(
-        "services.git.create_empty_commit.tempfile.mkdtemp",
-        return_value="/tmp/gitauto-tmp",
-    ) as _mock_mkdtemp, patch(  # noqa: F841
-        "services.git.create_empty_commit.shutil.rmtree"
-    ) as mock_rmtree:
-        result = create_empty_commit(base_args_without_clone)
-
-        assert result is True
-        # First call: clone
-        assert mock_subprocess.call_args_list[0] == call(
-            args=[
-                "git",
-                "clone",
-                "--depth",
-                "1",
-                "--branch",
-                "feature-branch",
-                "https://x-access-token:token@github.com/test-owner/test-repo.git",
-                "/tmp/gitauto-tmp",
-            ],
-            cwd="/tmp",
-        )
-        # Cleanup temp dir
-        mock_rmtree.assert_called_once_with("/tmp/gitauto-tmp", ignore_errors=True)
 
 
 def test_create_empty_commit_skips_pre_commit_hooks(base_args_with_clone):
     """Reproduces production failure: repos with pre-commit hooks (e.g. lint-staged)
     fail in Lambda because npm can't mkdir in /home/sbx_user1051. --no-verify skips hooks.
     """
-    with patch(
-        "services.git.create_empty_commit.run_subprocess"
-    ) as mock_subprocess, patch(
-        "services.git.create_empty_commit.os.path.isdir", return_value=True
-    ) as _mock_isdir:  # noqa: F841
+    with patch("services.git.create_empty_commit.run_subprocess") as mock_subprocess:
         create_empty_commit(base_args_with_clone)
 
-        commit_call = mock_subprocess.call_args_list[2]
+        commit_call = mock_subprocess.call_args_list[0]
         assert "--no-verify" in commit_call[1]["args"]
         assert "--allow-empty" in commit_call[1]["args"]
 
 
 def test_create_empty_commit_failure(base_args_with_clone):
-    with patch(
-        "services.git.create_empty_commit.run_subprocess"
-    ) as mock_subprocess, patch(
-        "services.git.create_empty_commit.os.path.isdir", return_value=True
-    ) as _mock_isdir:  # noqa: F841
-        # Config succeeds, commit fails
+    with patch("services.git.create_empty_commit.run_subprocess") as mock_subprocess:
+        # Commit fails
         mock_subprocess.side_effect = [
-            None,
-            None,
             ValueError("commit failed"),
         ]
 
@@ -126,14 +71,10 @@ def test_create_empty_commit_failure(base_args_with_clone):
 
 
 def test_create_empty_commit_custom_message(base_args_with_clone):
-    with patch(
-        "services.git.create_empty_commit.run_subprocess"
-    ) as mock_subprocess, patch(
-        "services.git.create_empty_commit.os.path.isdir", return_value=True
-    ) as _mock_isdir:  # noqa: F841
+    with patch("services.git.create_empty_commit.run_subprocess") as mock_subprocess:
         create_empty_commit(base_args_with_clone, message="Custom message")
 
-        commit_call = mock_subprocess.call_args_list[2]
+        commit_call = mock_subprocess.call_args_list[0]
         assert commit_call == call(
             args=[
                 "git",
@@ -145,30 +86,6 @@ def test_create_empty_commit_custom_message(base_args_with_clone):
             ],
             cwd="/tmp/test-owner/test-repo/pr-123",
         )
-
-
-def test_create_empty_commit_temp_clone_cleanup_on_failure(base_args_without_clone):
-    with patch(
-        "services.git.create_empty_commit.run_subprocess"
-    ) as mock_subprocess, patch(
-        "services.git.create_empty_commit.tempfile.mkdtemp",
-        return_value="/tmp/gitauto-tmp",
-    ) as _mock_mkdtemp, patch(  # noqa: F841
-        "services.git.create_empty_commit.shutil.rmtree"
-    ) as mock_rmtree:
-        # Clone succeeds, config succeeds, commit fails
-        mock_subprocess.side_effect = [
-            None,
-            None,
-            None,
-            ValueError("commit failed"),
-        ]
-
-        result = create_empty_commit(base_args_without_clone)
-
-        assert result is False
-        # Temp dir should still be cleaned up
-        mock_rmtree.assert_called_once_with("/tmp/gitauto-tmp", ignore_errors=True)
 
 
 # --- Integration tests (real git, local bare repo) ---
@@ -208,24 +125,6 @@ def test_integration_create_empty_commit_with_clone(local_repo, create_test_base
         text=True,
     )
     assert log_result.stdout.strip() == "Integration test empty commit"
-
-
-@pytest.mark.integration
-def test_integration_create_empty_commit_without_clone(
-    local_repo, create_test_base_args
-):
-    bare_url, work_dir = local_repo
-    sha_before = _get_sha(work_dir, "main")
-
-    base_args = create_test_base_args(
-        clone_url=bare_url, new_branch="main", clone_dir=""
-    )
-    result = create_empty_commit(base_args, message="Temp clone test")
-    assert result is True
-
-    subprocess.run(["git", "pull"], cwd=work_dir, check=True, capture_output=True)
-    sha_after = _get_sha(work_dir, "main")
-    assert sha_after != sha_before
 
 
 @pytest.mark.integration

--- a/services/git/test_create_empty_commit.py
+++ b/services/git/test_create_empty_commit.py
@@ -143,6 +143,19 @@ def test_integration_empty_commit_on_shallow_clone_with_new_branch(
         check=True,
         capture_output=True,
     )
+    # git_clone_to_tmp sets identity after clone; CI runners have no global git config
+    subprocess.run(
+        ["git", "config", "user.name", "test"],
+        cwd=shallow_dir,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=shallow_dir,
+        check=True,
+        capture_output=True,
+    )
 
     # 2. Push a new commit to bare repo (simulates Foxquilt pushing code)
     subprocess.run(

--- a/services/git/test_git_clone_to_tmp.py
+++ b/services/git/test_git_clone_to_tmp.py
@@ -12,8 +12,9 @@ from services.git.git_clone_to_tmp import git_clone_to_tmp
 class TestGitCloneToTmpUnit:
     """Unit tests with mocked run_subprocess."""
 
+    @patch("services.git.git_clone_to_tmp.set_git_identity")
     @patch("services.git.git_clone_to_tmp.run_subprocess")
-    def test_fresh_clone(self, mock_run):
+    def test_fresh_clone(self, mock_run, _mock_identity):
         """Fresh clone when .git does not exist."""
         with tempfile.TemporaryDirectory() as clone_dir:
             result = git_clone_to_tmp(clone_dir, "https://github.com/o/r.git", "main")
@@ -33,8 +34,9 @@ class TestGitCloneToTmpUnit:
                 clone_dir,
             )
 
+    @patch("services.git.git_clone_to_tmp.set_git_identity")
     @patch("services.git.git_clone_to_tmp.run_subprocess")
-    def test_existing_clone_updates(self, mock_run):
+    def test_existing_clone_updates(self, mock_run, _mock_identity):
         """When .git exists, fetch + checkout instead of clone."""
         with tempfile.TemporaryDirectory() as clone_dir:
             os.makedirs(os.path.join(clone_dir, ".git"))
@@ -60,8 +62,9 @@ class TestGitCloneToTmpUnit:
                 in calls
             )
 
+    @patch("services.git.git_clone_to_tmp.set_git_identity")
     @patch("services.git.git_clone_to_tmp.run_subprocess")
-    def test_existing_clone_adds_origin_when_missing(self, mock_run):
+    def test_existing_clone_adds_origin_when_missing(self, mock_run, _mock_identity):
         """When origin remote is missing, add it instead of set-url."""
         with tempfile.TemporaryDirectory() as clone_dir:
             os.makedirs(os.path.join(clone_dir, ".git"))
@@ -84,8 +87,11 @@ class TestGitCloneToTmpUnit:
                 in mock_run.call_args_list
             )
 
+    @patch("services.git.git_clone_to_tmp.set_git_identity")
     @patch("services.git.git_clone_to_tmp.run_subprocess")
-    def test_creates_parent_dirs(self, mock_run):  # pylint: disable=unused-argument
+    def test_creates_parent_dirs(
+        self, mock_run, _mock_identity
+    ):  # pylint: disable=unused-argument
         """makedirs is called for fresh clone when parent doesn't exist."""
         with tempfile.TemporaryDirectory() as base:
             clone_dir = os.path.join(base, "owner", "repo")

--- a/services/git/test_git_commit_and_push.py
+++ b/services/git/test_git_commit_and_push.py
@@ -60,8 +60,8 @@ def test_git_commit_and_push_add_fails():
     def mock_run(args, cwd):
         nonlocal call_count
         call_count += 1
-        # First two calls are git config (user.name, user.email), third is git add
-        if call_count == 3:
+        # First call is git add (identity is set upstream in clone_repo_and_install_dependencies)
+        if call_count == 1:
             raise ValueError("Command failed: fatal: pathspec 'bad.py' did not match")
         return MagicMock(returncode=0, stdout="")
 

--- a/services/git/test_git_merge_base_into_pr.py
+++ b/services/git/test_git_merge_base_into_pr.py
@@ -116,6 +116,9 @@ def _simulate_production_clone(clone_url: str, base_branch: str, pr_branch: str)
         check=True,
         capture_output=True,
     )
+    # git_clone_to_tmp sets identity after clone
+    run(["git", "config", "user.name", "test"])
+    run(["git", "config", "user.email", "test@test.com"])
     # Step 2: Fetch PR branch (matches git_fetch)
     run(["git", "fetch", "--depth", "1", clone_url, pr_branch])
     # Step 3: Checkout PR branch (matches git_checkout)

--- a/services/git/test_git_merge_base_into_pr.py
+++ b/services/git/test_git_merge_base_into_pr.py
@@ -1,0 +1,256 @@
+# pyright: reportUnusedVariable=false
+import os
+import shutil
+import subprocess
+import tempfile
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from services.git.git_merge_base_into_pr import git_merge_base_into_pr
+
+
+# ---------------------------------------------------------------------------
+# Solitary tests (mocked run_subprocess)
+# ---------------------------------------------------------------------------
+
+
+@patch("services.git.git_merge_base_into_pr.run_subprocess")
+def test_clean_merge_with_api_count(mock_run):
+    result = git_merge_base_into_pr(
+        clone_dir="/tmp/repo", base_branch="main", behind_by=50
+    )
+
+    assert result is True
+    # Should deepen by behind_by + buffer (50 + 10 = 60)
+    mock_run.assert_any_call(
+        ["git", "fetch", "--deepen", "60", "origin", "main"], "/tmp/repo"
+    )
+    mock_run.assert_any_call(["git", "merge", "origin/main", "--no-edit"], "/tmp/repo")
+    # On clean merge, git diff --diff-filter=U should NOT be called
+    for c in mock_run.call_args_list:
+        assert c != call(["git", "diff", "--name-only", "--diff-filter=U"], "/tmp/repo")
+
+
+@patch("services.git.git_merge_base_into_pr.run_subprocess")
+def test_clean_merge_with_exponential_fallback(mock_run):
+    result = git_merge_base_into_pr(
+        clone_dir="/tmp/repo", base_branch="main", behind_by=0
+    )
+
+    assert result is True
+    # Should try exponential deepen (first step = 100), then merge-base succeeds
+    mock_run.assert_any_call(
+        ["git", "fetch", "--deepen", "100", "origin", "main"], "/tmp/repo"
+    )
+    mock_run.assert_any_call(["git", "merge-base", "HEAD", "origin/main"], "/tmp/repo")
+
+
+@patch("services.git.git_merge_base_into_pr.run_subprocess")
+def test_conflict_merge_commits_markers(mock_run):
+    mock_diff_result = MagicMock()
+    mock_diff_result.stdout = "shared.txt\nother.txt\n"
+
+    def side_effect(args, _cwd):
+        if args[:2] == ["git", "merge"]:
+            raise ValueError("merge conflict")
+        if args[:2] == ["git", "diff"]:
+            return mock_diff_result
+        return MagicMock()
+
+    mock_run.side_effect = side_effect
+
+    result = git_merge_base_into_pr(
+        clone_dir="/tmp/repo", base_branch="main", behind_by=50
+    )
+
+    assert result is True
+    # After conflict, should get conflicted files and add them individually
+    mock_run.assert_any_call(
+        ["git", "diff", "--name-only", "--diff-filter=U"], "/tmp/repo"
+    )
+    mock_run.assert_any_call(["git", "add", "shared.txt"], "/tmp/repo")
+    mock_run.assert_any_call(["git", "add", "other.txt"], "/tmp/repo")
+    mock_run.assert_any_call(
+        ["git", "commit", "--no-edit", "-m", "Merge main (conflicts)"], "/tmp/repo"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (real git operations)
+# ---------------------------------------------------------------------------
+
+
+def _setup_repo_with_initial_commit(bare_dir: str, work_dir: str):
+    """Initialize a bare repo, clone it, and create an initial commit on main."""
+
+    def run(args, cwd):
+        subprocess.run(args, cwd=cwd, check=True, capture_output=True)
+
+    run(["git", "init", "--bare", bare_dir], bare_dir)
+    run(["git", "symbolic-ref", "HEAD", "refs/heads/main"], bare_dir)
+    run(["git", "clone", bare_dir, work_dir], work_dir)
+    run(["git", "config", "user.name", "test"], work_dir)
+    run(["git", "config", "user.email", "test@test.com"], work_dir)
+
+    with open(os.path.join(work_dir, "README.md"), "w", encoding="utf-8") as f:
+        f.write("# Test\n")
+    run(["git", "add", "."], work_dir)
+    run(["git", "commit", "-m", "Initial commit"], work_dir)
+    run(["git", "branch", "-M", "main"], work_dir)
+    run(["git", "push", "-u", "origin", "main"], work_dir)
+
+
+def _simulate_production_clone(clone_url: str, base_branch: str, pr_branch: str):
+    """Simulate clone_repo_and_install_dependencies steps 1-3:
+    clone base branch (shallow), fetch PR branch, checkout PR branch.
+    Returns the clone directory path."""
+    clone_dir = tempfile.mkdtemp(prefix="gitauto-clone-")
+
+    def run(args):
+        subprocess.run(args, cwd=clone_dir, check=True, capture_output=True)
+
+    # Step 1: Shallow clone of base branch (matches git_clone_to_tmp)
+    subprocess.run(
+        ["git", "clone", "--depth", "1", "-b", base_branch, clone_url, clone_dir],
+        check=True,
+        capture_output=True,
+    )
+    # Step 2: Fetch PR branch (matches git_fetch)
+    run(["git", "fetch", "--depth", "1", clone_url, pr_branch])
+    # Step 3: Checkout PR branch (matches git_checkout)
+    run(["git", "checkout", "-f", "-B", pr_branch, "FETCH_HEAD"])
+
+    return clone_dir
+
+
+@pytest.fixture
+def conflict_repo():
+    """Bare repo with conflicting changes on main and feature branches."""
+    bare_dir = tempfile.mkdtemp(prefix="gitauto-merge-bare-")
+    work_dir = tempfile.mkdtemp(prefix="gitauto-merge-work-")
+
+    def run(args, cwd):
+        subprocess.run(args, cwd=cwd, check=True, capture_output=True)
+
+    _setup_repo_with_initial_commit(bare_dir, work_dir)
+
+    # Create a shared file on main
+    shared_file = os.path.join(work_dir, "shared.txt")
+    with open(shared_file, "w", encoding="utf-8") as f:
+        f.write("line 1\nline 2\nline 3\n")
+    run(["git", "add", "."], work_dir)
+    run(["git", "commit", "-m", "Add shared file"], work_dir)
+    run(["git", "push", "origin", "main"], work_dir)
+
+    # Create feature branch and modify shared.txt
+    run(["git", "checkout", "-b", "feature"], work_dir)
+    with open(shared_file, "w", encoding="utf-8") as f:
+        f.write("line 1\nfeature change\nline 3\n")
+    run(["git", "add", "."], work_dir)
+    run(["git", "commit", "-m", "Feature change"], work_dir)
+    run(["git", "push", "-u", "origin", "feature"], work_dir)
+
+    # Go back to main and make a conflicting change on the same line
+    run(["git", "checkout", "main"], work_dir)
+    with open(shared_file, "w", encoding="utf-8") as f:
+        f.write("line 1\nmain change\nline 3\n")
+    run(["git", "add", "."], work_dir)
+    run(["git", "commit", "-m", "Main conflicting change"], work_dir)
+    run(["git", "push", "origin", "main"], work_dir)
+
+    yield f"file://{bare_dir}", work_dir
+
+    shutil.rmtree(bare_dir, ignore_errors=True)
+    shutil.rmtree(work_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def clean_merge_repo():
+    """Bare repo where main and feature have non-conflicting changes."""
+    bare_dir = tempfile.mkdtemp(prefix="gitauto-clean-bare-")
+    work_dir = tempfile.mkdtemp(prefix="gitauto-clean-work-")
+
+    def run(args, cwd):
+        subprocess.run(args, cwd=cwd, check=True, capture_output=True)
+
+    _setup_repo_with_initial_commit(bare_dir, work_dir)
+
+    # Feature branch: add a new file (no conflict with main)
+    run(["git", "checkout", "-b", "feature"], work_dir)
+    with open(os.path.join(work_dir, "feature.txt"), "w", encoding="utf-8") as f:
+        f.write("feature content\n")
+    run(["git", "add", "."], work_dir)
+    run(["git", "commit", "-m", "Add feature file"], work_dir)
+    run(["git", "push", "-u", "origin", "feature"], work_dir)
+
+    # Main: add a different file (no conflict with feature)
+    run(["git", "checkout", "main"], work_dir)
+    with open(os.path.join(work_dir, "main_only.txt"), "w", encoding="utf-8") as f:
+        f.write("main content\n")
+    run(["git", "add", "."], work_dir)
+    run(["git", "commit", "-m", "Add main-only file"], work_dir)
+    run(["git", "push", "origin", "main"], work_dir)
+
+    yield f"file://{bare_dir}", work_dir
+
+    shutil.rmtree(bare_dir, ignore_errors=True)
+    shutil.rmtree(work_dir, ignore_errors=True)
+
+
+@pytest.mark.integration
+def test_integration_conflict_merge(conflict_repo):
+    """Clone base, fetch+checkout PR, merge base - verify conflict markers appear."""
+    clone_url, _ = conflict_repo
+    clone_dir = _simulate_production_clone(clone_url, "main", "feature")
+
+    try:
+        # behind_by=0 triggers exponential deepen fallback (no GitHub API in local tests)
+        git_merge_base_into_pr(clone_dir=clone_dir, base_branch="main", behind_by=0)
+
+        # Verify conflict markers are in shared.txt (committed, not in working tree)
+        shared_path = os.path.join(clone_dir, "shared.txt")
+        with open(shared_path, encoding="utf-8") as f:
+            content = f.read()
+
+        assert "<<<<<<<" in content
+        assert ">>>>>>>" in content
+
+        # Verify git is in a clean state (no merge in progress)
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=clone_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.stdout.strip() == ""
+    finally:
+        shutil.rmtree(clone_dir, ignore_errors=True)
+
+
+@pytest.mark.integration
+def test_integration_clean_merge(clean_merge_repo):
+    """Clone base, fetch+checkout PR, merge base - verify clean merge."""
+    clone_url, _ = clean_merge_repo
+    clone_dir = _simulate_production_clone(clone_url, "main", "feature")
+
+    try:
+        # behind_by=0 triggers exponential deepen fallback (no GitHub API in local tests)
+        git_merge_base_into_pr(clone_dir=clone_dir, base_branch="main", behind_by=0)
+
+        # After clean merge, feature.txt and main_only.txt should both exist
+        assert os.path.isfile(os.path.join(clone_dir, "feature.txt"))
+        assert os.path.isfile(os.path.join(clone_dir, "main_only.txt"))
+
+        # Verify git is clean
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=clone_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.stdout.strip() == ""
+    finally:
+        shutil.rmtree(clone_dir, ignore_errors=True)

--- a/services/git/test_initialize_repo.py
+++ b/services/git/test_initialize_repo.py
@@ -19,8 +19,6 @@ class TestInitializeRepo:
         """Mock configuration constants."""
         with patch.multiple(
             "services.git.initialize_repo",
-            GITHUB_APP_GIT_EMAIL="161652217+gitauto-ai[bot]@users.noreply.github.com",
-            GITHUB_APP_USER_NAME="gitauto-ai[bot]",
             PRODUCT_NAME="GitAuto",
             UTF8="utf-8",
         ):
@@ -90,18 +88,9 @@ class TestInitializeRepo:
             assert "https://www.youtube.com/watch?v=demo" in written_content
 
             # Verify git commands were executed in correct order
+            # (identity is set via set_git_identity, not run_subprocess)
             expected_calls = [
                 call(["git", "init", "-b", "main"], test_repo_path),
-                call(["git", "config", "user.name", "gitauto-ai[bot]"], test_repo_path),
-                call(
-                    [
-                        "git",
-                        "config",
-                        "user.email",
-                        "161652217+gitauto-ai[bot]@users.noreply.github.com",
-                    ],
-                    test_repo_path,
-                ),  # GITHUB_APP_GIT_EMAIL
                 call(["git", "add", "README.md"], test_repo_path),
                 call(
                     ["git", "commit", "-m", "Initial commit with README"],
@@ -268,7 +257,7 @@ class TestInitializeRepo:
                 "- [GitAuto YouTube](https://youtube.com/@gitauto)" in written_content
             )
 
-    def test_initialize_repo_git_config_commands(
+    def test_initialize_repo_sets_git_identity(
         self,
         mock_config_constants,
         mock_url_constants,
@@ -276,30 +265,16 @@ class TestInitializeRepo:
         test_remote_url,
         test_token,
     ):
-        """Test that git config commands use correct user information."""
+        """Test that set_git_identity is called with the repo path."""
         with patch("os.path.exists", return_value=True), patch(
             "builtins.open", mock_open()
-        ), patch("services.git.initialize_repo.run_subprocess") as mock_run_subprocess:
+        ), patch("services.git.initialize_repo.run_subprocess"), patch(
+            "services.git.initialize_repo.set_git_identity"
+        ) as mock_identity:
 
             initialize_repo(test_repo_path, test_remote_url, test_token)
 
-            # Verify git config commands
-            config_name_call = call(
-                ["git", "config", "user.name", "gitauto-ai[bot]"],
-                test_repo_path,
-            )
-            config_email_call = call(
-                [
-                    "git",
-                    "config",
-                    "user.email",
-                    "161652217+gitauto-ai[bot]@users.noreply.github.com",
-                ],
-                test_repo_path,
-            )
-
-            assert config_name_call in mock_run_subprocess.call_args_list
-            assert config_email_call in mock_run_subprocess.call_args_list
+            mock_identity.assert_called_once_with(test_repo_path)
 
     @pytest.mark.parametrize(
         "remote_url,expected_auth_url",

--- a/services/github/commits/get_head_commit_count_behind_base.py
+++ b/services/github/commits/get_head_commit_count_behind_base.py
@@ -1,0 +1,21 @@
+import requests
+
+from config import GITHUB_API_URL, TIMEOUT
+from services.github.utils.create_headers import create_headers
+from utils.error.handle_exceptions import handle_exceptions
+from utils.logging.logging_config import logger
+
+
+@handle_exceptions(default_return_value=0, raise_on_error=False)
+def get_head_commit_count_behind_base(
+    owner: str, repo: str, base: str, head: str, token: str
+):
+    """https://docs.github.com/en/rest/commits/commits#compare-two-commits
+    Returns how many commits head is behind base."""
+    url = f"{GITHUB_API_URL}/repos/{owner}/{repo}/compare/{base}...{head}"
+    headers = create_headers(token=token)
+    response = requests.get(url=url, headers=headers, timeout=TIMEOUT)
+    response.raise_for_status()
+    behind_by: int = response.json()["behind_by"]
+    logger.info("%s is %d commits behind %s", head, behind_by, base)
+    return behind_by

--- a/services/github/types/webhook/review_run_payload.py
+++ b/services/github/types/webhook/review_run_payload.py
@@ -2,7 +2,7 @@ from typing import Literal, NotRequired, TypedDict
 
 from services.github.types.installation import Installation
 from services.github.types.organization import Organization
-from services.github.types.pull_request import PullRequest
+from services.github.types.webhook_pull_request import WebhookPullRequest
 from services.github.types.repository import Repository
 from services.github.types.user import User
 
@@ -27,6 +27,6 @@ class ReviewRunPayload(TypedDict):
     comment: ReviewRunComment
     installation: Installation
     organization: NotRequired[Organization]  # Personal repos don't have this key
-    pull_request: PullRequest
+    pull_request: WebhookPullRequest
     repository: Repository
     sender: User

--- a/services/github/types/webhook_pull_request.py
+++ b/services/github/types/webhook_pull_request.py
@@ -1,0 +1,48 @@
+from typing import Optional, TypedDict
+
+from services.github.types.label import Label
+from services.github.types.ref import Ref
+from services.github.types.user import User
+
+
+class WebhookPullRequest(TypedDict):
+    """PR object from webhook payloads (e.g. pull_request_review_comment). Missing REST API-only
+    fields like mergeable_state, merged, mergeable, commits, additions, deletions, changed_files.
+    """
+
+    url: str
+    id: int
+    node_id: str
+    number: int
+    head: Ref
+    base: Ref
+    html_url: str
+    diff_url: str
+    patch_url: str
+    issue_url: str
+    state: str
+    locked: bool
+    title: str
+    user: User
+    body: str | None
+    created_at: str
+    updated_at: str
+    closed_at: Optional[str]
+    merged_at: Optional[str]
+    merge_commit_sha: Optional[str]
+    assignee: Optional[User]
+    assignees: list[User]
+    requested_reviewers: list[User]
+    requested_teams: list[dict]
+    labels: list[Label]
+    milestone: Optional[dict]
+    draft: bool
+    commits_url: str
+    review_comments_url: str
+    review_comment_url: str
+    comments_url: str
+    statuses_url: str
+    _links: dict
+    author_association: str
+    auto_merge: Optional[dict]
+    active_lock_reason: Optional[str]

--- a/services/webhook/check_suite_handler.py
+++ b/services/webhook/check_suite_handler.py
@@ -26,6 +26,10 @@ from services.git.get_clone_url import get_clone_url
 from services.git.clone_repo_and_install_dependencies import (
     clone_repo_and_install_dependencies,
 )
+from services.git.git_merge_base_into_pr import git_merge_base_into_pr
+from services.github.commits.get_head_commit_count_behind_base import (
+    get_head_commit_count_behind_base,
+)
 from services.github.check_suites.get_failed_check_runs import (
     get_failed_check_runs_from_check_suite,
 )
@@ -38,6 +42,9 @@ from services.github.installations.get_installation_permissions import (
 from services.github.pulls.get_pull_request import get_pull_request
 from services.github.pulls.get_pull_request_commits import get_pull_request_commits
 from services.github.pulls.get_pull_request_files import get_pull_request_files
+from services.github.pulls.update_pr_body_with_section import (
+    update_pr_body_with_section,
+)
 from services.github.token.get_installation_token import get_installation_access_token
 from services.github.types.github_types import CheckSuiteCompletedPayload
 from services.github.users.get_email_from_commits import get_email_from_commits
@@ -258,6 +265,23 @@ async def handle_check_suite(
         token=token,
         clone_dir=clone_dir,
     )
+
+    # Merge base branch into PR only when GitHub detects conflicts
+    mergeable_state = full_pr.get("mergeable_state")
+    if mergeable_state == "dirty":
+        logger.info("Merging base branch, mergeable_state=%s", mergeable_state)
+        behind_by = get_head_commit_count_behind_base(
+            owner=owner_name,
+            repo=repo_name,
+            base=base_branch,
+            head=head_branch,
+            token=token,
+        )
+        git_merge_base_into_pr(
+            clone_dir=clone_dir, base_branch=base_branch, behind_by=behind_by
+        )
+    else:
+        logger.info("Skipping merge, mergeable_state=%s", mergeable_state)
 
     # Install dependencies (read repo files from clone_dir, cache on S3)
     node_ready = ensure_node_packages(
@@ -781,6 +805,20 @@ async def handle_check_suite(
         else:
             final_msg = f"I tried to fix `{check_run_name}` but verification still shows errors. Please review the changes."
         update_comment(body=final_msg, base_args=base_args)
+
+        # Update PR body with CI fix status
+        if is_completed:
+            fix_content = f"## CI Fix: `{check_run_name}`\nFixed the failing CI check and created an empty commit to re-trigger."
+        else:
+            fix_content = f"## CI Fix: `{check_run_name}`\nAttempted to fix but verification still shows errors. Please review."
+        update_pr_body_with_section(
+            owner=owner_name,
+            repo=repo_name,
+            pr_number=pr_number,
+            token=token,
+            marker="GITAUTO_FAILURE_FIX",
+            content=fix_content,
+        )
 
     # Update usage record
     end_time = time.time()

--- a/services/webhook/check_suite_handler.py
+++ b/services/webhook/check_suite_handler.py
@@ -42,9 +42,6 @@ from services.github.installations.get_installation_permissions import (
 from services.github.pulls.get_pull_request import get_pull_request
 from services.github.pulls.get_pull_request_commits import get_pull_request_commits
 from services.github.pulls.get_pull_request_files import get_pull_request_files
-from services.github.pulls.update_pr_body_with_section import (
-    update_pr_body_with_section,
-)
 from services.github.token.get_installation_token import get_installation_access_token
 from services.github.types.github_types import CheckSuiteCompletedPayload
 from services.github.users.get_email_from_commits import get_email_from_commits
@@ -805,20 +802,6 @@ async def handle_check_suite(
         else:
             final_msg = f"I tried to fix `{check_run_name}` but verification still shows errors. Please review the changes."
         update_comment(body=final_msg, base_args=base_args)
-
-        # Update PR body with CI fix status
-        if is_completed:
-            fix_content = f"## CI Fix: `{check_run_name}`\nFixed the failing CI check and created an empty commit to re-trigger."
-        else:
-            fix_content = f"## CI Fix: `{check_run_name}`\nAttempted to fix but verification still shows errors. Please review."
-        update_pr_body_with_section(
-            owner=owner_name,
-            repo=repo_name,
-            pr_number=pr_number,
-            token=token,
-            marker="GITAUTO_FAILURE_FIX",
-            content=fix_content,
-        )
 
     # Update usage record
     end_time = time.time()

--- a/services/webhook/review_run_handler.py
+++ b/services/webhook/review_run_handler.py
@@ -35,9 +35,6 @@ from services.git.create_empty_commit import create_empty_commit
 from services.git.get_reference import get_reference
 from services.github.pulls.get_pull_request import get_pull_request
 from services.github.pulls.get_pull_request_files import get_pull_request_files
-from services.github.pulls.update_pr_body_with_section import (
-    update_pr_body_with_section,
-)
 from services.github.pulls.get_review_summary import get_review_summary
 from services.github.pulls.get_review_thread_comments import get_review_thread_comments
 from services.github.token.get_installation_token import get_installation_access_token
@@ -509,20 +506,6 @@ async def handle_review_run(
         reply_to_comment(base_args=base_args, body=completion_reason)
     else:
         update_comment(body=completion_reason, base_args=base_args)
-
-    # Update PR body with review response
-    review_target = (
-        f"`{review_path}:{review_line}`" if review_path else "general comment"
-    )
-    review_content = f"## Review Response: {review_target}\n{completion_reason}"
-    update_pr_body_with_section(
-        owner=owner_name,
-        repo=repo_name,
-        pr_number=pr_number,
-        token=token,
-        marker="GITAUTO_REVIEW_FIX",
-        content=review_content,
-    )
 
     # Update usage record
     end_time = time.time()

--- a/services/webhook/review_run_handler.py
+++ b/services/webhook/review_run_handler.py
@@ -23,13 +23,21 @@ from services.git.get_clone_url import get_clone_url
 from services.git.clone_repo_and_install_dependencies import (
     clone_repo_and_install_dependencies,
 )
+from services.git.git_merge_base_into_pr import git_merge_base_into_pr
 from services.github.comments.create_comment import create_comment
+from services.github.commits.get_head_commit_count_behind_base import (
+    get_head_commit_count_behind_base,
+)
 from services.github.comments.reply_to_comment import reply_to_comment
 from services.github.comments.update_comment import update_comment
 from services.slack.slack_notify import slack_notify
 from services.git.create_empty_commit import create_empty_commit
 from services.git.get_reference import get_reference
+from services.github.pulls.get_pull_request import get_pull_request
 from services.github.pulls.get_pull_request_files import get_pull_request_files
+from services.github.pulls.update_pr_body_with_section import (
+    update_pr_body_with_section,
+)
 from services.github.pulls.get_review_summary import get_review_summary
 from services.github.pulls.get_review_thread_comments import get_review_thread_comments
 from services.github.token.get_installation_token import get_installation_access_token
@@ -239,6 +247,26 @@ async def handle_review_run(
         token=token,
         clone_dir=clone_dir,
     )
+
+    # Webhook payload doesn't include mergeable_state, so fetch the full PR from REST API
+    full_pr = get_pull_request(
+        owner=owner_name, repo=repo_name, pr_number=pr_number, token=token
+    )
+    mergeable_state = full_pr.get("mergeable_state") if full_pr else None
+    if mergeable_state == "dirty":
+        logger.info("Merging base branch, mergeable_state=%s", mergeable_state)
+        behind_by = get_head_commit_count_behind_base(
+            owner=owner_name,
+            repo=repo_name,
+            base=base_branch,
+            head=head_branch,
+            token=token,
+        )
+        git_merge_base_into_pr(
+            clone_dir=clone_dir, base_branch=base_branch, behind_by=behind_by
+        )
+    else:
+        logger.info("Skipping merge, mergeable_state=%s", mergeable_state)
 
     # Install dependencies (read repo files from clone_dir, cache on S3)
     node_ready = ensure_node_packages(
@@ -481,6 +509,20 @@ async def handle_review_run(
         reply_to_comment(base_args=base_args, body=completion_reason)
     else:
         update_comment(body=completion_reason, base_args=base_args)
+
+    # Update PR body with review response
+    review_target = (
+        f"`{review_path}:{review_line}`" if review_path else "general comment"
+    )
+    review_content = f"## Review Response: {review_target}\n{completion_reason}"
+    update_pr_body_with_section(
+        owner=owner_name,
+        repo=repo_name,
+        pr_number=pr_number,
+        token=token,
+        marker="GITAUTO_REVIEW_FIX",
+        content=review_content,
+    )
 
     # Update usage record
     end_time = time.time()

--- a/services/webhook/schedule_handler.py
+++ b/services/webhook/schedule_handler.py
@@ -20,8 +20,8 @@ from schemas.supabase.types import Coverages, CoveragesInsert
 from services.claude.evaluate_condition import evaluate_condition
 from services.claude.evaluate_quality_checks import evaluate_quality_checks
 from services.aws.delete_scheduler import delete_scheduler
-from services.git.git_clone_to_tmp import git_clone_to_tmp
 from services.git.create_empty_commit import create_empty_commit
+from services.git.git_clone_to_tmp import git_clone_to_tmp
 from services.git.create_remote_branch import create_remote_branch
 from services.git.git_checkout import git_checkout
 from services.git.git_fetch import git_fetch

--- a/services/webhook/test_check_suite_handler.py
+++ b/services/webhook/test_check_suite_handler.py
@@ -167,9 +167,16 @@ async def test_handle_check_suite_skips_when_trigger_disabled(
 @patch("services.webhook.check_suite_handler.create_comment")
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 async def test_handle_check_suite_skips_when_comment_exists(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     mock_create_comment,
@@ -239,9 +246,16 @@ async def test_handle_check_suite_skips_when_comment_exists(
 @patch("services.webhook.check_suite_handler.verify_task_is_complete")
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 async def test_handle_check_suite_race_condition_prevention(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     _mock_verify_task,
@@ -356,9 +370,16 @@ async def test_handle_check_suite_race_condition_prevention(
 @patch("services.webhook.check_suite_handler.update_usage")
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 async def test_handle_check_suite_full_workflow(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     _mock_update_usage,
@@ -477,9 +498,16 @@ async def test_handle_check_suite_full_workflow(
 @patch("services.webhook.check_suite_handler.get_installation_permissions")
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 async def test_handle_check_suite_with_404_logs(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     mock_get_permissions,
@@ -567,9 +595,16 @@ async def test_handle_check_suite_with_404_logs(
 @patch("services.webhook.check_suite_handler.update_comment")
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 async def test_handle_check_suite_with_none_logs(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     mock_update_comment,
@@ -655,9 +690,16 @@ async def test_handle_check_suite_with_none_logs(
 @patch("services.webhook.check_suite_handler.clean_logs")
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 async def test_handle_check_suite_with_existing_retry_pair(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     mock_clean_logs,
@@ -761,9 +803,16 @@ async def test_handle_check_suite_with_existing_retry_pair(
 @patch("services.webhook.check_suite_handler.update_usage")
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 async def test_handle_check_suite_with_closed_pr(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     _mock_update_usage,
@@ -857,9 +906,16 @@ async def test_handle_check_suite_with_closed_pr(
 @patch("services.webhook.check_suite_handler.update_usage")
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 async def test_handle_check_suite_with_deleted_branch(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     _mock_update_usage,
@@ -954,9 +1010,16 @@ async def test_handle_check_suite_with_deleted_branch(
 @patch("services.webhook.check_suite_handler.update_usage")
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 async def test_check_run_handler_token_accumulation(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     mock_update_usage,
@@ -1071,9 +1134,16 @@ async def test_check_run_handler_token_accumulation(
 @patch("services.webhook.check_suite_handler.should_bail", return_value=False)
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 async def test_handle_check_suite_skips_duplicate_older_request(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     _mock_should_bail,
@@ -1189,9 +1259,16 @@ async def test_handle_check_suite_skips_duplicate_older_request(
 @patch("services.webhook.check_suite_handler.get_codecov_commit_coverage")
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 async def test_handle_check_suite_codecov_failure(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     mock_get_codecov_coverage,
@@ -1316,9 +1393,16 @@ async def test_handle_check_suite_codecov_failure(
 @patch("services.webhook.check_suite_handler.get_codecov_token")
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 async def test_handle_check_suite_codecov_no_token(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     mock_get_codecov_token,
@@ -1428,10 +1512,17 @@ async def test_handle_check_suite_codecov_no_token(
 @patch("services.webhook.check_suite_handler.update_usage")
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 @patch("services.webhook.check_suite_handler.MAX_ITERATIONS", 2)
 async def test_handle_check_suite_max_iterations_forces_verification(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     _mock_update_usage,
@@ -1538,9 +1629,16 @@ async def test_handle_check_suite_max_iterations_forces_verification(
 @patch("services.webhook.check_suite_handler.update_usage")
 @patch("services.webhook.check_suite_handler.ensure_node_packages")
 @patch("services.webhook.check_suite_handler.ensure_php_packages")
+@patch(
+    "services.webhook.check_suite_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.check_suite_handler.git_merge_base_into_pr")
 @patch("services.webhook.check_suite_handler.clone_repo_and_install_dependencies")
 async def test_handle_check_suite_skips_same_error_hash_across_workflow_ids(
     _mock_prepare_repo,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_ensure_php,
     _mock_start_async,
     mock_update_usage,

--- a/services/webhook/test_review_run_handler.py
+++ b/services/webhook/test_review_run_handler.py
@@ -1,8 +1,5 @@
 # pylint: disable=unused-argument
-"""Integration tests for review_run_handler.py"""
-
 # pyright: reportUnusedVariable=false
-
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -63,6 +60,7 @@ def mock_review_comment_payload():
     }
 
 
+@patch("services.webhook.review_run_handler.get_pull_request")
 @patch("services.webhook.review_run_handler.slack_notify")
 @patch("services.webhook.review_run_handler.get_local_file_tree", return_value=[])
 @patch("services.webhook.review_run_handler.set_npm_token_env")
@@ -82,6 +80,11 @@ def mock_review_comment_payload():
 @patch("services.webhook.review_run_handler.update_usage")
 @patch("services.webhook.review_run_handler.ensure_node_packages")
 @patch("services.webhook.review_run_handler.clone_repo_and_install_dependencies")
+@patch(
+    "services.webhook.review_run_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.review_run_handler.git_merge_base_into_pr")
 @patch("services.webhook.review_run_handler.ensure_php_packages")
 @patch(
     "services.webhook.review_run_handler.verify_task_is_ready", new_callable=AsyncMock
@@ -91,6 +94,8 @@ def mock_review_comment_payload():
 async def test_review_run_handler_accumulates_tokens_correctly(
     _mock_verify_task_is_ready,
     _mock_ensure_php,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_prepare_repo,
     _mock_ensure_node_packages,
     mock_update_usage,
@@ -110,6 +115,7 @@ async def test_review_run_handler_accumulates_tokens_correctly(
     _mock_set_npm_token_env,
     _mock_get_local_file_tree,
     _mock_slack_notify,
+    _mock_get_pull_request,
     mock_review_comment_payload,
 ):
     """Test that review run handler accumulates tokens from multiple chat_with_agent calls."""
@@ -185,11 +191,10 @@ async def test_review_run_handler_accumulates_tokens_correctly(
     # Verify other expected parameters
     assert "total_seconds" in usage_call_kwargs
     assert usage_call_kwargs["pr_number"] == 123
-
-    # Verify get_repository was called with owner_id and repo_id
     mock_get_repo.assert_called_with(owner_id=11111, repo_id=98765)
 
 
+@patch("services.webhook.review_run_handler.get_pull_request")
 @patch("services.webhook.review_run_handler.slack_notify")
 @patch("services.webhook.review_run_handler.get_local_file_tree", return_value=[])
 @patch("services.webhook.review_run_handler.set_npm_token_env")
@@ -210,6 +215,11 @@ async def test_review_run_handler_accumulates_tokens_correctly(
 @patch("services.webhook.review_run_handler.update_usage")
 @patch("services.webhook.review_run_handler.ensure_node_packages")
 @patch("services.webhook.review_run_handler.clone_repo_and_install_dependencies")
+@patch(
+    "services.webhook.review_run_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.review_run_handler.git_merge_base_into_pr")
 @patch("services.webhook.review_run_handler.ensure_php_packages")
 @patch(
     "services.webhook.review_run_handler.verify_task_is_ready", new_callable=AsyncMock
@@ -220,6 +230,8 @@ async def test_review_run_handler_accumulates_tokens_correctly(
 async def test_review_run_handler_max_iterations_forces_verification(
     _mock_verify_task_is_ready,
     _mock_ensure_php,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_prepare_repo,
     _mock_ensure_node_packages,
     _mock_update_usage,
@@ -240,6 +252,7 @@ async def test_review_run_handler_max_iterations_forces_verification(
     _mock_set_npm_token_env,
     _mock_get_local_file_tree,
     _mock_slack_notify,
+    _mock_get_pull_request,
     mock_review_comment_payload,
 ):
     """Test that review run handler forces verify_task_is_complete when MAX_ITERATIONS is reached."""
@@ -347,6 +360,7 @@ def mock_bot_review_comment_payload():
     }
 
 
+@patch("services.webhook.review_run_handler.get_pull_request")
 @patch("services.webhook.review_run_handler.slack_notify")
 @patch("services.webhook.review_run_handler.get_local_file_tree", return_value=[])
 @patch("services.webhook.review_run_handler.set_npm_token_env")
@@ -366,6 +380,11 @@ def mock_bot_review_comment_payload():
 @patch("services.webhook.review_run_handler.update_usage")
 @patch("services.webhook.review_run_handler.ensure_node_packages")
 @patch("services.webhook.review_run_handler.clone_repo_and_install_dependencies")
+@patch(
+    "services.webhook.review_run_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.review_run_handler.git_merge_base_into_pr")
 @patch("services.webhook.review_run_handler.ensure_php_packages")
 @patch(
     "services.webhook.review_run_handler.verify_task_is_ready", new_callable=AsyncMock
@@ -375,6 +394,8 @@ def mock_bot_review_comment_payload():
 async def test_thread_resolved_during_loop_stops_agent(
     _mock_verify_task_is_ready,
     _mock_ensure_php,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_prepare_repo,
     _mock_ensure_node,
     _mock_update_usage,
@@ -394,6 +415,7 @@ async def test_thread_resolved_during_loop_stops_agent(
     _mock_set_npm_token_env,
     _mock_get_local_file_tree,
     _mock_slack_notify,
+    _mock_get_pull_request,
     mock_review_comment_payload,
 ):
     """Thread resolved while agent is working should stop the loop before chat_with_agent."""
@@ -429,6 +451,7 @@ async def test_thread_resolved_during_loop_stops_agent(
     mock_chat_with_agent.assert_not_called()
 
 
+@patch("services.webhook.review_run_handler.get_pull_request")
 @patch("services.webhook.review_run_handler.slack_notify")
 @patch("services.webhook.review_run_handler.get_local_file_tree", return_value=[])
 @patch("services.webhook.review_run_handler.set_npm_token_env")
@@ -448,6 +471,11 @@ async def test_thread_resolved_during_loop_stops_agent(
 @patch("services.webhook.review_run_handler.update_usage")
 @patch("services.webhook.review_run_handler.ensure_node_packages")
 @patch("services.webhook.review_run_handler.clone_repo_and_install_dependencies")
+@patch(
+    "services.webhook.review_run_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.review_run_handler.git_merge_base_into_pr")
 @patch("services.webhook.review_run_handler.ensure_php_packages")
 @patch(
     "services.webhook.review_run_handler.verify_task_is_ready", new_callable=AsyncMock
@@ -457,6 +485,8 @@ async def test_thread_resolved_during_loop_stops_agent(
 async def test_bot_first_review_comment_is_processed(
     _mock_verify_task_is_ready,
     _mock_ensure_php,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_prepare_repo,
     _mock_ensure_node,
     _mock_update_usage,
@@ -476,6 +506,7 @@ async def test_bot_first_review_comment_is_processed(
     _mock_set_npm_token_env,
     _mock_get_local_file_tree,
     _mock_slack_notify,
+    _mock_get_pull_request,
     mock_bot_review_comment_payload,
 ):
     """Bot's first review comment (no GitAuto reply in thread yet) should be processed."""
@@ -604,6 +635,7 @@ async def test_bot_reply_after_gitauto_replied_is_skipped(
     mock_chat_with_agent.assert_not_called()
 
 
+@patch("services.webhook.review_run_handler.get_pull_request")
 @patch("services.webhook.review_run_handler.slack_notify")
 @patch("services.webhook.review_run_handler.get_local_file_tree", return_value=[])
 @patch("services.webhook.review_run_handler.set_npm_token_env")
@@ -623,6 +655,11 @@ async def test_bot_reply_after_gitauto_replied_is_skipped(
 @patch("services.webhook.review_run_handler.update_usage")
 @patch("services.webhook.review_run_handler.ensure_node_packages")
 @patch("services.webhook.review_run_handler.clone_repo_and_install_dependencies")
+@patch(
+    "services.webhook.review_run_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.review_run_handler.git_merge_base_into_pr")
 @patch("services.webhook.review_run_handler.ensure_php_packages")
 @patch(
     "services.webhook.review_run_handler.verify_task_is_ready", new_callable=AsyncMock
@@ -632,6 +669,8 @@ async def test_bot_reply_after_gitauto_replied_is_skipped(
 async def test_human_review_comment_always_processed(
     _mock_verify_task_is_ready,
     _mock_ensure_php,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_prepare_repo,
     _mock_ensure_node,
     _mock_update_usage,
@@ -651,6 +690,7 @@ async def test_human_review_comment_always_processed(
     _mock_set_npm_token_env,
     _mock_get_local_file_tree,
     _mock_slack_notify,
+    _mock_get_pull_request,
     mock_review_comment_payload,
 ):
     """Human review comment should always be processed, even if GitAuto already replied."""
@@ -752,6 +792,7 @@ def mock_pr_comment_payload():
     }
 
 
+@patch("services.webhook.review_run_handler.get_pull_request")
 @patch("services.webhook.review_run_handler.slack_notify")
 @patch("services.webhook.review_run_handler.get_local_file_tree", return_value=[])
 @patch("services.webhook.review_run_handler.set_npm_token_env")
@@ -772,6 +813,11 @@ def mock_pr_comment_payload():
 @patch("services.webhook.review_run_handler.update_usage")
 @patch("services.webhook.review_run_handler.ensure_node_packages")
 @patch("services.webhook.review_run_handler.clone_repo_and_install_dependencies")
+@patch(
+    "services.webhook.review_run_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.review_run_handler.git_merge_base_into_pr")
 @patch("services.webhook.review_run_handler.ensure_php_packages")
 @patch(
     "services.webhook.review_run_handler.verify_task_is_ready", new_callable=AsyncMock
@@ -781,6 +827,8 @@ def mock_pr_comment_payload():
 async def test_pr_comment_uses_create_comment_not_reply(
     _mock_verify_task_is_ready,
     _mock_ensure_php,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_prepare_repo,
     _mock_ensure_node,
     _mock_update_usage,
@@ -801,6 +849,7 @@ async def test_pr_comment_uses_create_comment_not_reply(
     _mock_set_npm_token_env,
     _mock_get_local_file_tree,
     _mock_slack_notify,
+    _mock_get_pull_request,
     mock_pr_comment_payload,
 ):
     """PR comment (no review_path) should use create_comment, not reply_to_comment, and skip thread checks."""
@@ -848,6 +897,7 @@ async def test_pr_comment_uses_create_comment_not_reply(
 @pytest.mark.skip(
     reason="Integration test - calls real Claude API, costs money. Run manually to verify."
 )
+@patch("services.webhook.review_run_handler.get_pull_request")
 @patch("services.webhook.review_run_handler.slack_notify")
 @patch("services.webhook.review_run_handler.get_local_file_tree", return_value=[])
 @patch("services.webhook.review_run_handler.set_npm_token_env")
@@ -867,6 +917,11 @@ async def test_pr_comment_uses_create_comment_not_reply(
 @patch("services.webhook.review_run_handler.update_usage")
 @patch("services.webhook.review_run_handler.ensure_node_packages")
 @patch("services.webhook.review_run_handler.clone_repo_and_install_dependencies")
+@patch(
+    "services.webhook.review_run_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.review_run_handler.git_merge_base_into_pr")
 @patch("services.webhook.review_run_handler.ensure_php_packages")
 @patch(
     "services.webhook.review_run_handler.verify_task_is_ready", new_callable=AsyncMock
@@ -878,6 +933,8 @@ async def test_question_comment_agent_replies_without_code_changes(
     _mock_tools_to_call,
     _mock_verify_task_is_ready,
     _mock_ensure_php,
+    _mock_get_behind,
+    _mock_merge_base,
     _mock_prepare_repo,
     _mock_ensure_node,
     _mock_update_usage,
@@ -897,6 +954,7 @@ async def test_question_comment_agent_replies_without_code_changes(
     _mock_set_npm_token_env,
     _mock_get_local_file_tree,
     _mock_slack_notify,
+    _mock_get_pull_request,
     mock_pr_comment_payload,
 ):
     """Integration test: real Claude call for a question comment. Agent should just reply, no code changes."""

--- a/services/webhook/test_review_run_handler.py
+++ b/services/webhook/test_review_run_handler.py
@@ -1,4 +1,4 @@
-# pylint: disable=unused-argument
+# pylint: disable=unused-argument,too-many-lines
 # pyright: reportUnusedVariable=false
 from unittest.mock import AsyncMock, patch
 


### PR DESCRIPTION
## Summary
- Add `git_merge_base_into_pr` to merge base branch into PR when `mergeable_state == "dirty"`, so the agent can see and resolve conflict markers
- Replace `--unshallow` (137s for 61K commits) with GitHub Compare API (`behind_by`) + exponential `--deepen` fallback (100 -> 500 -> 2500 -> 12500, then `--unshallow` as last resort)
- Create `WebhookPullRequest` TypedDict for webhook payloads (missing REST API-only fields like `mergeable_state`)
- Add `get_pull_request` REST API call in `review_run_handler` since webhook payload doesn't include `mergeable_state`
- Extract `set_git_identity` into its own file (was duplicated in `create_empty_commit` and `initialize_repo`)
