### PR TITLE
Extract mongodb-binaries from S3 cache on Lambda

### DIFF
--- a/scripts/git/recent_social_posts.sh
+++ b/scripts/git/recent_social_posts.sh
@@ -60,4 +60,7 @@ for body in bodies:
         print("[" + str(count) + "] " + post_lines[0])
         for pl in post_lines[1:]:
             print(pl)
+
+if count == 0:
+    print("No " + section.replace("## ", "") + " sections found in last 10 merged PRs.")
 '

--- a/services/aws/s3/test_download_and_extract_dependency.py
+++ b/services/aws/s3/test_download_and_extract_dependency.py
@@ -8,6 +8,7 @@ from services.aws.s3.download_and_extract_dependency import download_and_extract
 
 def test_skips_when_target_dirs_exist(tmp_path):
     clone_dir = str(tmp_path)
+    os.makedirs(os.path.join(clone_dir, "mongodb-binaries"))
     os.makedirs(os.path.join(clone_dir, "node_modules"))
     os.makedirs(os.path.join(clone_dir, "vendor"))
 
@@ -42,6 +43,6 @@ def test_downloads_and_extracts_tarball(tmp_path):
 
         download_and_extract_s3_deps("owner", "repo", clone_dir)
 
-        # Should have called download_file for node_modules and vendor
-        assert mock_s3.download_file.call_count == 2
-        assert mock_run.call_count == 2
+        # Should have called download_file for mongodb-binaries, node_modules, and vendor
+        assert mock_s3.download_file.call_count == 3
+        assert mock_run.call_count == 3

--- a/services/jest/run_jest_test.py
+++ b/services/jest/run_jest_test.py
@@ -68,9 +68,8 @@ async def run_jest_test(
     env = os.environ.copy()
     env["CI"] = "true"
 
-    # MongoMemoryServer downloads mongod binary on first use (~3s on Lambda).
-    # Downloaded from S3 cache on first use (~3s on Lambda cold start).
-    env["MONGOMS_DOWNLOAD_DIR"] = "/tmp/mongodb-binaries"
+    # MongoMemoryServer looks for mongod binary here. CodeBuild caches it to S3 as mongodb-binaries.tar.gz, extracted alongside node_modules by download_and_extract_s3_deps into {clone_dir}/mongodb-binaries/.
+    env["MONGOMS_DOWNLOAD_DIR"] = os.path.join(clone_dir, "mongodb-binaries")
     mongoms_distro = get_mongoms_distro(clone_dir)
     if mongoms_distro:
         env["MONGOMS_DISTRO"] = mongoms_distro

--- a/services/jest/test_run_jest_test.py
+++ b/services/jest/test_run_jest_test.py
@@ -402,7 +402,7 @@ async def test_run_jest_test_type_error_in_output(
 async def test_run_jest_test_sets_mongoms_download_dir(
     mock_exists, mock_subprocess, _mock_distro
 ):
-    """Verify MONGOMS_DOWNLOAD_DIR is set to /tmp for MongoMemoryServer binary caching."""
+    """Verify MONGOMS_DOWNLOAD_DIR points to {clone_dir}/mongodb-binaries for S3 cache extraction."""
     mock_exists.return_value = True
     mock_subprocess.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
@@ -424,7 +424,7 @@ async def test_run_jest_test_sets_mongoms_download_dir(
     # Verify jest was called with MONGOMS_DOWNLOAD_DIR in env (first call is jest)
     call_kwargs = mock_subprocess.call_args_list[0].kwargs
     env = call_kwargs["env"]
-    assert env["MONGOMS_DOWNLOAD_DIR"] == "/tmp/mongodb-binaries"
+    assert env["MONGOMS_DOWNLOAD_DIR"] == "/tmp/clone/mongodb-binaries"
 
 
 # Real Jest output captured from foxden-rating-quoting-backend on 2026-03-23.

--- a/utils/files/is_dependency_file.py
+++ b/utils/files/is_dependency_file.py
@@ -2,6 +2,7 @@ from utils.error.handle_exceptions import handle_exceptions
 
 # Dependency dirs we support caching as tarballs for faster installs
 SUPPORTED_DEPENDENCY_DIRS = [
+    "mongodb-binaries",  # MongoMemoryServer (mongod binary, ~100MB)
     "node_modules",  # npm/yarn/pnpm (JS/TS)
     "vendor",  # Composer (PHP), Go modules
 ]


### PR DESCRIPTION
## Summary

- Add `mongodb-binaries` to `SUPPORTED_DEPENDENCY_DIRS` so Lambda extracts the pre-cached MongoMemoryServer binary from S3 instead of downloading ~80MB at runtime per invocation
- Change `MONGOMS_DOWNLOAD_DIR` from `/tmp/mongodb-binaries` to `{clone_dir}/mongodb-binaries` so the extracted binary matches where MongoMemoryServer looks for it, and different repos don't collide on warm Lambda containers
- Fix `recent_social_posts.sh` to print a message when no posts are found instead of producing silent empty output
