### PR TITLE
Fix reply_to_comment 404 for pr_comment subject type

### DIFF
--- a/services/github/comments/reply_to_comment.py
+++ b/services/github/comments/reply_to_comment.py
@@ -39,9 +39,10 @@ def reply_to_comment(base_args: ReviewBaseArgs, body: str, **_kwargs):
             f"pr_number is required for reply_to_comment but got: {pr_number}"
         )
 
-    # PR-level reviews (no file path) use the issue comments API, not the inline comment reply API
+    # PR-level comments (no file path) use the issue comments API, not the inline comment reply API
+    # "pr_review" = PR-level review, "pr_comment" = general PR comment (adapted from issue_comment)
     review_subject_type = base_args.get("review_subject_type")
-    if review_subject_type == "pr_review":
+    if review_subject_type in ("pr_review", "pr_comment"):
         url = f"{GITHUB_API_URL}/repos/{owner}/{repo}/issues/{pr_number}/comments"
     else:
         if not comment_id:

--- a/services/github/comments/test_reply_to_comment.py
+++ b/services/github/comments/test_reply_to_comment.py
@@ -429,6 +429,33 @@ def test_pr_review_uses_issue_comments_api(mock_post_response, mock_create_heade
         )
 
 
+def test_pr_comment_uses_issue_comments_api(mock_post_response, mock_create_headers):
+    """Test that review_subject_type='pr_comment' (adapted from issue_comment) uses the issue comments API."""
+    base_args = {
+        "owner": "test-owner",
+        "repo": "test-repo",
+        "token": "test-token",
+        "pr_number": 123,
+        "review_id": 789,
+        "review_subject_type": "pr_comment",
+    }
+
+    with patch("services.github.comments.reply_to_comment.requests.post") as mock_post:
+        mock_post.return_value = mock_post_response
+
+        # Intentionally passing partial dict to test runtime behavior
+        reply_to_comment(
+            base_args, "PR comment reply"  # pyright: ignore[reportArgumentType]
+        )
+
+        mock_post.assert_called_once()
+        call_url = mock_post.call_args[1]["url"]
+        assert (
+            call_url
+            == "https://api.github.com/repos/test-owner/test-repo/issues/123/comments"
+        )
+
+
 def test_inline_review_without_review_id_returns_none(mock_create_headers):
     """Test that inline review (not pr_review) without review_id returns None via error handler."""
     base_args = {


### PR DESCRIPTION
## Summary

- Fix `reply_to_comment` 404: `pr_comment` subject type (adapted from `issue_comment` webhook) was falling into the inline review reply API (`/pulls/{pr}/comments/{id}/replies`) instead of the issue comments API (`/issues/{pr}/comments`), causing 404 errors when the agent tried to respond to PR-level comments
- Add `MongoMemoryServer Instance failed` and `SIGABRT` to infra failure detection patterns

## Social Media Post (GitAuto)

Found a subtle routing bug. When someone leaves a general comment on a PR (not on a specific line), our agent tried to reply using the wrong GitHub API endpoint, getting 404s every time. One character class difference in the webhook payload (pr_comment vs pr_review) and the reply goes to a completely different API.
