### PR TITLE
Remove dead LAMBDA_DISTRO and MONGOMS_DISTRO from CodeBuild env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use Lambda base image with Python 3.13 (Amazon Linux 2023). If changing base image, update LAMBDA_DISTRO in constants/aws.py.
+# Use Lambda base image with Python 3.13 (Amazon Linux 2023).
 FROM public.ecr.aws/lambda/python:3.13
 
 # Copy to Lambda root(which is specified in Lambda function, usually /var/task/ directory)

--- a/constants/aws.py
+++ b/constants/aws.py
@@ -2,9 +2,6 @@ import os
 
 AWS_REGION = "us-west-1"
 
-# MongoMemoryServer 7.x misdetects Amazon Linux 2023 as "amazon" (release 2023 > upper bound 3), causing 403 on MongoDB CDN. Versions 9.x+ fixed the detection. Must match the base image in Dockerfile (public.ecr.aws/lambda/python:3.13 = Amazon Linux 2023).
-LAMBDA_DISTRO = "amazon2023"
-
 # S3 bucket for dependency tarballs (node_modules.tar.gz, vendor.tar.gz)
 S3_DEPENDENCY_BUCKET = os.environ.get(
     "S3_DEPENDENCY_BUCKET", "gitauto-dependency-cache"

--- a/services/aws/run_install_via_codebuild.py
+++ b/services/aws/run_install_via_codebuild.py
@@ -1,6 +1,6 @@
 from mypy_boto3_codebuild.type_defs import EnvironmentVariableTypeDef
 
-from constants.aws import LAMBDA_DISTRO, S3_DEPENDENCY_BUCKET
+from constants.aws import S3_DEPENDENCY_BUCKET
 from constants.general import IS_PRD
 from constants.node import FALLBACK_NODE_VERSION
 from services.aws.clients import codebuild_client
@@ -25,8 +25,6 @@ def run_install_via_codebuild(
         {"name": "S3_KEY_PREFIX", "value": s3_key_prefix, "type": "PLAINTEXT"},
         {"name": "PKG_MANAGER", "value": pkg_manager, "type": "PLAINTEXT"},
         {"name": "NODE_VERSION", "value": node_version, "type": "PLAINTEXT"},
-        # MONGOMS_DISTRO: 7.x ignores this env var (not in its config), 9.x+ reads it but auto-detects correctly — safety net
-        {"name": "MONGOMS_DISTRO", "value": LAMBDA_DISTRO, "type": "PLAINTEXT"},
     ]
 
     npm_token = get_npm_token(owner_id)


### PR DESCRIPTION
## Summary
- Removed `LAMBDA_DISTRO` constant from `constants/aws.py` — only consumer was the `MONGOMS_DISTRO` env var passed to CodeBuild, which the buildspec doesn't use
- Removed `MONGOMS_DISTRO` env var override from `run_install_via_codebuild.py` — the buildspec uses Python (`get_mongoms_archive_name`) to derive the archive name dynamically, which already contains the correct distro
- Removed stale Dockerfile cross-reference comment pointing to `LAMBDA_DISTRO`