### PR TITLE
Reduce SNS delay and exclude .github from test triggers

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -7,11 +7,13 @@ on:
     paths:
       - "**/*.mjs"
       - "**/*.js"
+      - "!.github/**"
   push:
     branches: [main]
     paths:
       - "**/*.mjs"
       - "**/*.js"
+      - "!.github/**"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Reduced `post-twitter.js` random delay from 5-60 seconds to 5-15 seconds to save GitHub Actions runner minutes
- Excluded `.github/**` from `node-test.yml` paths trigger so CI scripts don't run node tests
- Updated CLAUDE.md with blog cover image requirements and social media post format docs