### PR TITLE
Add bot PR comment relevance check and loop prevention

### DIFF
--- a/services/webhook/review_run_handler.py
+++ b/services/webhook/review_run_handler.py
@@ -25,6 +25,7 @@ from services.git.clone_repo_and_install_dependencies import (
 )
 from services.git.git_merge_base_into_pr import git_merge_base_into_pr
 from services.github.comments.create_comment import create_comment
+from services.github.comments.get_all_comments import get_all_comments
 from services.github.commits.get_head_commit_count_behind_base import (
     get_head_commit_count_behind_base,
 )
@@ -142,8 +143,37 @@ async def handle_review_run(
         if summary_body and summary_body.strip():
             review_summary = summary_body
 
-    # For inline review comments, get thread context and check resolved status
+    # For PR-level comments (no file path), check bot relevance and loop prevention
+    bot_pr_files = None
     if not review_path:
+        if review_author_is_bot:
+            # Check if bot comment mentions any PR file paths (skip irrelevant bot comments like Security Hub scans)
+            bot_pr_files = get_pull_request_files(
+                owner=owner_name, repo=repo_name, pr_number=pr_number, token=token
+            )
+            pr_file_paths = [f["filename"] for f in bot_pr_files]
+            mentions_pr_file = any(path in review_body for path in pr_file_paths)
+            if not mentions_pr_file:
+                logger.info(
+                    "Ignoring bot PR comment from %s - does not mention any PR file paths: %s",
+                    review_author["login"],
+                    pr_file_paths,
+                )
+                return
+            # Check if GitAuto already commented on this PR to prevent bot-to-bot loops
+            pr_comments = get_all_comments(
+                owner=owner_name, repo=repo_name, pr_number=pr_number, token=token
+            )
+            gitauto_already_commented = any(
+                c.get("user") and c["user"].get("login") == GITHUB_APP_USER_NAME
+                for c in pr_comments
+            )
+            if gitauto_already_commented:
+                logger.info(
+                    "Ignoring bot PR comment from %s - GitAuto already commented on this PR",
+                    review_author["login"],
+                )
+                return
         review_comment = review_body
     else:
         # Get all comments in the review thread
@@ -332,7 +362,7 @@ async def handle_review_run(
             update_comment(body=comment_body, base_args=base_args)
 
     # Get list of changed files in the PR (filenames only, not contents)
-    pr_files = get_pull_request_files(
+    pr_files = bot_pr_files or get_pull_request_files(
         owner=owner_name, repo=repo_name, pr_number=pr_number, token=token
     )
     if not review_author_is_bot:

--- a/services/webhook/test_review_run_handler.py
+++ b/services/webhook/test_review_run_handler.py
@@ -998,3 +998,213 @@ async def test_question_comment_agent_replies_without_code_changes(
 
     # Empty commit NOT created (agent just replied, no code changes)
     mock_create_empty_commit.assert_not_called()
+
+
+@pytest.fixture
+def mock_bot_pr_comment_payload():
+    """Bot PR-level comment payload (no file path, from a bot like github-actions)."""
+    return {
+        "action": "created",
+        "comment": {
+            "id": 66666,
+            "node_id": "IC_66666",
+            "body": "AWS Security Hub found 100 medium severity CVEs",
+            "user": {"login": "github-actions[bot]", "type": "Bot"},
+            "path": "",
+            "subject_type": "pr_comment",
+            "line": 0,
+            "side": "",
+        },
+        "pull_request": {
+            "number": 85,
+            "title": "Low Test Coverage: rates.go",
+            "body": "Adds tests for rates.go",
+            "url": "https://api.github.com/repos/test-owner/test-repo/pulls/85",
+            "user": {"login": "gitauto-ai[bot]"},
+            "head": {
+                "ref": f"{PRODUCT_ID}/coverage-20250101-Ab1C",
+                "sha": "aaa111bbb222",
+            },
+            "base": {"ref": "develop"},
+        },
+        "repository": {
+            "id": 98765,
+            "name": "test-repo",
+            "owner": {
+                "id": 11111,
+                "login": "test-owner",
+                "type": "Organization",
+            },
+            "clone_url": "https://github.com/test-owner/test-repo.git",
+            "fork": False,
+        },
+        "sender": {
+            "id": 55555,
+            "login": "github-actions[bot]",
+        },
+        "installation": {
+            "id": 33333,
+        },
+    }
+
+
+@patch("services.webhook.review_run_handler.set_npm_token_env")
+@patch("services.webhook.review_run_handler.get_installation_access_token")
+@patch("services.webhook.review_run_handler.get_user_public_info")
+@patch("services.webhook.review_run_handler.get_pull_request_files")
+@patch("services.webhook.review_run_handler.chat_with_agent")
+@patch("services.webhook.review_run_handler.GITHUB_APP_USER_NAME", "gitauto-ai[bot]")
+@pytest.mark.asyncio
+async def test_bot_pr_comment_irrelevant_to_pr_files_is_skipped(
+    mock_chat_with_agent,
+    mock_get_pr_files,
+    mock_get_user_public_info,
+    mock_get_token,
+    _mock_set_npm_token_env,
+    mock_bot_pr_comment_payload,
+):
+    """Bot PR-level comment that doesn't mention any PR file paths should be skipped."""
+    mock_get_token.return_value = "ghs_test_token"
+    mock_get_user_public_info.return_value = type(
+        "UserPublicInfo", (), {"email": "bot@test.com", "display_name": "GH Actions"}
+    )()
+    mock_get_pr_files.return_value = [
+        {"filename": "internal/models/core/rates_test.go", "status": "added"},
+    ]
+
+    await handle_review_run(mock_bot_pr_comment_payload, trigger="pr_comment")
+
+    mock_chat_with_agent.assert_not_called()
+
+
+@patch("services.webhook.review_run_handler.set_npm_token_env")
+@patch("services.webhook.review_run_handler.get_installation_access_token")
+@patch("services.webhook.review_run_handler.get_user_public_info")
+@patch("services.webhook.review_run_handler.get_pull_request_files")
+@patch("services.webhook.review_run_handler.get_all_comments")
+@patch("services.webhook.review_run_handler.chat_with_agent")
+@patch("services.webhook.review_run_handler.GITHUB_APP_USER_NAME", "gitauto-ai[bot]")
+@pytest.mark.asyncio
+async def test_bot_pr_comment_skipped_when_gitauto_already_commented(
+    mock_chat_with_agent,
+    mock_get_all_comments,
+    mock_get_pr_files,
+    mock_get_user_public_info,
+    mock_get_token,
+    _mock_set_npm_token_env,
+    mock_bot_pr_comment_payload,
+):
+    """Bot PR-level comment should be skipped if GitAuto already commented on the PR."""
+    # Make the comment mention a PR file so it passes the relevance check
+    mock_bot_pr_comment_payload["comment"]["body"] = "Lint error in internal/models/core/rates_test.go"
+    mock_get_token.return_value = "ghs_test_token"
+    mock_get_user_public_info.return_value = type(
+        "UserPublicInfo", (), {"email": "bot@test.com", "display_name": "GH Actions"}
+    )()
+    mock_get_pr_files.return_value = [
+        {"filename": "internal/models/core/rates_test.go", "status": "added"},
+    ]
+    mock_get_all_comments.return_value = [
+        {"user": {"login": "github-actions[bot]"}, "body": "Security scan results"},
+        {"user": {"login": "gitauto-ai[bot]"}, "body": "I'm working on this PR"},
+    ]
+
+    await handle_review_run(mock_bot_pr_comment_payload, trigger="pr_comment")
+
+    mock_chat_with_agent.assert_not_called()
+
+
+@patch("services.webhook.review_run_handler.get_pull_request")
+@patch("services.webhook.review_run_handler.slack_notify")
+@patch("services.webhook.review_run_handler.get_local_file_tree", return_value=[])
+@patch("services.webhook.review_run_handler.set_npm_token_env")
+@patch("services.webhook.review_run_handler.get_installation_access_token")
+@patch("services.webhook.review_run_handler.get_user_public_info")
+@patch("services.webhook.review_run_handler.get_repository")
+@patch("services.webhook.review_run_handler.create_user_request")
+@patch("services.webhook.review_run_handler.get_review_thread_comments")
+@patch("services.webhook.review_run_handler.reply_to_comment")
+@patch("services.webhook.review_run_handler.create_comment")
+@patch("services.webhook.review_run_handler.get_local_file_content")
+@patch("services.webhook.review_run_handler.get_pull_request_files")
+@patch("services.webhook.review_run_handler.update_comment")
+@patch("services.webhook.review_run_handler.should_bail", return_value=False)
+@patch("services.webhook.review_run_handler.chat_with_agent")
+@patch("services.webhook.review_run_handler.create_empty_commit")
+@patch("services.webhook.review_run_handler.get_reference", return_value="changed_sha")
+@patch("services.webhook.review_run_handler.update_usage")
+@patch("services.webhook.review_run_handler.ensure_node_packages")
+@patch("services.webhook.review_run_handler.clone_repo_and_install_dependencies")
+@patch(
+    "services.webhook.review_run_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.review_run_handler.git_merge_base_into_pr")
+@patch("services.webhook.review_run_handler.ensure_php_packages")
+@patch(
+    "services.webhook.review_run_handler.verify_task_is_ready", new_callable=AsyncMock
+)
+@patch("services.webhook.review_run_handler.get_all_comments")
+@patch("services.webhook.review_run_handler.GITHUB_APP_USER_NAME", "gitauto-ai[bot]")
+@pytest.mark.asyncio
+async def test_bot_pr_comment_processed_when_gitauto_has_not_commented(
+    _mock_get_all_comments,
+    _mock_verify_task_is_ready,
+    _mock_ensure_php,
+    _mock_get_behind,
+    _mock_merge_base,
+    _mock_prepare_repo,
+    _mock_ensure_node,
+    _mock_update_usage,
+    _mock_get_reference,
+    _mock_create_empty_commit,
+    mock_chat_with_agent,
+    _mock_should_bail,
+    _mock_update_comment,
+    mock_get_pr_files,
+    _mock_get_file_content,
+    mock_create_comment,
+    mock_reply_to_comment,
+    mock_get_thread_comments,
+    mock_create_user_request,
+    mock_get_repo,
+    mock_get_user_public_info,
+    mock_get_token,
+    _mock_set_npm_token_env,
+    _mock_get_local_file_tree,
+    _mock_slack_notify,
+    _mock_get_pull_request,
+    mock_bot_pr_comment_payload,
+):
+    """Bot PR-level comment should be processed if GitAuto has not commented yet."""
+    # Make the comment mention a PR file so it passes the relevance check
+    mock_bot_pr_comment_payload["comment"]["body"] = "Lint error in internal/models/core/rates_test.go"
+    mock_get_token.return_value = "ghs_test_token"
+    mock_get_user_public_info.return_value = type(
+        "UserPublicInfo", (), {"email": "bot@test.com", "display_name": "GH Actions"}
+    )()
+    mock_get_repo.return_value = {"id": 98765, "trigger_on_review_comment": True}
+    mock_create_user_request.return_value = 777
+    mock_create_comment.return_value = "http://new-comment-url"
+    mock_get_pr_files.return_value = [
+        {"filename": "internal/models/core/rates_test.go", "status": "added"},
+    ]
+    _mock_verify_task_is_ready.return_value = VerifyTaskIsReadyResult()
+    # No GitAuto comment in the PR yet
+    _mock_get_all_comments.return_value = [
+        {"user": {"login": "github-actions[bot]"}, "body": "Security scan results"},
+    ]
+
+    mock_chat_with_agent.return_value = AgentResult(
+        messages=[{"role": "user", "content": "review"}],
+        token_input=100,
+        token_output=50,
+        is_completed=True,
+        completion_reason="Addressed the security findings.",
+        p=40,
+        is_planned=False,
+    )
+
+    await handle_review_run(mock_bot_pr_comment_payload, trigger="pr_comment")
+
+    mock_chat_with_agent.assert_called_once()


### PR DESCRIPTION
## Summary

- For bot PR-level comments (e.g., Security Hub, lint bots), check if the comment body mentions any file path from the PR's changed files. Skip if irrelevant (prevents GitAuto from responding to unrelated bot noise like CVE scan results)
- If the bot comment IS relevant, check if GitAuto already commented on the PR. Skip if yes (prevents bot-to-bot feedback loops that burned 47 Lambda invocations and 70 Opus API calls on a single PR)
- Reuse the PR files fetched during the relevance check later in the handler to avoid a duplicate API call

## Social Media Post (GitAuto)

A single Security Hub scan comment triggered our agent 11 times on one PR, spawning 47 Lambda invocations. The bot's CVE report had zero overlap with the PR's changed files. Now we check if bot comments actually reference any file the PR touches before running the agent. If they don't, we skip. If they do but we already responded, we skip. Two gates, zero wasted compute.

## Social Media Post (Wes)

Traced a cost spike to a Security Hub bot posting CVE scan results on a PR that only added a Go test file. Our agent treated every bot comment as actionable feedback, ran 47 times, made 70 Claude API calls. Added two checks: does the bot comment mention any file this PR actually changed? And has our agent already responded? Simple string matching, big savings.