### PR TITLE
Use background_tasks for retarget_pr endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -195,7 +195,7 @@ async def api_sync_files_from_github_to_coverage(
     background_tasks: BackgroundTasks,
     api_key: str = Header(..., alias="X-API-Key"),
 ):
-    """Sync repository files from local clone to coverage database. Returns immediately, runs in background."""
+    """Sync repository files from local clone to coverage database. Returns immediately via background_tasks.add_task."""
     background_tasks.add_task(
         sync_files_from_github_to_coverage,
         owner=owner,
@@ -220,8 +220,10 @@ async def api_retarget_pr(
     owner: str,
     repo: str,
     body: RetargetRequest,
+    background_tasks: BackgroundTasks,
     api_key: str = Header(..., alias="X-API-Key"),
 ):
+    """Retarget a PR to a new base branch. Returns immediately via background_tasks.add_task."""
     verify_api_key(api_key)
     set_request_id(str(uuid4()))
     set_owner_repo(owner, repo)
@@ -229,7 +231,8 @@ async def api_retarget_pr(
     set_trigger("retarget")
 
     token = get_installation_access_token(installation_id=body.installation_id)
-    retarget_pr(
+    background_tasks.add_task(
+        retarget_pr,
         owner_name=owner,
         repo_name=repo,
         token=token,

--- a/test_main.py
+++ b/test_main.py
@@ -22,6 +22,7 @@ from main import (
     handle_webhook,
     handler,
     root,
+    api_retarget_pr,
     api_sync_files_from_github_to_coverage,
 )
 from payloads.aws.event_bridge_scheduler.event_types import EventBridgeSchedulerEvent
@@ -858,6 +859,36 @@ class TestTypeAnnotations:
 
         assert isinstance(result, dict)
         assert all(isinstance(k, str) for k in result.keys())
+
+
+class TestApiRetargetPr:
+    @patch("main.retarget_pr")
+    @patch("main.get_installation_access_token", return_value="fake-token")
+    @pytest.mark.asyncio
+    async def test_api_retarget_pr_uses_background_task(
+        self, mock_get_token, mock_retarget
+    ):
+        mock_background_tasks = MagicMock()
+
+        result = await api_retarget_pr(
+            owner="test-owner",
+            repo="test-repo",
+            body=MagicMock(
+                installation_id=123, new_base_branch="develop", pr_number=42
+            ),
+            background_tasks=mock_background_tasks,
+            api_key="test-api-key",
+        )
+
+        mock_background_tasks.add_task.assert_called_once()
+        call_kwargs = mock_background_tasks.add_task.call_args.kwargs
+        assert call_kwargs["owner_name"] == "test-owner"
+        assert call_kwargs["repo_name"] == "test-repo"
+        assert call_kwargs["token"] == "fake-token"
+        assert call_kwargs["new_base_branch"] == "develop"
+        assert call_kwargs["pr_number"] == 42
+        assert call_kwargs["installation_id"] == 123
+        assert result == {"status": "processing"}
 
 
 class TestApiSyncFilesFromGithubToCoverage:


### PR DESCRIPTION
## Summary

- Changed `api_retarget_pr` endpoint to use `background_tasks.add_task` so it returns immediately instead of blocking for ~50s per PR (API Gateway 30s timeout)
- Added identical docstrings to both background task endpoints explaining the pattern
- Added test verifying `background_tasks.add_task` is called with correct args