### PR TITLE
Remove non-test structured rules from test fixtures

### DIFF
--- a/services/webhook/utils/test_create_system_message.py
+++ b/services/webhook/utils/test_create_system_message.py
@@ -102,9 +102,8 @@ def test_with_structured_rules_only(mock_read_xml_file, mock_get_trigger_prompt)
 
     structured_rules = {
         "codePatternStrategy": "Best practices first",
-        "preferredApiApproach": "GraphQL first",
-        "enforceOneFunctionPerFile": True,
-        "preferConciseCodeTechniques": True,
+        "enableCommentsInGeneratedTestCode": False,
+        "enforceComponentIsolationInTests": True,
     }
     repo_settings = create_repositories_data(structured_rules=structured_rules)
 
@@ -112,9 +111,8 @@ def test_with_structured_rules_only(mock_read_xml_file, mock_get_trigger_prompt)
 
     assert "<structured_repository_rules>" in result
     assert "codePatternStrategy: Best practices first" in result
-    assert "preferredApiApproach: GraphQL first" in result
-    assert "enforceOneFunctionPerFile: True" in result
-    assert "preferConciseCodeTechniques: True" in result
+    assert "enableCommentsInGeneratedTestCode: False" in result
+    assert "enforceComponentIsolationInTests: True" in result
     assert "</structured_repository_rules>" in result
 
 

--- a/services/website/test_get_default_structured_rules.py
+++ b/services/website/test_get_default_structured_rules.py
@@ -21,27 +21,17 @@ def sample_structured_rules():
     """Fixture providing sample structured rules data."""
     return {
         "codePatternStrategy": "Best practices first",
-        "preferredApiApproach": "GraphQL first",
         "customTestConstantsPath": "",
         "preferredCommentLanguage": "Auto-detect",
-        "enforceOneFunctionPerFile": True,
         "customTestFileNamingPattern": "",
-        "preferConciseCodeTechniques": True,
-        "fixUnrelatedIssuesWhenNoticed": False,
-        "allowCreatingIntermediateLayers": False,
         "customIntegrationTestFileSuffix": "",
-        "enforceOneResponsibilityPerFile": True,
-        "includeJSDocOrDocstringComments": False,
         "separateUnitAndIntegrationTests": True,
         "testConstantsManagementStrategy": "Auto-detect from existing tests",
-        "allowTodoCommentsInGeneratedCode": False,
         "enforceComponentIsolationInTests": True,
         "enableCommentsInGeneratedTestCode": False,
-        "preferEarlyReturnsToReduceNesting": True,
         "preferredTestFileNamingConvention": "filename_test.ext (Go style)",
         "preferredIntegrationTestFileSuffix": "Auto-detect language conventions",
         "preferredTestConstantsFileLocation": "Auto-detect from project structure",
-        "enableCommentsInGeneratedSourceCode": False,
         "preferFunctionStyleOverClassStyleInTests": True,
         "enableIntegrationTestsForReadOnlyOperations": False,
         "allowRefactoringSourceCodeBeforeWritingTests": True,
@@ -74,7 +64,6 @@ def test_get_default_structured_rules_success(
     assert result == sample_structured_rules
     assert isinstance(result, dict)
     assert "codePatternStrategy" in result
-    assert "preferredApiApproach" in result
 
 
 def test_get_default_structured_rules_empty_response(mock_requests_get):
@@ -232,7 +221,7 @@ def test_get_default_structured_rules_partial_data(mock_requests_get):
     # Setup mock response with partial data
     partial_data = {
         "codePatternStrategy": "Best practices first",
-        "preferredApiApproach": "GraphQL first",
+        "enableCommentsInGeneratedTestCode": False,
     }
     mock_response = MagicMock()
     mock_response.json.return_value = partial_data
@@ -245,4 +234,4 @@ def test_get_default_structured_rules_partial_data(mock_requests_get):
     assert result == partial_data
     assert len(result) == 2
     assert "codePatternStrategy" in result
-    assert "preferredApiApproach" in result
+    assert "enableCommentsInGeneratedTestCode" in result


### PR DESCRIPTION
## Summary
- Removed 10 structured rule keys that are unrelated to test generation from test fixtures: `preferredApiApproach`, `enforceOneFunctionPerFile`, `preferConciseCodeTechniques`, `allowCreatingIntermediateLayers`, `enforceOneResponsibilityPerFile`, `preferEarlyReturnsToReduceNesting`, `enableCommentsInGeneratedSourceCode`, `allowTodoCommentsInGeneratedCode`, `includeJSDocOrDocstringComments`, `fixUnrelatedIssuesWhenNoticed`
- Updated test data in `test_get_default_structured_rules.py` and `test_create_system_message.py` to use remaining valid keys
- Companion PR: gitautoai/website (removes rules from dashboard config, docs page, and code examples)
- Supabase cleanup deferred to after both PRs merge

## GitAuto post
Cleaned up our structured rules config. We had 10 rules about coding style (early returns, one function per file, API approach) mixed in with test generation settings. Users toggled them, but the agent only generates tests - those rules never applied to anything. Removed them.

## Wes post
Had rules like "enforce one function per file" and "prefer early returns" sitting in our test generation config. Customers were configuring them. They did nothing. The agent writes tests, not source code. Deleted 10 rules, 4 code example files, and a docs section. Sometimes cleaning up is the feature.