### PR TITLE
Add n for per-repo Node version switching, clean up Dockerfile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ When the user explicitly says "LGTM", execute this workflow:
      - Sequential: pip-freeze, generate-types, black, ruff --fix, print check, builtin logging check
      - Then concurrent: pylint + pyright + pytest (via `scripts/lint/pre_commit_parallel_checks.sh`)
    - Install hook once: `ln -sf ../../scripts/git/pre_commit_hook.sh .git/hooks/pre-commit`
-   - **If hooks fail**: fix issues, re-stage affected files, commit again. Repeat until all pass.
+   - **If hooks fail**: fix issues, re-stage affected files, commit again. Repeat until all pass. If a test failure is caused by another session's unstaged changes, fix the test but do NOT stage the other session's files. Only stage your fix to the test file.
    - **Use `--no-verify`** for trivial amendments that don't change code logic (e.g., removing a file, fixing a typo in a comment, re-staging after a hook-only change). Don't re-run the full test suite for non-code changes.
    - For test files with unused mock parameters, add `# pyright: reportUnusedVariable=false` at top
    - NO Claude Code credits, co-author lines, or `[skip ci]`

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,15 @@ COPY . ${LAMBDA_TASK_ROOT}
 RUN pip install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
 RUN dnf install -y git tar
 
-# Install Node.js (including npm) and yarn
+# Install Node.js (including npm), n (version manager), and yarn
 # https://github.com/nodesource/distributions
 # Node 22 because express-oauth2-jwt-bearer in foxden-admin-portal-backend requires ≤22.
-# Must match DEFAULT_NODE_VERSION in services/node/detect_node_version.py so native addons compiled by CodeBuild load on Lambda.
-RUN curl -fsSL https://rpm.nodesource.com/setup_22.x | bash - && \
+# FALLBACK_NODE_VERSION env var is read by constants/node.py at runtime.
+ARG NODE_VERSION=22
+ENV FALLBACK_NODE_VERSION=$NODE_VERSION
+RUN curl -fsSL https://rpm.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
     dnf install -y nodejs && \
-    npm install -g yarn
+    npm install -g n yarn
 
 # Install PHP CLI and Composer for PHPUnit test execution
 # Same packages are also installed in CodeBuild (infrastructure/setup-infra.yml)
@@ -27,11 +29,7 @@ RUN curl -fsSL https://rpm.nodesource.com/setup_22.x | bash - && \
 RUN dnf install -y php-cli php-json php-mbstring php-xml php-pdo && \
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-# Install cloc directly without adding the entire EPEL repository
-RUN curl -L https://github.com/AlDanial/cloc/releases/download/v1.98/cloc-1.98.pl -o /usr/local/bin/cloc && \
-    chmod +x /usr/local/bin/cloc
-
-# Install Playwright's browser without dependencies (install-deps)
+# Install Playwright's Chromium so customer repos with Playwright/Vitest browser tests can run during verify_task_is_complete (e.g. @vitest/browser-playwright with chromium)
 # https://playwright.dev/python/docs/browsers
 RUN python -m playwright install chromium
 

--- a/constants/node.py
+++ b/constants/node.py
@@ -1,0 +1,5 @@
+import os
+
+# Fallback Node.js version when a repo doesn't declare one (.nvmrc, .node-version, engines).
+# Read from Dockerfile ENV FALLBACK_NODE_VERSION; falls back to "22" for local dev.
+FALLBACK_NODE_VERSION = os.environ.get("FALLBACK_NODE_VERSION", "22")

--- a/services/agents/verify_task_is_complete.py
+++ b/services/agents/verify_task_is_complete.py
@@ -8,6 +8,7 @@ from constants.files import (
     PHP_TEST_FILE_EXTENSIONS,
     TS_TEST_FILE_EXTENSIONS,
 )
+from constants.node import FALLBACK_NODE_VERSION
 from services.agents.run_quality_gate import QUALITY_GATE_MESSAGE, run_quality_gate
 from services.eslint.ensure_eslint_relaxed_for_tests import (
     ensure_eslint_relaxed_for_tests,
@@ -20,6 +21,7 @@ from services.github.pulls.get_pull_request_files import get_pull_request_files
 from services.types.base_args import BaseArgs
 from services.jest.format_coverage_comment import format_coverage_comment
 from services.jest.run_jest_test import run_jest_test
+from services.node.detect_node_version import detect_node_version
 from services.node.ensure_jest_timeout_for_ci import ensure_jest_timeout_for_ci
 from services.node.ensure_jest_uses_tsconfig_for_tests import (
     ensure_jest_uses_tsconfig_for_tests,
@@ -28,6 +30,7 @@ from services.node.ensure_tsconfig_relaxed_for_tests import (
     ensure_tsconfig_relaxed_for_tests,
 )
 from services.node.ensure_vitest_timeout_for_ci import ensure_vitest_timeout_for_ci
+from services.node.switch_node_version import switch_node_version
 from services.phpunit.run_phpunit_test import run_phpunit_test
 from services.prettier.run_prettier_fix import run_prettier_fix
 from services.slack.slack_notify import slack_notify
@@ -130,6 +133,11 @@ async def verify_task_is_complete(
     ]
 
     if js_test_files:
+        # Switch Node.js to the version the repo requires (no-op if already matching default)
+        detected_node = detect_node_version(clone_dir)
+        if detected_node != FALLBACK_NODE_VERSION:
+            switch_node_version(version=detected_node, base_args=base_args)
+
         root_files = [
             f
             for f in os.listdir(clone_dir)

--- a/services/aws/run_install_via_codebuild.py
+++ b/services/aws/run_install_via_codebuild.py
@@ -2,8 +2,8 @@ from mypy_boto3_codebuild.type_defs import EnvironmentVariableTypeDef
 
 from constants.aws import S3_DEPENDENCY_BUCKET
 from constants.general import IS_PRD
+from constants.node import FALLBACK_NODE_VERSION
 from services.aws.clients import codebuild_client
-from services.node.detect_node_version import DEFAULT_NODE_VERSION
 from services.supabase.npm_tokens.get_npm_token import get_npm_token
 from utils.error.handle_exceptions import handle_exceptions
 from utils.logging.logging_config import logger
@@ -14,7 +14,7 @@ def run_install_via_codebuild(
     s3_key_prefix: str,  # e.g. "Foxquilt/foxcom-forms" — S3 path for manifests and tarballs
     owner_id: int,
     pkg_manager: str,
-    node_version: str = DEFAULT_NODE_VERSION,
+    node_version: str = FALLBACK_NODE_VERSION,
 ):
     if not IS_PRD:
         logger.info("codebuild: Skipping in non-prod environment")

--- a/services/aws/s3/check_s3_dep_freshness_and_trigger_install.py
+++ b/services/aws/s3/check_s3_dep_freshness_and_trigger_install.py
@@ -2,8 +2,8 @@ from botocore.exceptions import ClientError
 
 from config import UTF8
 from constants.aws import S3_DEPENDENCY_BUCKET
+from constants.node import FALLBACK_NODE_VERSION
 from services.aws.clients import s3_client
-from services.node.detect_node_version import DEFAULT_NODE_VERSION
 from services.aws.run_install_via_codebuild import run_install_via_codebuild
 from utils.error.handle_exceptions import handle_exceptions
 from utils.logging.logging_config import logger
@@ -19,7 +19,7 @@ def check_s3_dep_freshness_and_trigger_install(
     manifest_hash: str,
     manifest_files: dict[str, str],  # filename -> content, uploaded to S3 for CodeBuild
     log_prefix: str,  # e.g. "node" or "php"
-    node_version: str = DEFAULT_NODE_VERSION,
+    node_version: str = FALLBACK_NODE_VERSION,
 ):
     """Check S3 tarball freshness and trigger CodeBuild if stale. Returns True if fresh."""
     # Check S3 tarball freshness via HeadObject metadata

--- a/services/claude/tools/tools.py
+++ b/services/claude/tools/tools.py
@@ -33,6 +33,10 @@ from services.github.comments.reply_to_comment import (
     REPLY_TO_REVIEW_COMMENT,
     reply_to_comment,
 )
+from services.node.switch_node_version import (
+    SWITCH_NODE_VERSION,
+    switch_node_version,
+)
 from services.git.reset_pr_branch_to_new_base import (
     RESET_PR_BRANCH_TO_NEW_BASE,
     reset_pr_branch_to_new_base,
@@ -68,6 +72,7 @@ _TOOLS_BASE: list[ToolUnionParam] = [
     SEARCH_AND_REPLACE,
     SEARCH_LOCAL_FILE_CONTENT,
     # SEARCH_WEB disabled: DDG CAPTCHAs bots. Use paid API (e.g. Brave Search) if needed.
+    SWITCH_NODE_VERSION,
     VERIFY_TASK_IS_COMPLETE,
     WEB_FETCH,
     WRITE_AND_COMMIT_FILE,
@@ -120,6 +125,7 @@ tools_to_call: dict[str, Any] = {
     "search_local_file_contents": search_local_file_contents,
     # "search_web": web_search,  # Disabled: DDG CAPTCHAs bots
     "set_env": set_env,
+    "switch_node_version": switch_node_version,
     "verify_task_is_complete": verify_task_is_complete,
     "web_fetch": web_fetch,
     "write_and_commit_file": write_and_commit_file,

--- a/services/node/detect_node_version.py
+++ b/services/node/detect_node_version.py
@@ -1,5 +1,6 @@
 import json
 
+from constants.node import FALLBACK_NODE_VERSION
 from utils.error.handle_exceptions import handle_exceptions
 from utils.files.read_local_file import read_local_file
 from utils.logging.logging_config import logger
@@ -8,12 +9,8 @@ from utils.versions.extract_max_major_from_constraint import (
 )
 from utils.versions.parse_major_version import parse_major_version
 
-# Node 22 because express-oauth2-jwt-bearer in foxden-admin-portal-backend requires ≤22.
-# Must match Dockerfile setup_22.x so native addons compiled by CodeBuild load on Lambda.
-DEFAULT_NODE_VERSION = "22"
 
-
-@handle_exceptions(default_return_value=DEFAULT_NODE_VERSION, raise_on_error=False)
+@handle_exceptions(default_return_value=FALLBACK_NODE_VERSION, raise_on_error=False)
 def detect_node_version(clone_dir: str):
     """Detect the Node.js major version from repo config files. Returns e.g. '22'."""
     # 1. Check .nvmrc
@@ -49,6 +46,6 @@ def detect_node_version(clone_dir: str):
                 return parsed
 
     logger.info(
-        "node: No Node version specified, defaulting to %s", DEFAULT_NODE_VERSION
+        "node: No Node version specified, defaulting to %s", FALLBACK_NODE_VERSION
     )
-    return DEFAULT_NODE_VERSION
+    return FALLBACK_NODE_VERSION

--- a/services/node/switch_node_version.py
+++ b/services/node/switch_node_version.py
@@ -1,0 +1,33 @@
+from anthropic.types import ToolUnionParam
+
+from utils.command.run_subprocess import run_subprocess
+from utils.error.handle_exceptions import handle_exceptions
+from utils.logging.logging_config import logger
+
+SWITCH_NODE_VERSION: ToolUnionParam = {
+    "name": "switch_node_version",
+    "description": "Switches the active Node.js version using `n`. Use this when you see NODE_MODULE_VERSION mismatch errors or need a specific Node version for the repo. The version is a major number like '20' or '18'.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "version": {
+                "type": "string",
+                "description": "The Node.js major version to switch to. For example, '20', '18', '22'.",
+            },
+        },
+        "required": ["version"],
+        "additionalProperties": False,
+    },
+    "strict": True,
+}
+
+
+@handle_exceptions(
+    default_return_value="Failed to switch Node.js version.", raise_on_error=False
+)
+def switch_node_version(*, version: str, **_kwargs):
+    """Switch Node.js to the specified major version using n."""
+    logger.info("switch_node_version: Switching to Node %s", version)
+    run_subprocess(["n", version], cwd="/tmp")
+    logger.info("switch_node_version: Switched to Node %s", version)
+    return f"Switched to Node.js {version}."

--- a/services/node/test_detect_node_version.py
+++ b/services/node/test_detect_node_version.py
@@ -2,7 +2,8 @@ import os
 
 import pytest
 
-from services.node.detect_node_version import DEFAULT_NODE_VERSION, detect_node_version
+from constants.node import FALLBACK_NODE_VERSION
+from services.node.detect_node_version import detect_node_version
 
 REPOS_ROOT = os.path.join(os.path.dirname(__file__), "..", "..", "..")
 
@@ -40,13 +41,13 @@ class TestRealRepos:
 
     def test_foxcom_forms_no_version_defaults_to_22(self):
         repo = real_repo(os.path.join(REPOS_ROOT, "Foxquilt", "foxcom-forms"))
-        assert detect_node_version(repo) == DEFAULT_NODE_VERSION
+        assert detect_node_version(repo) == FALLBACK_NODE_VERSION
 
     def test_foxden_admin_portal_backend_no_version_defaults_to_22(self):
         repo = real_repo(
             os.path.join(REPOS_ROOT, "Foxquilt", "foxden-admin-portal-backend")
         )
-        assert detect_node_version(repo) == DEFAULT_NODE_VERSION
+        assert detect_node_version(repo) == FALLBACK_NODE_VERSION
 
 
 # Solitary tests with tmp_path fixtures
@@ -69,7 +70,7 @@ class TestNvmrc:
     def test_lts_falls_through_to_default(self, repo_dir: str):
         with open(os.path.join(repo_dir, ".nvmrc"), "w", encoding="utf-8") as f:
             f.write("lts/*\n")
-        assert detect_node_version(repo_dir) == DEFAULT_NODE_VERSION
+        assert detect_node_version(repo_dir) == FALLBACK_NODE_VERSION
 
 
 class TestNodeVersionFile:
@@ -88,4 +89,4 @@ class TestNodeVersionFile:
 
 class TestDefault:
     def test_empty_dir_returns_default(self, repo_dir: str):
-        assert detect_node_version(repo_dir) == DEFAULT_NODE_VERSION
+        assert detect_node_version(repo_dir) == FALLBACK_NODE_VERSION

--- a/services/node/test_switch_node_version.py
+++ b/services/node/test_switch_node_version.py
@@ -1,0 +1,18 @@
+# pyright: reportUnusedVariable=false
+from unittest.mock import patch
+
+from services.node.switch_node_version import switch_node_version
+
+
+@patch("services.node.switch_node_version.run_subprocess")
+def test_switches_version(mock_run):
+    result = switch_node_version(version="20")
+    assert result == "Switched to Node.js 20."
+    mock_run.assert_called_once_with(["n", "20"], cwd="/tmp")
+
+
+@patch("services.node.switch_node_version.run_subprocess")
+def test_returns_default_on_failure(mock_run):
+    mock_run.side_effect = ValueError("Command failed")
+    result = switch_node_version(version="18")
+    assert result == "Failed to switch Node.js version."


### PR DESCRIPTION
## Summary
- Install `n` (Node version manager) in Dockerfile so Lambda can switch Node versions at runtime per repo
- Add `switch_node_version` as both an upfront call in `verify_task_is_complete` and an agent tool for reactive fallback
- Move `FALLBACK_NODE_VERSION` to `constants/node.py`, shared between Dockerfile env var, detect_node_version, and CodeBuild
- Remove unused `cloc` from Dockerfile
- Add comments explaining why Playwright Chromium is needed

## GitAuto Post
Our CI kept crashing on a native addon compiled for Node 22 but loaded on Node 24. Root cause: Dockerfile and CodeBuild were pinned to different versions. Fixed by aligning both to 22 and adding `n` so Lambda can switch per repo at runtime.

## Wes Post
Native Node addons encode their ABI version at compile time. If your build step compiles with Node 22 (ABI 127) but your runtime uses Node 24 (ABI 137), you get a MODULE_VERSION mismatch and a segfault. We added `n` to our Lambda image so it can match whatever version the repo needs.