### PR TITLE
Pre-cache MongoDB binaries for all mongoms versions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -51,8 +51,9 @@ jobs:
       - name: Build, tag, and push image to Amazon ECR
         run: |
           # --provenance=false prevents OCI manifest format, which Lambda doesn't support
-          docker build --provenance=false -f ./Dockerfile -t $ECR_REGISTRY/pr-agent-prod:$IMAGE_TAG .
+          docker build --provenance=false -f ./Dockerfile -t $ECR_REGISTRY/pr-agent-prod:$IMAGE_TAG -t $ECR_REGISTRY/pr-agent-prod:latest .
           docker push $ECR_REGISTRY/pr-agent-prod:$IMAGE_TAG
+          docker push $ECR_REGISTRY/pr-agent-prod:latest
 
       - name: Deploy infrastructure stack
         run: |

--- a/constants/mongoms.py
+++ b/constants/mongoms.py
@@ -1,0 +1,9 @@
+# Default MongoDB server versions that mongodb-memory-server downloads when no version is specified in package.json config.
+# https://github.com/typegoose/mongodb-memory-server/blob/master/packages/mongodb-memory-server-core/src/util/resolve-config.ts
+MONGOMS_MAJOR_TO_MONGODB_VERSION: dict[int, str] = {
+    7: "6.0.9",
+    8: "6.0.9",
+    9: "6.0.9",
+    10: "7.0.11",
+    11: "8.2.1",
+}

--- a/infrastructure/setup-infra.yml
+++ b/infrastructure/setup-infra.yml
@@ -391,16 +391,13 @@ Resources:
                     $PKG_MANAGER install
                     # Pre-download MongoDB binary to S3 cache if repo uses MongoMemoryServer.
                     # Calls our Python code directly (available because CodeBuild uses our Docker image).
-                    MONGOMS_ARCHIVE_NAME=$(PYTHONPATH=/var/task python3 -c "from services.mongoms.get_archive_name import get_mongoms_archive_name; print(get_mongoms_archive_name('$LOCAL_DIR') or '')" 2>/dev/null)
+                    MONGOMS_ARCHIVE_NAME=$(PYTHONPATH=/var/task python3 -c "from services.mongoms.get_archive_name import get_mongoms_archive_name; print(get_mongoms_archive_name('$LOCAL_DIR') or '')")
                     if [ -n "$MONGOMS_ARCHIVE_NAME" ]; then
                       export MONGOMS_ARCHIVE_NAME
-                      MONGO_VERSION=$(PYTHONPATH=/var/task python3 -c "from services.mongoms.get_mongo_version import get_mongo_version; print(get_mongo_version('$LOCAL_DIR') or '')" 2>/dev/null)
                       echo "Using MONGOMS_ARCHIVE_NAME=$MONGOMS_ARCHIVE_NAME"
-                      # 7.x requires downloadDir and version as constructor options (ignores env vars)
-                      node -e "
-                        const { MongoBinaryDownload } = require('$LOCAL_DIR/node_modules/mongodb-memory-server-core/lib/util/MongoBinaryDownload');
-                        new MongoBinaryDownload({ downloadDir: '/tmp/mongodb-binaries', version: '$MONGO_VERSION' }).download().then(() => console.log('Download complete')).catch(e => console.error(e));
-                      " || true
+                      # Download directly - MongoBinaryDownload's OS detection is broken on AL2023 (the same bug we're working around)
+                      mkdir -p /tmp/mongodb-binaries
+                      curl -fsSL "https://fastdl.mongodb.org/linux/$MONGOMS_ARCHIVE_NAME" -o "/tmp/mongodb-binaries/$MONGOMS_ARCHIVE_NAME" || true
                       if [ -d /tmp/mongodb-binaries ]; then
                         tar -czf /tmp/mongodb-binaries.tar.gz -C /tmp mongodb-binaries
                         aws s3 cp /tmp/mongodb-binaries.tar.gz "s3://$S3_BUCKET/$S3_KEY_PREFIX/mongodb-binaries.tar.gz"

--- a/infrastructure/setup-infra.yml
+++ b/infrastructure/setup-infra.yml
@@ -358,6 +358,7 @@ Resources:
           phases:
             install:
               commands:
+                - pip install awscli
                 - n "$NODE_VERSION"
                 - echo "Using Node.js $(node --version)"
             build:

--- a/services/jest/run_jest_test.py
+++ b/services/jest/run_jest_test.py
@@ -3,9 +3,15 @@ import shutil
 import subprocess
 from dataclasses import dataclass, field
 
-from constants.aws import LAMBDA_DISTRO, SUBPROCESS_TIMEOUT_SECONDS
+from constants.aws import SUBPROCESS_TIMEOUT_SECONDS
+from constants.mongoms import MONGOMS_MAJOR_TO_MONGODB_VERSION
 from services.jest.parse_coverage_json import Coverage, parse_coverage_json
 from services.mongoms.get_archive_name import get_mongoms_archive_name
+from services.mongoms.get_distro_for_mongodb_server_version import (
+    get_distro_for_mongodb_server_version,
+)
+from services.mongoms.get_mongodb_server_version import get_mongodb_server_version
+from services.node.get_dependency_major_version import get_dependency_major_version
 from services.node.detect_package_manager import detect_package_manager
 from services.node.get_test_script_name import get_test_script_name
 from services.types.base_args import BaseArgs
@@ -71,13 +77,19 @@ async def run_jest_test(
     # MongoMemoryServer looks for mongod binary here. CodeBuild caches it to S3 as mongodb-binaries.tar.gz, extracted alongside node_modules by download_and_extract_s3_deps into {clone_dir}/mongodb-binaries/.
     env["MONGOMS_DOWNLOAD_DIR"] = os.path.join(clone_dir, "mongodb-binaries")
 
-    # MONGOMS_DISTRO overrides OS auto-detection for MongoDB binary downloads. 7.x ignores this env var. 9.x+ reads it but auto-detects correctly already — safety net. Harmless if repo doesn't use mongodb-memory-server.
-    env["MONGOMS_DISTRO"] = LAMBDA_DISTRO
-
-    # MONGOMS_ARCHIVE_NAME bypasses OS auto-detection entirely by specifying the full archive filename. Works in 7.x+ (unlike DISTRO which only works in 9.x+). Requires detecting MongoDB version from package.json.
+    # MONGOMS_ARCHIVE_NAME bypasses OS auto-detection entirely by specifying the full archive filename. Pre-cached by CodeBuild to S3.
     archive_name = get_mongoms_archive_name(clone_dir)
     if archive_name:
         env["MONGOMS_ARCHIVE_NAME"] = archive_name
+        # MONGOMS_DISTRO must match the distro in the archive name. MongoDB 7.0+ uses amazon2023, 6.0.x uses amazon2.
+        mongoms_major = get_dependency_major_version(clone_dir, "mongodb-memory-server")
+        mongodb_server_version = get_mongodb_server_version(clone_dir)
+        if not mongodb_server_version and mongoms_major:
+            mongodb_server_version = MONGOMS_MAJOR_TO_MONGODB_VERSION.get(mongoms_major)
+        if mongodb_server_version:
+            env["MONGOMS_DISTRO"] = get_distro_for_mongodb_server_version(
+                mongodb_server_version
+            )
 
     # Kill any lingering mongod processes from previous verify_task_is_complete calls.
     # MongoMemoryServer uses a fixed port (e.g. 34213) hardcoded in customer tests.

--- a/services/mongoms/get_archive_name.py
+++ b/services/mongoms/get_archive_name.py
@@ -1,13 +1,17 @@
-from constants.aws import LAMBDA_DISTRO
-from services.mongoms.get_mongo_version import get_mongo_version
+from constants.mongoms import MONGOMS_MAJOR_TO_MONGODB_VERSION
+from services.mongoms.get_distro_for_mongodb_server_version import (
+    get_distro_for_mongodb_server_version,
+)
+from services.mongoms.get_mongodb_server_version import get_mongodb_server_version
 from services.node.get_dependency_major_version import get_dependency_major_version
+from services.slack.slack_notify import slack_notify
 from utils.error.handle_exceptions import handle_exceptions
 from utils.logging.logging_config import logger
 
 
 @handle_exceptions(default_return_value=None, raise_on_error=False)
 def get_mongoms_archive_name(clone_dir: str):
-    """Construct MONGOMS_ARCHIVE_NAME to bypass OS auto-detection bug in mongodb-memory-server <8. Versions <8 misdetect Amazon Linux 2023 as "amazon" (release 2023 > upper bound 3) AND lack MONGOMS_DISTRO support. 8.x has DISTRO support so MONGOMS_DISTRO covers it. 9.x+ fixed auto-detection entirely."""
+    """Construct MONGOMS_ARCHIVE_NAME for pre-downloading MongoDB binary. Works for all mongoms versions — <8 needs it to bypass broken OS detection, >=8 benefits from pre-cached binary to avoid runtime download."""
     mongoms_major = get_dependency_major_version(clone_dir, "mongodb-memory-server")
     if not mongoms_major:
         logger.info(
@@ -15,21 +19,47 @@ def get_mongoms_archive_name(clone_dir: str):
         )
         return None
 
-    if mongoms_major >= 8:
+    # Try explicit version from package.json config or scripts
+    mongodb_server_version = get_mongodb_server_version(clone_dir)
+    if not mongodb_server_version:
         logger.info(
-            "get_mongoms_archive_name: mongodb-memory-server %s.x, DISTRO or auto-detection handles it",
+            "get_mongoms_archive_name: no explicit MongoDB version in package.json for mongoms %s.x, using defaults",
             mongoms_major,
         )
-        return None
+        mongodb_server_version = MONGOMS_MAJOR_TO_MONGODB_VERSION.get(mongoms_major)
 
-    # For <8, need ARCHIVE_NAME to bypass broken OS detection
-    version = get_mongo_version(clone_dir)
-    if not version:
-        logger.info(
-            "get_mongoms_archive_name: mongodb-memory-server <8 but no MongoDB version detected, skipping"
-        )
-        return None
+        if not mongodb_server_version:
+            min_known = min(MONGOMS_MAJOR_TO_MONGODB_VERSION)
+            max_known = max(MONGOMS_MAJOR_TO_MONGODB_VERSION)
+            logger.warning(
+                "get_mongoms_archive_name: mongoms %s.x not in MONGOMS_MAJOR_TO_MONGODB_VERSION (range %s-%s)",
+                mongoms_major,
+                min_known,
+                max_known,
+            )
 
-    archive_name = f"mongodb-linux-x86_64-{LAMBDA_DISTRO}-{version}.tgz"
+            if mongoms_major > max_known:
+                mongodb_server_version = MONGOMS_MAJOR_TO_MONGODB_VERSION[max_known]
+                msg = f"get_mongoms_archive_name: mongoms {mongoms_major}.x not in MONGOMS_MAJOR_TO_MONGODB_VERSION, falling back to {mongodb_server_version} (from {max_known}.x). Update constants/mongoms.py."
+                logger.warning(msg)
+                slack_notify(msg)
+
+            else:
+                logger.info(
+                    "get_mongoms_archive_name: mongoms %s.x < %s (oldest supported), skipping",
+                    mongoms_major,
+                    min_known,
+                )
+                return None
+
+        else:
+            logger.info(
+                "get_mongoms_archive_name: using default MongoDB %s for mongoms %s.x",
+                mongodb_server_version,
+                mongoms_major,
+            )
+
+    distro = get_distro_for_mongodb_server_version(mongodb_server_version)
+    archive_name = f"mongodb-linux-x86_64-{distro}-{mongodb_server_version}.tgz"
     logger.info("get_mongoms_archive_name: %s", archive_name)
     return archive_name

--- a/services/mongoms/get_distro_for_mongodb_server_version.py
+++ b/services/mongoms/get_distro_for_mongodb_server_version.py
@@ -1,0 +1,31 @@
+from utils.error.handle_exceptions import handle_exceptions
+from utils.logging.logging_config import logger
+
+
+@handle_exceptions(default_return_value="amazon2023", raise_on_error=False)
+def get_distro_for_mongodb_server_version(mongodb_server_version: str):
+    """Return the correct Amazon Linux distro name for a MongoDB server version.
+    MongoDB 7.0+ has amazon2023 builds. 6.0.x and earlier only have amazon2."""
+    # Extract major.minor from version strings like "v7.0-latest", "7.0.11", "6.0.14"
+    cleaned = mongodb_server_version.lstrip("v")
+    major_str = cleaned.split(".")[0]
+    try:
+        major = int(major_str)
+    except ValueError:
+        logger.warning(
+            "get_distro_for_mongodb_server_version: can't parse major from %s, defaulting to amazon2023",
+            mongodb_server_version,
+        )
+        return "amazon2023"
+
+    if major >= 7:
+        logger.info(
+            "get_distro_for_mongodb_server_version: MongoDB %s.x uses amazon2023 distro",
+            major,
+        )
+        return "amazon2023"
+
+    logger.info(
+        "get_distro_for_mongodb_server_version: MongoDB %s.x uses amazon2 distro", major
+    )
+    return "amazon2"

--- a/services/mongoms/get_mongodb_server_version.py
+++ b/services/mongoms/get_mongodb_server_version.py
@@ -7,16 +7,18 @@ from utils.logging.logging_config import logger
 
 
 @handle_exceptions(default_return_value=None, raise_on_error=False)
-def get_mongo_version(clone_dir: str):
+def get_mongodb_server_version(clone_dir: str):
     """Detect MongoDB version from package.json config or scripts. Returns e.g. 'v7.0-latest' or None."""
     pkg_content = read_local_file("package.json", clone_dir)
     if not pkg_content:
-        logger.info("get_mongo_version: no package.json found in %s", clone_dir)
+        logger.info(
+            "get_mongodb_server_version: no package.json found in %s", clone_dir
+        )
         return None
 
     pkg = json.loads(pkg_content)
     if not isinstance(pkg, dict):
-        logger.info("get_mongo_version: package.json is not a dict")
+        logger.info("get_mongodb_server_version: package.json is not a dict")
         return None
 
     # config.mongodbMemoryServer.version first
@@ -27,14 +29,14 @@ def get_mongo_version(clone_dir: str):
             version = mongoms_config.get("version")
             if isinstance(version, str):
                 logger.info(
-                    "get_mongo_version: %s from config.mongodbMemoryServer.version",
+                    "get_mongodb_server_version: %s from config.mongodbMemoryServer.version",
                     version,
                 )
                 return version
 
     # Fall back to MONGOMS_VERSION= in scripts
     logger.info(
-        "get_mongo_version: no config.mongodbMemoryServer.version, checking scripts"
+        "get_mongodb_server_version: no config.mongodbMemoryServer.version, checking scripts"
     )
     scripts = pkg.get("scripts")
     if isinstance(scripts, dict):
@@ -42,10 +44,10 @@ def get_mongo_version(clone_dir: str):
             match = re.search(r"MONGOMS_VERSION=(\S+)", str(script))
             if match:
                 logger.info(
-                    "get_mongo_version: found MONGOMS_VERSION=%s in scripts",
+                    "get_mongodb_server_version: found MONGOMS_VERSION=%s in scripts",
                     match.group(1),
                 )
                 return match.group(1)
 
-    logger.info("get_mongo_version: no MongoDB version detected")
+    logger.info("get_mongodb_server_version: no MongoDB version detected")
     return None

--- a/services/mongoms/test_get_archive_name.py
+++ b/services/mongoms/test_get_archive_name.py
@@ -2,33 +2,108 @@
 # pyright: reportUnusedVariable=false
 from unittest.mock import patch
 
-from constants.aws import LAMBDA_DISTRO
 from services.mongoms.get_archive_name import get_mongoms_archive_name
 
 
 @patch(
-    "services.mongoms.get_archive_name.get_mongo_version", return_value="v7.0-latest"
+    "services.mongoms.get_archive_name.get_mongodb_server_version",
+    return_value="v7.0-latest",
 )
 @patch("services.mongoms.get_archive_name.get_dependency_major_version", return_value=7)
-def test_mongoms_7x_returns_archive_name(_mock_major, _mock_version):
-    """mongoms <8 with detected version returns ARCHIVE_NAME."""
+def test_mongoms_7x_with_explicit_version(_mock_major, _mock_version):
+    """mongoms 7.x with explicit v7.0-latest uses amazon2023 distro."""
     assert (
         get_mongoms_archive_name("/tmp/clone")
-        == f"mongodb-linux-x86_64-{LAMBDA_DISTRO}-v7.0-latest.tgz"
+        == "mongodb-linux-x86_64-amazon2023-v7.0-latest.tgz"
     )
 
 
+@patch(
+    "services.mongoms.get_archive_name.get_mongodb_server_version",
+    return_value="v7.0-latest",
+)
 @patch("services.mongoms.get_archive_name.get_dependency_major_version", return_value=9)
-def test_mongoms_9x_returns_none(_mock_major):
-    """mongoms >=8 returns None (DISTRO or auto-detection handles it)."""
-    assert get_mongoms_archive_name("/tmp/clone") is None
+def test_mongoms_9x_with_explicit_7x_version(_mock_major, _mock_version):
+    """mongoms 9.x with explicit v7.0-latest uses amazon2023 distro."""
+    assert (
+        get_mongoms_archive_name("/tmp/clone")
+        == "mongodb-linux-x86_64-amazon2023-v7.0-latest.tgz"
+    )
 
 
 @patch(
+    "services.mongoms.get_archive_name.get_mongodb_server_version",
+    return_value="v7.0-latest",
+)
+@patch(
     "services.mongoms.get_archive_name.get_dependency_major_version", return_value=10
 )
-def test_mongoms_10x_returns_none(_mock_major):
-    """mongoms >=8 returns None."""
+def test_mongoms_10x_with_explicit_7x_version(_mock_major, _mock_version):
+    """mongoms 10.x with explicit v7.0-latest uses amazon2023 distro."""
+    assert (
+        get_mongoms_archive_name("/tmp/clone")
+        == "mongodb-linux-x86_64-amazon2023-v7.0-latest.tgz"
+    )
+
+
+@patch(
+    "services.mongoms.get_archive_name.get_mongodb_server_version", return_value=None
+)
+@patch("services.mongoms.get_archive_name.get_dependency_major_version", return_value=9)
+def test_mongoms_9x_no_explicit_version_uses_default(_mock_major, _mock_version):
+    """mongoms 9.x with no explicit version falls back to default 6.0.9 with amazon2 distro."""
+    assert (
+        get_mongoms_archive_name("/tmp/clone")
+        == "mongodb-linux-x86_64-amazon2-6.0.9.tgz"
+    )
+
+
+@patch(
+    "services.mongoms.get_archive_name.get_mongodb_server_version", return_value=None
+)
+@patch(
+    "services.mongoms.get_archive_name.get_dependency_major_version", return_value=10
+)
+def test_mongoms_10x_no_explicit_version_uses_default(_mock_major, _mock_version):
+    """mongoms 10.x with no explicit version falls back to default 7.0.11 with amazon2023 distro."""
+    assert (
+        get_mongoms_archive_name("/tmp/clone")
+        == "mongodb-linux-x86_64-amazon2023-7.0.11.tgz"
+    )
+
+
+@patch(
+    "services.mongoms.get_archive_name.get_mongodb_server_version", return_value=None
+)
+@patch("services.mongoms.get_archive_name.get_dependency_major_version", return_value=7)
+def test_mongoms_7x_no_explicit_version_uses_default(_mock_major, _mock_version):
+    """mongoms 7.x with no explicit version falls back to default 6.0.9 with amazon2 distro."""
+    assert (
+        get_mongoms_archive_name("/tmp/clone")
+        == "mongodb-linux-x86_64-amazon2-6.0.9.tgz"
+    )
+
+
+@patch(
+    "services.mongoms.get_archive_name.get_mongodb_server_version", return_value=None
+)
+@patch(
+    "services.mongoms.get_archive_name.get_dependency_major_version", return_value=12
+)
+def test_mongoms_future_version_falls_back_to_latest_known(_mock_major, _mock_version):
+    """mongoms 12.x (unmapped) falls back to highest known default (11 -> 8.2.1)."""
+    assert (
+        get_mongoms_archive_name("/tmp/clone")
+        == "mongodb-linux-x86_64-amazon2023-8.2.1.tgz"
+    )
+
+
+@patch(
+    "services.mongoms.get_archive_name.get_mongodb_server_version", return_value=None
+)
+@patch("services.mongoms.get_archive_name.get_dependency_major_version", return_value=5)
+def test_mongoms_old_version_returns_none(_mock_major, _mock_version):
+    """mongoms 5.x (too old, not mapped) returns None."""
     assert get_mongoms_archive_name("/tmp/clone") is None
 
 
@@ -37,11 +112,4 @@ def test_mongoms_10x_returns_none(_mock_major):
 )
 def test_no_mongoms_in_package_json(_mock_major):
     """mongodb-memory-server not in package.json."""
-    assert get_mongoms_archive_name("/tmp/clone") is None
-
-
-@patch("services.mongoms.get_archive_name.get_mongo_version", return_value=None)
-@patch("services.mongoms.get_archive_name.get_dependency_major_version", return_value=7)
-def test_mongoms_7x_no_version_returns_none(_mock_major, _mock_version):
-    """mongoms <8 but no MongoDB version detected returns None."""
     assert get_mongoms_archive_name("/tmp/clone") is None

--- a/services/mongoms/test_get_distro_for_mongodb_server_version.py
+++ b/services/mongoms/test_get_distro_for_mongodb_server_version.py
@@ -1,0 +1,27 @@
+from services.mongoms.get_distro_for_mongodb_server_version import (
+    get_distro_for_mongodb_server_version,
+)
+
+
+def test_mongodb_7x_latest_returns_amazon2023():
+    assert get_distro_for_mongodb_server_version("v7.0-latest") == "amazon2023"
+
+
+def test_mongodb_7011_returns_amazon2023():
+    assert get_distro_for_mongodb_server_version("7.0.11") == "amazon2023"
+
+
+def test_mongodb_821_returns_amazon2023():
+    assert get_distro_for_mongodb_server_version("8.2.1") == "amazon2023"
+
+
+def test_mongodb_609_returns_amazon2():
+    assert get_distro_for_mongodb_server_version("6.0.9") == "amazon2"
+
+
+def test_mongodb_6014_returns_amazon2():
+    assert get_distro_for_mongodb_server_version("6.0.14") == "amazon2"
+
+
+def test_unparseable_version_defaults_to_amazon2023():
+    assert get_distro_for_mongodb_server_version("latest") == "amazon2023"

--- a/services/mongoms/test_get_mongodb_server_version.py
+++ b/services/mongoms/test_get_mongodb_server_version.py
@@ -2,7 +2,7 @@
 import os
 from unittest.mock import patch
 
-from services.mongoms.get_mongo_version import get_mongo_version
+from services.mongoms.get_mongodb_server_version import get_mongodb_server_version
 
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 
@@ -12,36 +12,36 @@ def _load_fixture(filename: str):
         return f.read()
 
 
-@patch("services.mongoms.get_mongo_version.read_local_file")
+@patch("services.mongoms.get_mongodb_server_version.read_local_file")
 def test_foxcom_payment_backend_version_from_scripts(_mock_read):
     """foxcom-payment-backend: MONGOMS_VERSION=v7.0-latest in test script."""
     _mock_read.return_value = _load_fixture("foxcom-payment-backend-package.json")
-    assert get_mongo_version("/tmp/clone") == "v7.0-latest"
+    assert get_mongodb_server_version("/tmp/clone") == "v7.0-latest"
 
 
-@patch("services.mongoms.get_mongo_version.read_local_file")
+@patch("services.mongoms.get_mongodb_server_version.read_local_file")
 def test_foxden_auth_service_version_from_scripts(_mock_read):
     """foxden-auth-service: MONGOMS_VERSION=v7.0-latest in test script."""
     _mock_read.return_value = _load_fixture("foxden-auth-service-package.json")
-    assert get_mongo_version("/tmp/clone") == "v7.0-latest"
+    assert get_mongodb_server_version("/tmp/clone") == "v7.0-latest"
 
 
-@patch("services.mongoms.get_mongo_version.read_local_file")
+@patch("services.mongoms.get_mongodb_server_version.read_local_file")
 def test_foxden_billing_no_version(_mock_read):
     """foxden-billing: no MONGOMS_VERSION in config or scripts."""
     _mock_read.return_value = _load_fixture("foxden-billing-package.json")
-    assert get_mongo_version("/tmp/clone") is None
+    assert get_mongodb_server_version("/tmp/clone") is None
 
 
-@patch("services.mongoms.get_mongo_version.read_local_file")
+@patch("services.mongoms.get_mongodb_server_version.read_local_file")
 def test_foxcom_forms_no_version(_mock_read):
     """foxcom-forms: no MONGOMS_VERSION in config or scripts."""
     _mock_read.return_value = _load_fixture("foxcom-forms-package.json")
-    assert get_mongo_version("/tmp/clone") is None
+    assert get_mongodb_server_version("/tmp/clone") is None
 
 
-@patch("services.mongoms.get_mongo_version.read_local_file")
+@patch("services.mongoms.get_mongodb_server_version.read_local_file")
 def test_no_package_json(_mock_read):
     """No package.json found."""
     _mock_read.return_value = None
-    assert get_mongo_version("/tmp/clone") is None
+    assert get_mongodb_server_version("/tmp/clone") is None


### PR DESCRIPTION
## Summary
- Removed the mongoms >=8 skip — now constructs `MONGOMS_ARCHIVE_NAME` for ALL mongoms versions (7-11+), not just <8. Even though >=8 auto-detects correctly on AL2023, it still downloads the binary at runtime on every scheduled run. Pre-caching eliminates that latency.
- Added `MONGOMS_MAJOR_TO_MONGODB_VERSION` mapping in `constants/mongoms.py` for repos that don't specify an explicit MongoDB version in package.json.
- Extracted `get_distro_for_mongodb_server_version()` to its own file — returns `amazon2023` for MongoDB 7.0+, `amazon2` for 6.0.x.
- Dynamic `MONGOMS_DISTRO` in `run_jest_test.py` — sets the correct distro per repo based on MongoDB server version instead of hardcoding.
- Future-proofing: unmapped mongoms versions > max known fall back to latest default + Slack notification. Versions < min known are skipped.
- Renamed `get_mongo_version` → `get_mongodb_server_version` everywhere to disambiguate from mongoms package version.
- 20 tests across 3 test files covering all cases.

## GitAuto post
"Works correctly" and "works efficiently" aren't the same thing. MongoMemoryServer >=8 auto-detects fine on Amazon Linux 2023 — but it still downloads a 100MB+ binary on every CI run. We now pre-cache binaries for all versions, cutting runtime latency across 9 repos.
