### PR TITLE
Fix transitive dep detection for MongoMemoryServer binary caching

### DIFF
--- a/services/node/get_dependency_major_version.py
+++ b/services/node/get_dependency_major_version.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from utils.error.handle_exceptions import handle_exceptions
 from utils.files.read_local_file import read_local_file
@@ -23,7 +24,23 @@ def get_dependency_major_version(clone_dir: str, package_name: str):
         version_spec = deps.get(package_name)
         if not isinstance(version_spec, str) or not version_spec:
             continue
+        logger.info("%s %s found in %s", package_name, version_spec, deps_key)
         return int(version_spec.lstrip("^~>=< ").split(".")[0])
 
-    logger.info("%s not found in package.json dependencies", package_name)
+    # Check transitive dep: package may be pulled in by another dep (e.g. mongodb-memory-server via @shelf/jest-mongodb)
+    transitive_pkg_path = os.path.join("node_modules", package_name, "package.json")
+    transitive_content = read_local_file(transitive_pkg_path, base_dir=clone_dir)
+    if transitive_content:
+        transitive_pkg = json.loads(transitive_content)
+        if isinstance(transitive_pkg, dict):
+            version_spec = transitive_pkg.get("version")
+            if isinstance(version_spec, str) and version_spec:
+                logger.info(
+                    "%s %s found as transitive dep in node_modules",
+                    package_name,
+                    version_spec,
+                )
+                return int(version_spec.split(".")[0])
+
+    logger.info("%s not found in package.json or node_modules", package_name)
     return None

--- a/services/node/test_get_dependency_major_version.py
+++ b/services/node/test_get_dependency_major_version.py
@@ -43,7 +43,8 @@ def test_returns_none_when_no_package_json():
 def test_returns_none_when_package_not_found():
     pkg = json.dumps({"devDependencies": {"prettier": "^3.0.0"}})
     with patch(
-        "services.node.get_dependency_major_version.read_local_file", return_value=pkg
+        "services.node.get_dependency_major_version.read_local_file",
+        side_effect=[pkg, None],
     ):
         assert get_dependency_major_version("/clone", "eslint") is None
 
@@ -62,3 +63,23 @@ def test_strips_semver_prefixes():
         "services.node.get_dependency_major_version.read_local_file", return_value=pkg
     ):
         assert get_dependency_major_version("/clone", "eslint") == 9
+
+
+def test_finds_transitive_dep_in_node_modules():
+    # mongodb-memory-server is not in package.json but installed via @shelf/jest-mongodb
+    root_pkg = json.dumps({"devDependencies": {"@shelf/jest-mongodb": "^4.1.0"}})
+    transitive_pkg = json.dumps({"name": "mongodb-memory-server", "version": "9.2.0"})
+    with patch(
+        "services.node.get_dependency_major_version.read_local_file",
+        side_effect=[root_pkg, transitive_pkg],
+    ):
+        assert get_dependency_major_version("/clone", "mongodb-memory-server") == 9
+
+
+def test_returns_none_when_transitive_dep_also_missing():
+    root_pkg = json.dumps({"devDependencies": {"jest": "^29.0.0"}})
+    with patch(
+        "services.node.get_dependency_major_version.read_local_file",
+        side_effect=[root_pkg, None],
+    ):
+        assert get_dependency_major_version("/clone", "mongodb-memory-server") is None


### PR DESCRIPTION
## Summary

- `get_dependency_major_version` now falls back to `node_modules/<package>/package.json` when the package isn't in root `package.json`
- Fixes: `mongodb-memory-server` (transitive dep via `@shelf/jest-mongodb`) was undetected, so `MONGOMS_ARCHIVE_NAME` was never set, so CodeBuild never cached the binary, so Lambda downloaded a nightly `v8.0-latest` that crashed with SIGABRT

## Social Media Post (GitAuto)

A transitive npm dependency was invisible to our version detection. It only checked package.json directly, missing packages pulled in by other packages. The fix: fall back to reading node_modules when the direct lookup fails. Simple, but it broke our entire MongoDB binary caching pipeline.
