### PR TITLE
Support craco.config.js in ensure_jest_timeout_for_ci

### DIFF
--- a/constants/files.py
+++ b/constants/files.py
@@ -144,6 +144,11 @@ TEST_QUALIFIER_STRIP = re.compile(
 # Top-level directories that indicate a "separate test directory" convention
 TOP_LEVEL_TEST_DIRS = frozenset({"test", "tests", "spec", "specs", "t"})
 
+CRACO_CONFIG_FILES = [
+    "craco.config.js",
+    "craco.config.ts",
+]
+
 JEST_CONFIG_FILES = [
     "jest.config.js",
     "jest.config.ts",

--- a/services/node/ensure_jest_timeout_for_ci.py
+++ b/services/node/ensure_jest_timeout_for_ci.py
@@ -1,18 +1,24 @@
 import re
 
-from constants.files import JEST_CONFIG_FILES
+from constants.files import CRACO_CONFIG_FILES, JEST_CONFIG_FILES
 from services.git.write_and_commit_file import write_and_commit_file
 from services.types.base_args import BaseArgs
 from utils.error.handle_exceptions import handle_exceptions
 from utils.files.read_local_file import read_local_file
 from utils.logging.logging_config import logger
 
-# Patterns to find the config object opening brace
-CONFIG_OBJECT_PATTERNS = [
+# Patterns to find the config object opening brace in jest config files
+JEST_CONFIG_OBJECT_PATTERNS = [
     re.compile(r"module\.exports\s*=\s*\{"),
     re.compile(r"export\s+default\s+\{"),
     re.compile(r":\s*Config(?:\.InitialOptions)?\s*=\s*\{"),
     re.compile(r"merge(?:\.recursive)?\([^{]*\{"),
+]
+
+# Patterns to find the jest.configure object in craco config files.
+# testTimeout must go inside jest: { configure: { ... } }, not at the top level.
+CRACO_CONFIGURE_OBJECT_PATTERNS = [
+    re.compile(r"configure\s*:\s*\{"),
 ]
 
 CI_TIMEOUT_MS = 180000
@@ -26,21 +32,41 @@ EXPECTED_TIMEOUT_LINE = (
 def ensure_jest_timeout_for_ci(root_files: list[str], base_args: BaseArgs):
     clone_dir = base_args["clone_dir"]
 
-    jest_config_file = None
-    for config_file in JEST_CONFIG_FILES:
-        if config_file in root_files:
-            jest_config_file = config_file
+    config_file = None
+    config_patterns = JEST_CONFIG_OBJECT_PATTERNS
+    content = None
+
+    # Craco configs take priority — `craco test` ignores jest.config.* files
+    for f in CRACO_CONFIG_FILES:
+        if f not in root_files:
+            logger.info("ensure_jest_timeout_for_ci: %s not in root_files", f)
+            continue
+        craco_content = read_local_file(file_path=f, base_dir=clone_dir)
+        if craco_content and re.search(r"configure\s*:\s*\{", craco_content):
+            config_file = f
+            config_patterns = CRACO_CONFIGURE_OBJECT_PATTERNS
+            content = craco_content
+            logger.info(
+                "ensure_jest_timeout_for_ci: Using craco jest.configure in %s", f
+            )
             break
 
-    if not jest_config_file:
-        logger.info("ensure_jest_timeout_for_ci: No Jest config file found")
+    # Fall back to standard jest config files
+    if not config_file:
+        for f in JEST_CONFIG_FILES:
+            if f in root_files:
+                config_file = f
+                logger.info("ensure_jest_timeout_for_ci: Found Jest config %s", f)
+                break
+
+    if not config_file:
+        logger.info("ensure_jest_timeout_for_ci: No Jest or CRACO config file found")
         return None
 
-    content = read_local_file(file_path=jest_config_file, base_dir=clone_dir)
     if not content:
-        logger.warning(
-            "ensure_jest_timeout_for_ci: Could not read %s", jest_config_file
-        )
+        content = read_local_file(file_path=config_file, base_dir=clone_dir)
+    if not content:
+        logger.warning("ensure_jest_timeout_for_ci: Could not read %s", config_file)
         return None
 
     # Find all testTimeout lines — duplicates cause last-key-wins in JS objects
@@ -52,7 +78,7 @@ def ensure_jest_timeout_for_ci(root_files: list[str], base_args: BaseArgs):
     # None — inject one at the top of the config object
     if len(timeout_line_nums) == 0:
         match = None
-        for pattern in CONFIG_OBJECT_PATTERNS:
+        for pattern in config_patterns:
             match = pattern.search(content)
             if match:
                 break
@@ -60,7 +86,7 @@ def ensure_jest_timeout_for_ci(root_files: list[str], base_args: BaseArgs):
         if not match:
             logger.info(
                 "ensure_jest_timeout_for_ci: Could not find config object pattern in %s",
-                jest_config_file,
+                config_file,
             )
             return None
 
@@ -81,14 +107,14 @@ def ensure_jest_timeout_for_ci(root_files: list[str], base_args: BaseArgs):
         if numbers and max(int(n) for n in numbers) >= CI_TIMEOUT_MS:
             logger.info(
                 "ensure_jest_timeout_for_ci: %s already has sufficient testTimeout",
-                jest_config_file,
+                config_file,
             )
             return None
 
         # Too low (e.g. 10000, 30000, 60000) — replace with our CI-aware value
         logger.info(
             "ensure_jest_timeout_for_ci: %s has testTimeout below %dms, updating",
-            jest_config_file,
+            config_file,
             CI_TIMEOUT_MS,
         )
         indent = re.match(r"(\s*)", existing_line)
@@ -101,7 +127,7 @@ def ensure_jest_timeout_for_ci(root_files: list[str], base_args: BaseArgs):
     else:
         logger.info(
             "ensure_jest_timeout_for_ci: %s has %d testTimeout entries, removing duplicates",
-            jest_config_file,
+            config_file,
             len(timeout_line_nums),
         )
         lines_to_remove: set[int] = set()
@@ -124,15 +150,13 @@ def ensure_jest_timeout_for_ci(root_files: list[str], base_args: BaseArgs):
 
     result = write_and_commit_file(
         file_content=updated_content,
-        file_path=jest_config_file,
+        file_path=config_file,
         base_args=base_args,
-        commit_message=f"Set testTimeout for CI stability in {jest_config_file}",
+        commit_message=f"Set testTimeout for CI stability in {config_file}",
     )
     if result.success:
-        logger.info(
-            "ensure_jest_timeout_for_ci: Added testTimeout to %s", jest_config_file
-        )
-        return jest_config_file
+        logger.info("ensure_jest_timeout_for_ci: Added testTimeout to %s", config_file)
+        return config_file
 
-    logger.warning("ensure_jest_timeout_for_ci: Failed to modify %s", jest_config_file)
+    logger.warning("ensure_jest_timeout_for_ci: Failed to modify %s", config_file)
     return None

--- a/services/node/test_ensure_jest_timeout_for_ci.py
+++ b/services/node/test_ensure_jest_timeout_for_ci.py
@@ -399,3 +399,148 @@ def test_website_next_jest(
     written = mock_write_and_commit.call_args.kwargs["file_content"]
     assert "testTimeout: process.env.CI ? 180000 : 5000," in written
     assert written.index("testTimeout") < written.index("setupFilesAfterEnv")
+
+
+# --- Real-world craco configs (foxden-admin-portal) ---
+
+# Original craco.config.js before GitAuto fix — missing testTimeout entirely
+FOXDEN_ADMIN_PORTAL_CRACO_NO_TIMEOUT = """module.exports = {
+  style: {
+    postcss: {
+      plugins: [require('tailwindcss'), require('autoprefixer')]
+    }
+  },
+  jest: {
+    configure: {
+      roots: ['<rootDir>/src', '<rootDir>/test'],
+      testMatch: ['<rootDir>/test/**/*.{spec,test}.{js,jsx,ts,tsx}'],
+      setupFilesAfterSetup: ['<rootDir>/test/setupTests.ts'],
+      testEnvironment: 'jsdom',
+      moduleNameMapper: {
+        '\\\\.(css|less|scss|sass)$': '<rootDir>/test/__mocks__/styleMock.js'
+      }
+    }
+  }
+};
+"""
+
+# After fix — testTimeout present with sufficient value
+FOXDEN_ADMIN_PORTAL_CRACO_WITH_TIMEOUT = """module.exports = {
+  style: {
+    postcss: {
+      plugins: [require('tailwindcss'), require('autoprefixer')]
+    }
+  },
+  jest: {
+    configure: {
+      testTimeout: process.env.CI ? 180000 : 5000,
+      roots: ['<rootDir>/src', '<rootDir>/test'],
+      testMatch: ['<rootDir>/test/**/*.{spec,test}.{js,jsx,ts,tsx}'],
+      setupFilesAfterSetup: ['<rootDir>/test/setupTests.ts'],
+      testEnvironment: 'jsdom',
+      moduleNameMapper: {
+        '\\\\.(css|less|scss|sass)$': '<rootDir>/test/__mocks__/styleMock.js'
+      }
+    }
+  }
+};
+"""
+
+# Craco config with testTimeout set too low
+FOXDEN_ADMIN_PORTAL_CRACO_LOW_TIMEOUT = """module.exports = {
+  style: {
+    postcss: {
+      plugins: [require('tailwindcss'), require('autoprefixer')]
+    }
+  },
+  jest: {
+    configure: {
+      testTimeout: 10000,
+      roots: ['<rootDir>/src', '<rootDir>/test'],
+      testEnvironment: 'jsdom'
+    }
+  }
+};
+"""
+
+# Craco config without any jest section
+CRACO_NO_JEST_SECTION = """module.exports = {
+  style: {
+    postcss: {
+      plugins: [require('tailwindcss'), require('autoprefixer')]
+    }
+  }
+};
+"""
+
+
+def test_craco_injects_timeout_into_configure_block(
+    mock_read_local_file: MagicMock, mock_write_and_commit: MagicMock
+):
+    mock_read_local_file.return_value = FOXDEN_ADMIN_PORTAL_CRACO_NO_TIMEOUT
+    result = ensure_jest_timeout_for_ci(
+        root_files=["craco.config.js", "package.json"], base_args=BASE_ARGS
+    )
+    assert result == "craco.config.js"
+    written = mock_write_and_commit.call_args.kwargs["file_content"]
+    assert "testTimeout: process.env.CI ? 180000 : 5000," in written
+    # testTimeout should appear INSIDE configure block, before roots
+    assert written.index("testTimeout") < written.index("roots")
+    assert written.index("testTimeout") > written.index("configure")
+
+
+def test_craco_already_has_correct_timeout(
+    mock_read_local_file: MagicMock, mock_write_and_commit: MagicMock
+):
+    mock_read_local_file.return_value = FOXDEN_ADMIN_PORTAL_CRACO_WITH_TIMEOUT
+    result = ensure_jest_timeout_for_ci(
+        root_files=["craco.config.js"], base_args=BASE_ARGS
+    )
+    assert result is None
+    mock_write_and_commit.assert_not_called()
+
+
+def test_craco_updates_low_timeout(
+    mock_read_local_file: MagicMock, mock_write_and_commit: MagicMock
+):
+    mock_read_local_file.return_value = FOXDEN_ADMIN_PORTAL_CRACO_LOW_TIMEOUT
+    result = ensure_jest_timeout_for_ci(
+        root_files=["craco.config.js"], base_args=BASE_ARGS
+    )
+    assert result == "craco.config.js"
+    written = mock_write_and_commit.call_args.kwargs["file_content"]
+    assert "testTimeout: process.env.CI ? 180000 : 5000," in written
+    assert "10000" not in written
+
+
+def test_craco_takes_priority_over_jest_config(
+    mock_read_local_file: MagicMock, mock_write_and_commit: MagicMock
+):
+    mock_read_local_file.return_value = FOXDEN_ADMIN_PORTAL_CRACO_NO_TIMEOUT
+    result = ensure_jest_timeout_for_ci(
+        root_files=["craco.config.js", "jest.config.js"], base_args=BASE_ARGS
+    )
+    assert result == "craco.config.js"
+    written = mock_write_and_commit.call_args.kwargs["file_content"]
+    assert "testTimeout: process.env.CI ? 180000 : 5000," in written
+
+
+def test_craco_without_jest_section_falls_through_to_jest_config(
+    mock_read_local_file: MagicMock, mock_write_and_commit: MagicMock
+):
+    jest_config = "module.exports = {\n  preset: 'ts-jest',\n};\n"
+
+    def side_effect(file_path, base_dir):
+        if file_path == "craco.config.js":
+            return CRACO_NO_JEST_SECTION
+        if file_path == "jest.config.js":
+            return jest_config
+        return None
+
+    mock_read_local_file.side_effect = side_effect
+    result = ensure_jest_timeout_for_ci(
+        root_files=["craco.config.js", "jest.config.js"], base_args=BASE_ARGS
+    )
+    assert result == "jest.config.js"
+    written = mock_write_and_commit.call_args.kwargs["file_content"]
+    assert "testTimeout: process.env.CI ? 180000 : 5000," in written


### PR DESCRIPTION
## Summary
- Extended `ensure_jest_timeout_for_ci` to check wrapper configs (craco.config.js) before standard jest configs
- When `craco test` runs instead of `jest`, it reads config from `craco.config.js`, ignoring `jest.config.*` entirely - so `testTimeout` must be set inside `jest: { configure: { ... } }`
- Added `CRACO_CONFIG_FILES` to `constants/files.py`
- 5 new tests covering craco injection, skip, low timeout update, priority over jest.config, and fallthrough when no jest section