### PR TITLE
Add MongoMemoryServer SIGABRT to infra failure detection

### DIFF
--- a/utils/logs/detect_infra_failure.py
+++ b/utils/logs/detect_infra_failure.py
@@ -22,6 +22,9 @@ INFRA_FAILURE_PATTERNS = [
     "out of memory",
     "exit code 137",
     "ENOMEM",
+    # MongoMemoryServer binary crash (version/distro mismatch with cached S3 binary)
+    "MongoMemoryServer Instance failed",
+    'signal "SIGABRT"',
 ]
 
 

--- a/utils/logs/test_detect_infra_failure.py
+++ b/utils/logs/test_detect_infra_failure.py
@@ -64,6 +64,17 @@ def test_detect_infra_failure_real_segfault_log():
         ),
         ("bash: line 1: 12345 Killed (exit code 137)", "exit code 137"),
         ("Cannot allocate memory (errno: ENOMEM)", "ENOMEM"),
+        # MongoMemoryServer binary crash
+        (
+            "Starting the MongoMemoryServer Instance failed, enable debug log for more information. Error:\n"
+            ' UnexpectedCloseError: Instance closed unexpectedly with code "null" and signal "SIGABRT"',
+            "MongoMemoryServer Instance failed",
+        ),
+        (
+            'Instance closed unexpectedly with code "null" and signal "SIGABRT"\n'
+            "    at ChildProcess.emit (node:events:519:28)",
+            'signal "SIGABRT"',
+        ),
     ],
     ids=[
         "yarn_502",
@@ -78,6 +89,8 @@ def test_detect_infra_failure_real_segfault_log():
         "oom_js_heap",
         "exit_code_137",
         "enomem",
+        "mongoms_instance_failed",
+        "sigabrt",
     ],
 )
 def test_detect_infra_failure_matches(error_log, expected):


### PR DESCRIPTION
## Summary

- Add `MongoMemoryServer Instance failed` and `signal "SIGABRT"` to `INFRA_FAILURE_PATTERNS`
- Prevents the agent from spinning on unfixable MongoMemoryServer binary crashes (version/distro mismatch with cached S3 binary)

## Social Media Post (GitAuto)

When MongoMemoryServer's cached binary crashes with SIGABRT on CI, there's nothing the AI agent can do about it. Now we detect it early and stop instead of burning tokens retrying.

## Social Media Post (Wes)

MongoMemoryServer downloads a nightly mongod binary if the cached one is missing. That nightly can crash with SIGABRT on certain distros. Added pattern detection so the agent stops immediately instead of looping for 30 turns trying to fix an infra problem.