### PR TITLE
Add forget_messages tool, fix test_files context cleanup

### DIFF
--- a/services/chat_with_agent.py
+++ b/services/chat_with_agent.py
@@ -227,12 +227,14 @@ async def chat_with_agent(
                         or ""
                     )
 
-            # Execute the tool
+            # Execute the tool (messages passed for tools like forget_messages; others absorb via **_kwargs)
             if isinstance(tool_args, dict):
+                # Pop keys we pass explicitly to avoid "got multiple values for keyword argument" TypeError
                 tool_args.pop("base_args", None)
-                tool_result = tools_to_call[tool_name](**tool_args, base_args=base_args)
-            else:
-                tool_result = tools_to_call[tool_name](base_args=base_args)
+                tool_args.pop("messages", None)
+                tool_result = tools_to_call[tool_name](
+                    **tool_args, base_args=base_args, messages=messages
+                )
             if inspect.iscoroutine(tool_result):
                 tool_result = await tool_result
 
@@ -458,6 +460,15 @@ async def chat_with_agent(
             and "new_file_path" in tool_args
         ):
             msg = f"Moved file from `{tool_args['old_file_path']}` to `{tool_args['new_file_path']}`."
+
+        elif tool_name == "forget_messages" and isinstance(tool_args, dict):
+            file_paths = tool_args.get("file_paths", [])
+            count = len(file_paths) if isinstance(file_paths, list) else 0
+            msg = f"Forgot {count} file(s) from context."
+            slack_notify(
+                f"🧪 forget_messages called: {file_paths}",
+                thread_ts=base_args.get("slack_thread_ts"),
+            )
 
         elif not msg:
             msg = f"Calling `{tool_name}()` with `{tool_args}`."

--- a/services/claude/forget_messages.py
+++ b/services/claude/forget_messages.py
@@ -1,0 +1,58 @@
+# Third party imports
+from anthropic.types import MessageParam, ToolUnionParam
+
+# Local imports
+from services.claude.measure_messages_chars import measure_messages_chars
+from services.claude.replace_old_file_content import replace_old_file_content
+from utils.error.handle_exceptions import handle_exceptions
+from utils.logging.logging_config import logger
+
+FORGET_MESSAGES: ToolUnionParam = {
+    "name": "forget_messages",
+    "description": (
+        "Remove file contents from conversation history to save tokens. "
+        "Use after reading reference files for pattern learning: once you've extracted "
+        "the patterns you need, forget the file contents. Does NOT delete files from "
+        "disk - only removes their content from the conversation context."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "file_paths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "List of file paths whose content should be removed from context.",
+            },
+        },
+        "required": ["file_paths"],
+        "additionalProperties": False,
+    },
+    "strict": True,
+}
+
+
+@handle_exceptions(
+    default_return_value="Failed to forget messages.", raise_on_error=False
+)
+def forget_messages(
+    file_paths: list[str],
+    messages: list[MessageParam],
+    **_kwargs,
+):
+    chars_before = measure_messages_chars(messages)
+    count = 0
+    for fp in file_paths:
+        logger.info("Forgetting file content for: %s", fp)
+        replace_old_file_content(messages, fp, is_full_file_read=True)
+        count += 1
+    chars_after = measure_messages_chars(messages)
+    chars_saved = chars_before - chars_after
+    pct = (chars_saved / chars_before * 100) if chars_before else 0
+    logger.info(
+        "forget_messages: removed %d chars out of %d total (%.2g%%, %d remaining)",
+        chars_saved,
+        chars_before,
+        pct,
+        chars_after,
+    )
+    return f"Forgot {count} file(s) from context. Saved {chars_saved:,} chars ({pct:.2g}%, {chars_before:,} → {chars_after:,})."

--- a/services/claude/measure_messages_chars.py
+++ b/services/claude/measure_messages_chars.py
@@ -1,0 +1,22 @@
+# Third party imports
+from anthropic.types import MessageParam
+
+# Local imports
+from utils.error.handle_exceptions import handle_exceptions
+
+
+@handle_exceptions(default_return_value=0, raise_on_error=False)
+def measure_messages_chars(messages: list[MessageParam]):
+    total = 0
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, str):
+            total += len(content)
+            continue
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            total += sum(len(v) for v in block.values() if isinstance(v, str))
+    return total

--- a/services/claude/test_forget_messages.py
+++ b/services/claude/test_forget_messages.py
@@ -1,0 +1,122 @@
+# pyright: reportGeneralTypeIssues=false
+# pyright: reportTypedDictNotRequiredAccess=false
+# pyright: reportIndexIssue=false
+# pyright: reportAssignmentType=false
+import json
+import os
+
+from services.claude.forget_messages import forget_messages
+from services.claude.measure_messages_chars import measure_messages_chars
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+REAL_MESSAGES_PATH = os.path.join(FIXTURES_DIR, "real_verify_messages.json")
+
+
+def load_real_messages():
+    with open(REAL_MESSAGES_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_forget_single_file_from_real_conversation():
+    """Forget .circleci/config.yml (21K chars) from real 86-message conversation."""
+    messages = load_real_messages()
+
+    # Capture before state
+    config_block = messages[39]["content"]
+    assert isinstance(config_block, list)
+    original_content = config_block[0]["content"]
+    assert isinstance(original_content, str)
+    assert original_content.startswith("```.circleci/config.yml")
+    chars_before = measure_messages_chars(messages)
+
+    result = forget_messages(
+        file_paths=[".circleci/config.yml"],
+        messages=messages,
+        base_args={},
+    )
+
+    placeholder = "[Outdated '.circleci/config.yml' content removed]"
+    assert config_block[0]["content"] == placeholder
+    chars_after = measure_messages_chars(messages)
+    chars_saved = chars_before - chars_after
+    pct = chars_saved / chars_before * 100
+    assert (
+        result
+        == f"Forgot 1 file(s) from context. Saved {chars_saved:,} chars ({pct:.2g}%, {chars_before:,} → {chars_after:,})."
+    )
+
+
+def test_forget_multiple_files_preserves_others():
+    """Forget 3 files from real conversation, verify others untouched."""
+    messages = load_real_messages()
+
+    # Capture before state
+    keep_msg_17 = messages[17]["content"][0]["content"]
+    keep_msg_27 = messages[27]["content"][0]["content"]
+    keep_msg_63 = messages[63]["content"][0]["content"]
+    chars_before = measure_messages_chars(messages)
+
+    result = forget_messages(
+        file_paths=["package.json", ".circleci/config.yml", "src/App.test.tsx"],
+        messages=messages,
+        base_args={},
+    )
+
+    chars_after = measure_messages_chars(messages)
+    chars_saved = chars_before - chars_after
+    pct = chars_saved / chars_before * 100
+    assert (
+        result
+        == f"Forgot 3 file(s) from context. Saved {chars_saved:,} chars ({pct:.2g}%, {chars_before:,} → {chars_after:,})."
+    )
+    # Forgotten files replaced
+    assert (
+        messages[13]["content"][0]["content"]
+        == "[Outdated 'package.json' content removed]"
+    )
+    assert (
+        messages[39]["content"][0]["content"]
+        == "[Outdated '.circleci/config.yml' content removed]"
+    )
+    assert (
+        messages[41]["content"][0]["content"]
+        == "[Outdated 'src/App.test.tsx' content removed]"
+    )
+    # Kept files untouched
+    assert messages[17]["content"][0]["content"] == keep_msg_17
+    assert messages[27]["content"][0]["content"] == keep_msg_27
+    assert messages[63]["content"][0]["content"] == keep_msg_63
+
+
+def test_forget_nonexistent_path_no_change():
+    """Forgetting a path not in real messages doesn't modify anything."""
+    messages = load_real_messages()
+    snapshot = json.dumps(messages)
+    chars_before = measure_messages_chars(messages)
+
+    result = forget_messages(
+        file_paths=["src/nonexistent.py"],
+        messages=messages,
+        base_args={},
+    )
+
+    assert (
+        result
+        == f"Forgot 1 file(s) from context. Saved 0 chars (0%, {chars_before:,} → {chars_before:,})."
+    )
+    assert json.dumps(messages) == snapshot
+
+
+def test_forget_empty_list_no_change():
+    """Forgetting zero files from real messages changes nothing."""
+    messages = load_real_messages()
+    snapshot = json.dumps(messages)
+    chars_before = measure_messages_chars(messages)
+
+    result = forget_messages(file_paths=[], messages=messages, base_args={})
+
+    assert (
+        result
+        == f"Forgot 0 file(s) from context. Saved 0 chars (0%, {chars_before:,} → {chars_before:,})."
+    )
+    assert json.dumps(messages) == snapshot

--- a/services/claude/test_measure_messages_chars.py
+++ b/services/claude/test_measure_messages_chars.py
@@ -1,0 +1,48 @@
+# pyright: reportGeneralTypeIssues=false
+# pyright: reportTypedDictNotRequiredAccess=false
+# pyright: reportIndexIssue=false
+# pyright: reportAssignmentType=false
+import json
+import os
+
+from services.claude.measure_messages_chars import measure_messages_chars
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+REAL_MESSAGES_PATH = os.path.join(FIXTURES_DIR, "real_verify_messages.json")
+
+
+def load_real_messages():
+    with open(REAL_MESSAGES_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_measure_real_conversation():
+    """Real 86-message conversation total chars."""
+    messages = load_real_messages()
+
+    result = measure_messages_chars(messages)
+
+    assert result == 505094
+
+
+def test_measure_empty():
+    """Empty message list returns 0."""
+    assert measure_messages_chars([]) == 0
+
+
+def test_measure_after_forgetting_is_exact_diff():
+    """After replacing a file read with placeholder, diff equals original - placeholder."""
+    messages = load_real_messages()
+    chars_before = measure_messages_chars(messages)
+
+    # Replace .circleci/config.yml with placeholder
+    config_block = messages[39]["content"]
+    assert isinstance(config_block, list)
+    original_content = config_block[0]["content"]
+    assert original_content.startswith("```.circleci/config.yml")
+    placeholder = "[Outdated '.circleci/config.yml' content removed]"
+    config_block[0]["content"] = placeholder
+
+    chars_after = measure_messages_chars(messages)
+
+    assert chars_before - chars_after == len(original_content) - len(placeholder)

--- a/services/claude/tools/tools.py
+++ b/services/claude/tools/tools.py
@@ -9,6 +9,7 @@ from services.agents.verify_task_is_complete import (
     VERIFY_TASK_IS_COMPLETE,
     verify_task_is_complete,
 )
+from services.claude.forget_messages import FORGET_MESSAGES, forget_messages
 from services.http.curl import CURL, curl
 from services.http.web_fetch import WEB_FETCH, web_fetch
 from services.env.set_env import SET_ENV, set_env
@@ -66,6 +67,7 @@ _TOOLS_BASE: list[ToolUnionParam] = [
     CREATE_DIRECTORY,
     CURL,
     DELETE_FILE,
+    FORGET_MESSAGES,
     GIT_REVERT_FILE,
     GET_LOCAL_FILE_TREE,
     MOVE_FILE,
@@ -115,6 +117,7 @@ tools_to_call: dict[str, Any] = {
     "create_directory": create_directory,
     "curl": curl,
     "delete_file": delete_file,
+    "forget_messages": forget_messages,
     "git_revert_file": git_revert_file,
     "get_local_file_content": get_local_file_content,
     "get_local_file_tree": get_local_file_tree,

--- a/services/webhook/new_pr_handler.py
+++ b/services/webhook/new_pr_handler.py
@@ -276,7 +276,10 @@ async def handle_new_pr(
         )
         file_path, content = get_remote_file_content_by_url(url=url, token=token)
         logger.info("```%s\n%s```\n", url, content)
-        reference_files[file_path] = content
+        if file_path and content:
+            reference_files[file_path] = format_content_with_line_numbers(
+                file_path=file_path, content=content
+            )
 
     today = datetime.now().strftime("%Y-%m-%d")
 
@@ -447,7 +450,8 @@ async def handle_new_pr(
         if target_dir_files:
             user_input_obj["target_dir_files"] = target_dir_files
     if test_files:
-        user_input_obj["test_files"] = test_files
+        # list() needed: dict_keys is not JSON serializable; content is in separate messages
+        user_input_obj["test_files_included"] = list(test_files.keys())
     if remaining_test_paths:
         user_input_obj["test_file_paths"] = remaining_test_paths
     if not test_files and not remaining_test_paths:
@@ -486,10 +490,12 @@ async def handle_new_pr(
             file_path=impl_file_path, content=impl_file_content
         )
         messages.append({"role": "user", "content": formatted_impl})
-    for path, c in reference_files.items():
+    for path, content in test_files.items():
+        messages.append({"role": "user", "content": content})
+    for path, content in reference_files.items():
         if path == impl_file_path:
             continue
-        messages.append({"role": "user", "content": c})
+        messages.append({"role": "user", "content": content})
 
     # Validate files for syntax issues before editing
     files_to_validate = list(

--- a/services/webhook/test_new_pr_handler.py
+++ b/services/webhook/test_new_pr_handler.py
@@ -1802,13 +1802,20 @@ async def test_few_test_files_include_contents_in_prompt(
 
     await handle_new_pr(payload=payload, trigger="dashboard")
 
-    # Verify test_files contents are included in the prompt (not just paths)
+    # Verify test file paths listed in JSON and contents as separate messages
     call_kwargs = mock_chat_with_agent.call_args.kwargs
     messages = call_kwargs["messages"]
     user_input = json.loads(messages[0]["content"])
-    assert "test_files" in user_input
+    assert "test_files_included" in user_input
+    assert len(user_input["test_files_included"]) == 3
     assert "test_file_paths" not in user_input
-    assert len(user_input["test_files"]) == 3
+    # Test file contents should be separate messages in ```path format
+    test_file_msgs = [
+        m
+        for m in messages[1:]
+        if isinstance(m["content"], str) and m["content"].startswith("```tests/")
+    ]
+    assert len(test_file_msgs) == 3
 
 
 @pytest.mark.asyncio
@@ -1941,13 +1948,20 @@ async def test_many_test_files_include_paths_only_in_prompt(
 
     await handle_new_pr(payload=payload, trigger="dashboard")
 
-    # Verify top 5 test files have contents and remaining 2 are paths-only
+    # Verify top 5 test files have paths in JSON and contents as separate messages
     call_kwargs = mock_chat_with_agent.call_args.kwargs
     messages = call_kwargs["messages"]
     user_input = json.loads(messages[0]["content"])
-    assert "test_files" in user_input
-    assert len(user_input["test_files"]) == 5
+    assert "test_files_included" in user_input
+    assert len(user_input["test_files_included"]) == 5
     assert "test_file_paths" in user_input
     assert len(user_input["test_file_paths"]) == 2
+    # Test file contents should be separate messages in ```path format
+    test_file_msgs = [
+        m
+        for m in messages[1:]
+        if isinstance(m["content"], str) and m["content"].startswith("```tests/")
+    ]
+    assert len(test_file_msgs) == 5
     # read_local_file called: 1 for impl file + 5 for top test files = 6
     assert mock_read_local_file.call_count == 6


### PR DESCRIPTION
Move test file contents from JSON to separate user messages in ```path format so replace_old_file_content can clean them up. Add forget_messages tool that lets the model remove reference file contents from context after pattern learning. Wrap reference files with format_content_with_line_numbers for the same cleanup path. Pass messages to all tool calls so forget_messages can mutate context in-place.

## Social Media Post (GitAuto)
Added a forget_messages tool that lets the AI agent drop file contents from its context after learning patterns from them. Reference files were persisting for 30+ turns, burning input tokens every call. Experimental, but the math checks out.

## Social Media Post (Wes)
Built a tool that lets the agent forget file contents after reading them. Every morning I check Claude invoices and wonder why reference files sit in context for 30+ turns. Now the agent can read, learn, and drop. Will see if it works.