### PR TITLE
Switch PR body summary to Claude with diffs and agent comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,8 +256,8 @@ When the user explicitly says "LGTM", execute this workflow:
         author: "Wes Nishio",
         authorUrl: "https://www.linkedin.com/in/hiroshi-nishio/",
         tags: ["vary-tags-based-on-the-specific-failure-and-fix"],
-        createdAt: "YYYY-MM-DD",
-        updatedAt: "YYYY-MM-DD",
+        createdAt: "YYYY-MM-DDTHH:MM:SS-07:00",
+        updatedAt: "YYYY-MM-DDTHH:MM:SS-07:00",
       };
       ```
 

--- a/constants/claude.py
+++ b/constants/claude.py
@@ -11,6 +11,7 @@ class ClaudeModelId(StrEnum):
     SONNET_4_6 = "claude-sonnet-4-6"
     SONNET_4_5 = "claude-sonnet-4-5"
     SONNET_4_0 = "claude-sonnet-4-0"
+    HAIKU_4_5 = "claude-haiku-4-5"
 
 
 # https://platform.claude.com/docs/en/docs/about-claude/models/all-models#model-comparison-table
@@ -20,6 +21,7 @@ CONTEXT_WINDOW: dict[ClaudeModelId, int] = {
     ClaudeModelId.OPUS_4_5: 200_000,
     ClaudeModelId.SONNET_4_5: 200_000,  # 1M available with context-1m-2025-08-07 beta header
     ClaudeModelId.SONNET_4_0: 200_000,  # 1M available with context-1m-2025-08-07 beta header
+    ClaudeModelId.HAIKU_4_5: 200_000,
 }
 
 MAX_OUTPUT_TOKENS: dict[ClaudeModelId, int] = {
@@ -28,6 +30,7 @@ MAX_OUTPUT_TOKENS: dict[ClaudeModelId, int] = {
     ClaudeModelId.OPUS_4_5: 64_000,
     ClaudeModelId.SONNET_4_5: 64_000,
     ClaudeModelId.SONNET_4_0: 64_000,
+    ClaudeModelId.HAIKU_4_5: 64_000,
 }
 
 MODEL_CHAIN = [

--- a/services/claude/chat_with_claude_simple.py
+++ b/services/claude/chat_with_claude_simple.py
@@ -1,0 +1,26 @@
+from constants.claude import ClaudeModelId
+from services.claude.client import claude
+from utils.error.handle_exceptions import handle_exceptions
+from utils.logging.logging_config import logger
+
+
+@handle_exceptions(default_return_value="", raise_on_error=False)
+def chat_with_claude_simple(
+    system_input: str,
+    user_input: str,
+    model_id: ClaudeModelId = ClaudeModelId.SONNET_4_6,
+):
+    response = claude.messages.create(
+        model=model_id,
+        system=system_input,
+        messages=[{"role": "user", "content": user_input}],
+        max_tokens=4096,
+        temperature=0.0,
+    )
+    text = ""
+    for block in response.content:
+        if block.type == "text":
+            text += block.text
+    if not text:
+        logger.warning("Claude returned empty text response")
+    return text

--- a/services/git/reset_pr_branch_to_new_base.py
+++ b/services/git/reset_pr_branch_to_new_base.py
@@ -6,7 +6,8 @@ from services.git.git_reset import git_reset
 from services.git.reapply_files import reapply_files
 from services.git.save_pr_files import save_pr_files
 from services.github.pulls.change_pr_base_branch import change_pr_base_branch
-from services.github.pulls.get_pull_request_files import Status, get_pull_request_files
+from services.github.pulls.get_pull_request_files import get_pull_request_files
+from services.github.types.pull_request_file import Status
 from services.types.base_args import BaseArgs
 from utils.error.handle_exceptions import handle_exceptions
 from utils.logging.logging_config import logger

--- a/services/git/save_pr_files.py
+++ b/services/git/save_pr_files.py
@@ -1,13 +1,13 @@
 from typing import Sequence
 
-from services.github.pulls.get_pull_request_files import FileChange
+from services.github.types.pull_request_file import PullRequestFile
 from utils.error.handle_exceptions import handle_exceptions
 from utils.files.read_local_file import read_local_file
 from utils.logging.logging_config import logger
 
 
 @handle_exceptions(default_return_value=({}, []), raise_on_error=False)
-def save_pr_files(clone_dir: str, pr_files: Sequence[FileChange]):
+def save_pr_files(clone_dir: str, pr_files: Sequence[PullRequestFile]):
     """Read PR file contents from clone_dir before a destructive operation like rebase.
     Returns (saved_files dict, deleted_files list) where saved_files maps file_path -> content.
     """

--- a/services/git/test_save_pr_files.py
+++ b/services/git/test_save_pr_files.py
@@ -1,8 +1,9 @@
 # pylint: disable=use-implicit-booleaness-not-comparison
 import os
 import tempfile
+from typing import cast
 
-from services.github.pulls.get_pull_request_files import FileChange
+from services.github.types.pull_request_file import PullRequestFile
 from services.git.save_pr_files import save_pr_files
 
 
@@ -14,10 +15,13 @@ def test_save_pr_files_reads_existing_files():
         with open(os.path.join(clone_dir, "README.md"), "w", encoding="utf-8") as f:
             f.write("# Readme\n")
 
-        pr_files: list[FileChange] = [
-            {"filename": "src/app.py", "status": "modified"},
-            {"filename": "README.md", "status": "added"},
-        ]
+        pr_files = cast(
+            list[PullRequestFile],
+            [
+                {"filename": "src/app.py", "status": "modified"},
+                {"filename": "README.md", "status": "added"},
+            ],
+        )
         saved, deleted = save_pr_files(clone_dir=clone_dir, pr_files=pr_files)
         assert saved == {"src/app.py": "print('hello')\n", "README.md": "# Readme\n"}
         assert deleted == []
@@ -28,10 +32,13 @@ def test_save_pr_files_handles_removed_files():
         with open(os.path.join(clone_dir, "keep.py"), "w", encoding="utf-8") as f:
             f.write("keep\n")
 
-        pr_files: list[FileChange] = [
-            {"filename": "keep.py", "status": "modified"},
-            {"filename": "gone.py", "status": "removed"},
-        ]
+        pr_files = cast(
+            list[PullRequestFile],
+            [
+                {"filename": "keep.py", "status": "modified"},
+                {"filename": "gone.py", "status": "removed"},
+            ],
+        )
         saved, deleted = save_pr_files(clone_dir=clone_dir, pr_files=pr_files)
         assert saved == {"keep.py": "keep\n"}
         assert deleted == ["gone.py"]
@@ -39,9 +46,10 @@ def test_save_pr_files_handles_removed_files():
 
 def test_save_pr_files_skips_missing_files():
     with tempfile.TemporaryDirectory() as clone_dir:
-        pr_files: list[FileChange] = [
-            {"filename": "nonexistent.py", "status": "modified"},
-        ]
+        pr_files = cast(
+            list[PullRequestFile],
+            [{"filename": "nonexistent.py", "status": "modified"}],
+        )
         saved, deleted = save_pr_files(clone_dir=clone_dir, pr_files=pr_files)
         assert saved == {}
         assert deleted == []

--- a/services/github/comments/get_comments.py
+++ b/services/github/comments/get_comments.py
@@ -9,9 +9,7 @@ from utils.error.handle_exceptions import handle_exceptions
 
 
 @handle_exceptions(default_return_value=[], raise_on_error=False)
-def get_comments(
-    pr_number: int, base_args: BaseArgs, includes_me: bool = False
-) -> list[str]:
+def get_comments(pr_number: int, base_args: BaseArgs, includes_me: bool = False):
     """https://docs.github.com/en/rest/issues/comments#list-issue-comments"""
     owner = base_args["owner"]
     repo = base_args["repo"]

--- a/services/github/pulls/generate_and_upsert_pr_body_section.py
+++ b/services/github/pulls/generate_and_upsert_pr_body_section.py
@@ -3,7 +3,7 @@ from json import dumps
 from constants.triggers import TRIGGER_TO_MARKER, TRIGGER_TO_PROMPT, Trigger
 from services.github.pulls.update_pull_request_body import update_pull_request_body
 from services.github.pulls.upsert_pr_body_section import upsert_pr_body_section
-from services.openai.chat import chat_with_ai
+from services.claude.chat_with_claude_simple import chat_with_claude_simple
 from utils.error.handle_exceptions import handle_exceptions
 from utils.logging.logging_config import logger
 
@@ -31,7 +31,9 @@ def generate_and_upsert_pr_body_section(
         repo_name,
         pr_number,
     )
-    generated_content = chat_with_ai(system_input=prompt, user_input=dumps(context))
+    generated_content = chat_with_claude_simple(
+        system_input=prompt, user_input=dumps(context)
+    )
     if not generated_content:
         logger.warning("LLM returned empty content for %s section", marker)
         return None

--- a/services/github/pulls/get_pull_request_files.py
+++ b/services/github/pulls/get_pull_request_files.py
@@ -1,21 +1,11 @@
-# Standard imports
-from typing import Literal, TypedDict
-
 # Third party imports
 import requests
 
 # Local imports
 from config import GITHUB_API_URL, PER_PAGE, TIMEOUT
+from services.github.types.pull_request_file import PullRequestFile
 from services.github.utils.create_headers import create_headers
 from utils.error.handle_exceptions import handle_exceptions
-
-
-Status = Literal["added", "modified", "removed"]
-
-
-class FileChange(TypedDict):
-    filename: str
-    status: Status
 
 
 @handle_exceptions(default_return_value=[], raise_on_error=False)
@@ -23,7 +13,7 @@ def get_pull_request_files(owner: str, repo: str, pr_number: int, token: str):
     """https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files"""
     url = f"{GITHUB_API_URL}/repos/{owner}/{repo}/pulls/{pr_number}/files"
     headers = create_headers(token=token)
-    file_changes: list[FileChange] = []
+    all_files: list[PullRequestFile] = []
     page = 1
 
     while True:
@@ -32,17 +22,12 @@ def get_pull_request_files(owner: str, repo: str, pr_number: int, token: str):
             url=url, headers=headers, params=params, timeout=TIMEOUT
         )
         response.raise_for_status()
-        files = response.json()
+        files: list[PullRequestFile] = response.json()
 
         if not files:
             break
 
-        for file in files:
-            if "filename" in file and "status" in file:
-                file_changes.append(
-                    {"filename": file["filename"], "status": file["status"]}
-                )
-
+        all_files.extend(files)
         page += 1
 
-    return file_changes
+    return all_files

--- a/services/github/pulls/test_get_pull_request_files.py
+++ b/services/github/pulls/test_get_pull_request_files.py
@@ -102,12 +102,7 @@ def test_get_pull_request_files_missing_fields():
             owner="test-owner", repo="test-repo", pr_number=1, token="token123"
         )
 
-        expected = [
-            {"filename": "file1.py", "status": "modified"},
-            {"filename": "file3.txt", "status": "removed"},
-        ]
-
-        assert result == expected
+        assert result == mock_response_data
 
 
 def test_get_pull_request_files_http_error():

--- a/services/github/types/pull_request_file.py
+++ b/services/github/types/pull_request_file.py
@@ -1,0 +1,18 @@
+# Standard imports
+from typing import Literal, NotRequired, TypedDict
+
+Status = Literal["added", "modified", "removed"]
+
+
+# https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files
+class PullRequestFile(TypedDict):
+    sha: str
+    filename: str
+    status: Status
+    additions: int
+    deletions: int
+    changes: int
+    blob_url: str
+    raw_url: str
+    contents_url: str
+    patch: NotRequired[str]

--- a/services/supabase/llm_requests/calculate_costs.py
+++ b/services/supabase/llm_requests/calculate_costs.py
@@ -15,6 +15,7 @@ def calculate_costs(
             "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
             "claude-sonnet-4-5": {"input": 3.00, "output": 15.00},
             "claude-sonnet-4-0": {"input": 3.00, "output": 15.00},
+            "claude-haiku-4-5": {"input": 0.80, "output": 4.00},
         },
         "openai": {
             "gpt-5.2": {"input": 1.75, "output": 14.00},

--- a/services/webhook/new_pr_handler.py
+++ b/services/webhook/new_pr_handler.py
@@ -655,7 +655,10 @@ async def handle_new_pr(
     )
     update_comment(body=body_after_pr, base_args=base_args)
 
-    # Update PR body with LLM-generated summary of what GA did
+    # Update PR body with Claude-generated summary of what GA did
+    agent_comments = get_comments(
+        pr_number=pr_number, base_args=base_args, includes_me=True
+    )
     pr_body_summary = generate_and_upsert_pr_body_section(
         owner_name=owner_name,
         repo_name=repo_name,
@@ -665,9 +668,9 @@ async def handle_new_pr(
         trigger=trigger,
         context={
             "pr_title": pr_title,
-            "trigger": trigger,
             "changed_files": changed_files,
             "completion_reason": completion_reason,
+            "agent_comments": agent_comments,
         },
     )
 

--- a/utils/prompts/write_pr_body_update.py
+++ b/utils/prompts/write_pr_body_update.py
@@ -4,23 +4,32 @@ WRITE_PR_BODY_UPDATE = f"""
 {BASE_ROLE}
 You are writing a section for a GitHub PR body that summarizes what an AI coding agent did on this PR. The reviewer will read this to understand the changes at a glance.
 
-Write in GitHub-flavored Markdown. Be concise but specific. Adapt to the actual context - don't use generic filler.
+Write in GitHub-flavored Markdown. Be extremely concise. Every word must earn its place. No filler, no repetition, no fluff.
+
+NEVER use bold markdown (**text**). It does not render in GitHub PR bodies. Use plain text only.
+
+Write in first person as the agent ("I tested...", "I found...").
+
+You will receive JSON with:
+- pr_title: the PR title
+- changed_files: list of files with filename, status (added/modified/removed), and patch (the actual diff)
+- completion_reason: the agent's own summary of what it did and why it stopped
+- agent_comments: the agent's progress comments posted during work
+
+Use the diff and agent comments to understand what actually happened, not just the file list. Reference specific functions, files, and behaviors from the diff - not generic summaries.
 
 Include:
-- What was tested/implemented and why it matters
-- Any bugs or potential issues discovered during the work (edge cases, untested paths, workarounds applied). If a bug was found, explain whether it was actually fixed or worked around (e.g. skipped the detecting test). Omit this section entirely if no bugs were found.
+- What specifically was tested or implemented, referencing actual functions and behaviors from the diff
+- Any bugs found in the implementation. For each bug, explain which workaround was used: (1) the implementation was fixed, (2) the test detecting the bug was skipped, or (3) the assertion was weakened/bypassed (e.g. TODO comment, relaxed assert, noted but not enforced). If no bugs were found, explicitly say so.
 - What the reviewer should pay attention to
 
 Template (adapt as needed):
-## What GitAuto Did
-[1-3 sentence summary of what was done and why]
+## What I Tested
+[1-3 sentences referencing specific functions, behaviors, and edge cases from the diff. Not a generic summary.]
 
 ## Potential Bugs Found
-- [Only if bugs/issues were discovered. Describe what was found, whether it was fixed or worked around, and why.]
+- [For each bug: (1) impl fixed, (2) test skipped, or (3) assertion weakened/TODO added? If none found, say "None found."]
 
-## Trade-offs & Assumptions
-- [Design decisions, why this approach was chosen over alternatives, assumptions made, and uncertainties the reviewer should verify. Omit if straightforward.]
-
-## Reviewer Action Items
-- [Non-code tasks after merging: env vars to set, migrations to run, configs to update, docs to change, stakeholders to notify, etc. Omit if none.]
+## Non-Code Tasks
+- [Tasks outside the code review: env vars to set, migrations to run, configs to update, docs to change, stakeholders to notify, etc. Omit if none.]
 """


### PR DESCRIPTION
## Summary
- Replaced OpenAI with a new lightweight `chat_with_claude_simple` function (Sonnet 4.6) for generating PR body summaries
- Added `PullRequestFile` TypedDict to `services/github/types/` and simplified `get_pull_request_files` to return raw API responses instead of converting to a separate `FileChange` type
- Enriched PR body context with actual diffs (patch data) and agent progress comments so Claude can write specific, actionable summaries instead of generic descriptions
- Updated the prompt to enforce concise first-person writing, prohibit bold markdown, and require structured bug reporting (impl fixed / test skipped / assertion weakened)

## Social Media Posts

### GitAuto
Our PR body summaries now use Claude Sonnet 4.6 instead of OpenAI. We also feed it the actual diffs and agent comments - so instead of "modified 3 files", it references specific functions and behaviors. Bugs found during work are categorized: fixed in code, test skipped, or assertion weakened.

### Wes
Ran a side-by-side comparison of Haiku 4.5 vs Sonnet 4.6 for PR body summaries using a real GitAuto PR. Haiku wrote a clean summary. Sonnet caught a potential truthiness bug with owner_id=0. Similar speed, negligible cost difference for a once-per-PR call. Went with Sonnet.