### PR TITLE
Fix Haiku pricing, add chat_with_claude_simple tests

### DIFF
--- a/services/claude/test_chat_with_claude_simple.py
+++ b/services/claude/test_chat_with_claude_simple.py
@@ -1,0 +1,70 @@
+# pyright: reportUnusedVariable=false
+from unittest.mock import Mock, patch
+
+from services.claude.chat_with_claude_simple import chat_with_claude_simple
+
+
+@patch("services.claude.chat_with_claude_simple.insert_llm_request")
+@patch("services.claude.chat_with_claude_simple.claude")
+def test_returns_text_and_inserts_llm_request(mock_claude, mock_insert):
+    mock_response = Mock()
+    mock_response.content = [Mock(type="text", text="Summary of changes")]
+    mock_response.usage = Mock(input_tokens=200, output_tokens=50)
+    mock_claude.messages.create.return_value = mock_response
+
+    result = chat_with_claude_simple(
+        system_input="You are a summarizer.",
+        user_input='{"pr_title": "Add tests"}',
+        usage_id=42,
+    )
+
+    assert result == "Summary of changes"
+    mock_insert.assert_called_once()
+    call_args = mock_insert.call_args[1]
+    assert call_args["usage_id"] == 42
+    assert call_args["provider"] == "claude"
+    assert call_args["model_id"] == "claude-sonnet-4-6"
+    assert call_args["input_tokens"] == 200
+    assert call_args["output_tokens"] == 50
+    assert call_args["created_by"] == "chat_with_claude_simple"
+    assert call_args["input_messages"] == [
+        {"role": "user", "content": '{"pr_title": "Add tests"}'}
+    ]
+    assert call_args["output_message"] == {
+        "role": "assistant",
+        "content": "Summary of changes",
+    }
+
+
+@patch("services.claude.chat_with_claude_simple.insert_llm_request")
+@patch("services.claude.chat_with_claude_simple.claude")
+def test_returns_empty_string_when_no_text_blocks(mock_claude, mock_insert):
+    mock_response = Mock()
+    mock_response.content = [Mock(type="tool_use", text="ignored")]
+    mock_response.usage = Mock(input_tokens=100, output_tokens=0)
+    mock_claude.messages.create.return_value = mock_response
+
+    result = chat_with_claude_simple(
+        system_input="system", user_input="input", usage_id=1
+    )
+
+    assert result == ""
+    mock_insert.assert_called_once()
+
+
+@patch("services.claude.chat_with_claude_simple.insert_llm_request")
+@patch("services.claude.chat_with_claude_simple.claude")
+def test_concatenates_multiple_text_blocks(mock_claude, _mock_insert):
+    mock_response = Mock()
+    mock_response.content = [
+        Mock(type="text", text="Part 1. "),
+        Mock(type="text", text="Part 2."),
+    ]
+    mock_response.usage = Mock(input_tokens=50, output_tokens=30)
+    mock_claude.messages.create.return_value = mock_response
+
+    result = chat_with_claude_simple(
+        system_input="system", user_input="input", usage_id=1
+    )
+
+    assert result == "Part 1. Part 2."

--- a/services/supabase/llm_requests/calculate_costs.py
+++ b/services/supabase/llm_requests/calculate_costs.py
@@ -15,7 +15,7 @@ def calculate_costs(
             "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
             "claude-sonnet-4-5": {"input": 3.00, "output": 15.00},
             "claude-sonnet-4-0": {"input": 3.00, "output": 15.00},
-            "claude-haiku-4-5": {"input": 0.80, "output": 4.00},
+            "claude-haiku-4-5": {"input": 1.00, "output": 5.00},
         },
         "openai": {
             "gpt-5.2": {"input": 1.75, "output": 14.00},


### PR DESCRIPTION
## Summary
- Fix Haiku pricing from $0.80/$4.00 to $1.00/$5.00 per MTok (matching current Anthropic pricing)
- Add unit tests for `chat_with_claude_simple` (empty response, multi-block concatenation, insert_llm_request integration)

## GitAuto Post
We checked our token cost tracking and found we'd been undercharging Haiku at $0.80/MTok instead of the actual $1/MTok. Small per-call, but every cent matters when you're routing thousands of summarization calls through it.

## Wes Post
Shipped a Haiku summarization layer yesterday. Checked the pricing today - we had $0.80/MTok hardcoded from an old rate. Actual price is $1. Off by 20%. Fixed, plus added tests for the function that was missing them.