### PR TITLE
Track PR body summary LLM usage in llm_requests table

### DIFF
--- a/services/claude/chat_with_claude_simple.py
+++ b/services/claude/chat_with_claude_simple.py
@@ -1,5 +1,8 @@
+import time
+
 from constants.claude import ClaudeModelId
 from services.claude.client import claude
+from services.supabase.llm_requests.insert_llm_request import insert_llm_request
 from utils.error.handle_exceptions import handle_exceptions
 from utils.logging.logging_config import logger
 
@@ -8,8 +11,10 @@ from utils.logging.logging_config import logger
 def chat_with_claude_simple(
     system_input: str,
     user_input: str,
+    usage_id: int,
     model_id: ClaudeModelId = ClaudeModelId.SONNET_4_6,
 ):
+    start = time.time()
     response = claude.messages.create(
         model=model_id,
         system=system_input,
@@ -17,10 +22,27 @@ def chat_with_claude_simple(
         max_tokens=4096,
         temperature=0.0,
     )
+    response_time_ms = int((time.time() - start) * 1000)
+
     text = ""
     for block in response.content:
         if block.type == "text":
             text += block.text
     if not text:
         logger.warning("Claude returned empty text response")
+
+    input_tokens = response.usage.input_tokens if response.usage else 0
+    output_tokens = response.usage.output_tokens if response.usage else 0
+    insert_llm_request(
+        usage_id=usage_id,
+        provider="claude",
+        model_id=model_id,
+        input_messages=[{"role": "user", "content": user_input}],
+        input_tokens=input_tokens,
+        output_message={"role": "assistant", "content": text},
+        output_tokens=output_tokens,
+        response_time_ms=response_time_ms,
+        created_by="chat_with_claude_simple",
+    )
+
     return text

--- a/services/github/pulls/generate_and_upsert_pr_body_section.py
+++ b/services/github/pulls/generate_and_upsert_pr_body_section.py
@@ -17,6 +17,7 @@ def generate_and_upsert_pr_body_section(
     current_body: str,
     trigger: Trigger,
     context: dict,
+    usage_id: int,
 ):
     marker = TRIGGER_TO_MARKER.get(trigger)
     prompt = TRIGGER_TO_PROMPT.get(trigger)
@@ -32,7 +33,7 @@ def generate_and_upsert_pr_body_section(
         pr_number,
     )
     generated_content = chat_with_claude_simple(
-        system_input=prompt, user_input=dumps(context)
+        system_input=prompt, user_input=dumps(context), usage_id=usage_id
     )
     if not generated_content:
         logger.warning("LLM returned empty content for %s section", marker)

--- a/services/webhook/new_pr_handler.py
+++ b/services/webhook/new_pr_handler.py
@@ -672,6 +672,7 @@ async def handle_new_pr(
             "completion_reason": completion_reason,
             "agent_comments": agent_comments,
         },
+        usage_id=usage_id,
     )
 
     if pr_body_summary:


### PR DESCRIPTION
## Summary
- Added `insert_llm_request` call to `chat_with_claude_simple` so every PR body summary generation is tracked with input/output tokens, cost, and response time
- Threaded `usage_id` through `generate_and_upsert_pr_body_section` from the handler

## Social Media Posts

### GitAuto
Every LLM call in GitAuto is now tracked - including PR body summaries. Input tokens, output tokens, cost, response time. No blind spots in our billing pipeline.

### Wes
Added a Claude Sonnet 4.6 call to generate PR body summaries and realized it wasn't hitting our llm_requests table. One missing insert and we'd have invisible costs. Fixed it before it shipped to production.