### PR TITLE
Add query_file tool and improve context placeholders

### DIFF
--- a/services/chat_with_agent.py
+++ b/services/chat_with_agent.py
@@ -470,6 +470,13 @@ async def chat_with_agent(
                 thread_ts=base_args.get("slack_thread_ts"),
             )
 
+        elif tool_name == "query_file" and isinstance(tool_args, dict):
+            msg = f"Queried `{tool_args.get('file_path', '')}`."
+            slack_notify(
+                f"🧪 query_file: {tool_args.get('file_path', '')}",
+                thread_ts=base_args.get("slack_thread_ts"),
+            )
+
         elif not msg:
             msg = f"Calling `{tool_name}()` with `{tool_args}`."
 

--- a/services/claude/forget_messages.py
+++ b/services/claude/forget_messages.py
@@ -43,7 +43,12 @@ def forget_messages(
     count = 0
     for fp in file_paths:
         logger.info("Forgetting file content for: %s", fp)
-        replace_old_file_content(messages, fp, is_full_file_read=True)
+        replace_old_file_content(
+            messages,
+            fp,
+            is_full_file_read=True,
+            reason="agent already extracted needed patterns",
+        )
         count += 1
     chars_after = measure_messages_chars(messages)
     chars_saved = chars_before - chars_after

--- a/services/claude/query_file.py
+++ b/services/claude/query_file.py
@@ -1,0 +1,67 @@
+# Third party imports
+from anthropic.types import ToolUnionParam
+
+# Local imports
+from constants.claude import ClaudeModelId
+from services.claude.chat_with_claude_simple import chat_with_claude_simple
+from utils.error.handle_exceptions import handle_exceptions
+from utils.files.read_local_file import read_local_file
+from utils.formatting.format_with_line_numbers import format_content_with_line_numbers
+from utils.logging.logging_config import logger
+
+QUERY_FILE: ToolUnionParam = {
+    "name": "query_file",
+    "description": (
+        "Ask a question about a file without loading its full content into context. "
+        "The file is read by a faster model that returns only the answer. "
+        "Use when you need to know something ABOUT a file (patterns, conventions, "
+        "framework, structure) but don't need the exact code for editing. "
+        "Use get_local_file_content instead when you need exact code to edit."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "file_path": {
+                "type": "string",
+                "description": "File path relative to the repository root.",
+            },
+            "prompt": {
+                "type": "string",
+                "description": "What to find out about the file. Be specific.",
+            },
+        },
+        "required": ["file_path", "prompt"],
+        "additionalProperties": False,
+    },
+    "strict": True,
+}
+
+
+@handle_exceptions(default_return_value="Failed to query file.", raise_on_error=False)
+def query_file(file_path: str, prompt: str, base_args: dict, **_kwargs):
+    usage_id = base_args.get("usage_id", 0)
+    clone_dir = base_args.get("clone_dir", "")
+
+    content = read_local_file(file_path=file_path, base_dir=clone_dir)
+    if content is None:
+        return f"File not found: '{file_path}'. Check the file path and try again."
+
+    formatted = format_content_with_line_numbers(file_path=file_path, content=content)
+    file_chars = len(formatted)
+
+    logger.info("query_file: sending %d chars of '%s' to Haiku", file_chars, file_path)
+    answer = chat_with_claude_simple(
+        system_input=f"You are analyzing the file '{file_path}'. Answer the question based only on the file content.",
+        user_input=f"{formatted}\n\n---\n\n{prompt}",
+        usage_id=usage_id,
+        model_id=ClaudeModelId.HAIKU_4_5,
+    )
+
+    answer_chars = len(answer) if answer else 0
+    logger.info(
+        "query_file: got %d char answer for %d char file '%s'",
+        answer_chars,
+        file_chars,
+        file_path,
+    )
+    return answer

--- a/services/claude/remove_outdated_file_edit_attempts.py
+++ b/services/claude/remove_outdated_file_edit_attempts.py
@@ -252,7 +252,9 @@ def remove_outdated_file_edit_attempts(
                 new_item = dict(item)
                 new_input = dict(input_data)
                 if "file_content" in new_input:
-                    new_input["file_content"] = "[Outdated file content removed]"
+                    new_input["file_content"] = (
+                        "[file content removed because file was re-read or edited]"
+                    )
                 new_item["input"] = new_input
                 new_content.append(new_item)
                 continue

--- a/services/claude/replace_old_file_content.py
+++ b/services/claude/replace_old_file_content.py
@@ -13,14 +13,18 @@ def is_tool_result(item: object) -> TypeGuard[ToolResultBlockParam]:
 
 @handle_exceptions(default_return_value=None, raise_on_error=False)
 def replace_old_file_content(
-    messages: list[MessageParam], identifier: str, is_full_file_read: bool
+    messages: list[MessageParam],
+    identifier: str,
+    is_full_file_read: bool,
+    reason: str = "file was re-read or edited",
 ):
     """Replace old file content with placeholder.
 
     - Full file read (is_full_file_read=True): identifier is file_path, removes ALL content
     - Partial read (is_full_file_read=False): identifier is file_path#L10-L20, removes exact match only
+    - reason: why the content was removed, shown in placeholder
     """
-    placeholder = f"[Outdated '{identifier}' content removed]"
+    placeholder = f"['{identifier}' content removed because {reason}]"
 
     for msg in messages:
         # Skip assistant messages (file content only appears in user messages)

--- a/services/claude/test_forget_messages.py
+++ b/services/claude/test_forget_messages.py
@@ -35,7 +35,7 @@ def test_forget_single_file_from_real_conversation():
         base_args={},
     )
 
-    placeholder = "[Outdated '.circleci/config.yml' content removed]"
+    placeholder = "['.circleci/config.yml' content removed because agent already extracted needed patterns]"
     assert config_block[0]["content"] == placeholder
     chars_after = measure_messages_chars(messages)
     chars_saved = chars_before - chars_after
@@ -72,15 +72,15 @@ def test_forget_multiple_files_preserves_others():
     # Forgotten files replaced
     assert (
         messages[13]["content"][0]["content"]
-        == "[Outdated 'package.json' content removed]"
+        == "['package.json' content removed because agent already extracted needed patterns]"
     )
     assert (
         messages[39]["content"][0]["content"]
-        == "[Outdated '.circleci/config.yml' content removed]"
+        == "['.circleci/config.yml' content removed because agent already extracted needed patterns]"
     )
     assert (
         messages[41]["content"][0]["content"]
-        == "[Outdated 'src/App.test.tsx' content removed]"
+        == "['src/App.test.tsx' content removed because agent already extracted needed patterns]"
     )
     # Kept files untouched
     assert messages[17]["content"][0]["content"] == keep_msg_17

--- a/services/claude/test_measure_messages_chars.py
+++ b/services/claude/test_measure_messages_chars.py
@@ -40,7 +40,9 @@ def test_measure_after_forgetting_is_exact_diff():
     assert isinstance(config_block, list)
     original_content = config_block[0]["content"]
     assert original_content.startswith("```.circleci/config.yml")
-    placeholder = "[Outdated '.circleci/config.yml' content removed]"
+    placeholder = (
+        "['.circleci/config.yml' content removed because file was re-read or edited]"
+    )
     config_block[0]["content"] = placeholder
 
     chars_after = measure_messages_chars(messages)

--- a/services/claude/test_query_file.py
+++ b/services/claude/test_query_file.py
@@ -1,0 +1,60 @@
+# pyright: reportCallIssue=false
+import os
+from unittest.mock import patch
+
+from services.claude.query_file import query_file
+
+# Use this repo's own file as test input
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+REAL_FILE = "services/claude/query_file.py"
+
+
+def make_base_args(clone_dir: str = REPO_ROOT):
+    return {"clone_dir": clone_dir, "usage_id": 0}
+
+
+@patch("services.claude.query_file.chat_with_claude_simple")
+def test_query_file_returns_haiku_answer(mock_haiku):
+    """Valid file sends content to Haiku and returns its answer."""
+    mock_haiku.return_value = "This file defines a query_file tool for GitAuto."
+
+    result = query_file(
+        file_path=REAL_FILE,
+        prompt="What does this file do?",
+        base_args=make_base_args(),
+    )
+
+    assert result == "This file defines a query_file tool for GitAuto."
+    mock_haiku.assert_called_once()
+    call_kwargs = mock_haiku.call_args
+    assert REAL_FILE in call_kwargs.kwargs["user_input"]
+    assert "What does this file do?" in call_kwargs.kwargs["user_input"]
+
+
+def test_query_file_nonexistent_returns_error():
+    """Nonexistent file returns error without calling Haiku."""
+    result = query_file(
+        file_path="nonexistent/file.py",
+        prompt="anything",
+        base_args=make_base_args(),
+    )
+
+    assert (
+        result
+        == "File not found: 'nonexistent/file.py'. Check the file path and try again."
+    )
+
+
+@patch("services.claude.query_file.chat_with_claude_simple")
+def test_query_file_passes_haiku_model(mock_haiku):
+    """Verifies Haiku 4.5 model is used, not the default Sonnet."""
+    mock_haiku.return_value = "answer"
+
+    query_file(
+        file_path=REAL_FILE,
+        prompt="test",
+        base_args=make_base_args(),
+    )
+
+    call_kwargs = mock_haiku.call_args.kwargs
+    assert call_kwargs["model_id"] == "claude-haiku-4-5"

--- a/services/claude/test_remove_outdated_file_edit_attempts.py
+++ b/services/claude/test_remove_outdated_file_edit_attempts.py
@@ -1567,7 +1567,7 @@ def test_write_and_commit_file_input_stripped_when_outdated():
     # First write_and_commit input: stripped
     assert (
         result[0]["content"][0]["input"]["file_content"]
-        == "[Outdated file content removed]"
+        == "[file content removed because file was re-read or edited]"
     )
     # First tool_result: stripped
     assert (

--- a/services/claude/test_replace_old_file_content.py
+++ b/services/claude/test_replace_old_file_content.py
@@ -26,7 +26,10 @@ def test_replace_old_file_content_replaces_matching_file():
 
     content = messages[0]["content"]
     assert isinstance(content, list)
-    assert content[0]["content"] == "[Outdated 'src/main.py' content removed]"
+    assert (
+        content[0]["content"]
+        == "['src/main.py' content removed because file was re-read or edited]"
+    )
 
 
 def test_replace_old_file_content_no_change_when_different_file():
@@ -81,7 +84,10 @@ def test_replace_old_file_content_replaces_string_content():
 
     replace_old_file_content(messages, "src/main.py", is_full_file_read=True)
 
-    assert messages[0]["content"] == "[Outdated 'src/main.py' content removed]"
+    assert (
+        messages[0]["content"]
+        == "['src/main.py' content removed because file was re-read or edited]"
+    )
 
 
 def test_replace_old_file_content_string_no_change_when_different_file():
@@ -147,7 +153,10 @@ def test_replace_old_file_content_handles_multiple_tool_results():
 
     content = messages[0]["content"]
     assert isinstance(content, list)
-    assert content[0]["content"] == "[Outdated 'src/main.py' content removed]"
+    assert (
+        content[0]["content"]
+        == "['src/main.py' content removed because file was re-read or edited]"
+    )
     assert content[1]["content"] == "```src/other.py\n1\tprint('other')\n```"
 
 
@@ -182,8 +191,14 @@ def test_replace_old_file_content_replaces_all_occurrences():
     content_2 = messages[2]["content"]
     assert isinstance(content_0, list)
     assert isinstance(content_2, list)
-    assert content_0[0]["content"] == "[Outdated 'src/main.py' content removed]"
-    assert content_2[0]["content"] == "[Outdated 'src/main.py' content removed]"
+    assert (
+        content_0[0]["content"]
+        == "['src/main.py' content removed because file was re-read or edited]"
+    )
+    assert (
+        content_2[0]["content"]
+        == "['src/main.py' content removed because file was re-read or edited]"
+    )
 
 
 def test_replace_old_file_content_handles_empty_messages():
@@ -283,7 +298,10 @@ def test_partial_read_only_removes_exact_match():
 
     content = messages[0]["content"]
     assert isinstance(content, list)
-    assert content[0]["content"] == "[Outdated 'src/main.py#L10-L20' content removed]"
+    assert (
+        content[0]["content"]
+        == "['src/main.py#L10-L20' content removed because file was re-read or edited]"
+    )
 
 
 def test_partial_read_does_not_remove_different_range():
@@ -342,8 +360,14 @@ def test_full_read_removes_partial_reads():
     content_1 = messages[1]["content"]
     assert isinstance(content_0, list)
     assert isinstance(content_1, list)
-    assert content_0[0]["content"] == "[Outdated 'src/main.py' content removed]"
-    assert content_1[0]["content"] == "[Outdated 'src/main.py' content removed]"
+    assert (
+        content_0[0]["content"]
+        == "['src/main.py' content removed because file was re-read or edited]"
+    )
+    assert (
+        content_1[0]["content"]
+        == "['src/main.py' content removed because file was re-read or edited]"
+    )
 
 
 def test_partial_read_preserves_different_file_same_lines():

--- a/services/claude/tools/tools.py
+++ b/services/claude/tools/tools.py
@@ -10,6 +10,7 @@ from services.agents.verify_task_is_complete import (
     verify_task_is_complete,
 )
 from services.claude.forget_messages import FORGET_MESSAGES, forget_messages
+from services.claude.query_file import QUERY_FILE, query_file
 from services.http.curl import CURL, curl
 from services.http.web_fetch import WEB_FETCH, web_fetch
 from services.env.set_env import SET_ENV, set_env
@@ -71,6 +72,7 @@ _TOOLS_BASE: list[ToolUnionParam] = [
     GIT_REVERT_FILE,
     GET_LOCAL_FILE_TREE,
     MOVE_FILE,
+    QUERY_FILE,
     SEARCH_AND_REPLACE,
     SEARCH_LOCAL_FILE_CONTENT,
     # SEARCH_WEB disabled: DDG CAPTCHAs bots. Use paid API (e.g. Brave Search) if needed.
@@ -122,6 +124,7 @@ tools_to_call: dict[str, Any] = {
     "get_local_file_content": get_local_file_content,
     "get_local_file_tree": get_local_file_tree,
     "move_file": move_file,
+    "query_file": query_file,
     "reply_to_review_comment": reply_to_comment,
     "reset_pr_branch_to_new_base": reset_pr_branch_to_new_base,
     "search_and_replace": search_and_replace,


### PR DESCRIPTION
## Summary
- Add `query_file` tool: reads file via Haiku and returns only the answer, avoiding full file content in Opus context. Same pattern as `web_fetch` but for local files.
- Add `reason` parameter to `replace_old_file_content` so placeholders explain why content was removed (e.g., "agent already extracted needed patterns" for forget_messages vs "file was re-read or edited" for stale replacements).

## Social Media Post (GitAuto)

Most agent frameworks load entire files into context even when the agent only needs a quick answer like "what test framework?" Added a query_file tool that routes file reads through Haiku first, so only the answer enters the main model's context. Input tokens are 95% of our costs so this matters.

## Social Media Post (Wes)

Added query_file to GitAuto. Instead of loading a 15K char file into Opus context just to learn "they use pytest," Haiku reads the file and returns a 200 char answer. Costs $0.004 instead of building up across 45 turns. Will see how the agent uses it.