### PR TITLE
Skip irrelevant bot PR comments by checking file path mentions

### DIFF
--- a/services/webhook/fixtures/security_hub_comment.txt
+++ b/services/webhook/fixtures/security_hub_comment.txt
@@ -1,0 +1,117 @@
+# 🔍 AWS Security Hub Scan Results
+
+<details>
+<summary><b>Click to view all findings in detail.</b></summary>
+
+| Severity | Finding | Resource |
+|----------|---------|----------|
+| 🟡 | Lambda.2 Lambda functions should use supported runtimes | landingzone-aws-backup-service-opt-in |
+| 🟡 | CVE-2025-61724 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2026-27142 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2025-58185 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2025-22866 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2025-58189 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2025-61730 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2025-4673 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2025-0913 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2025-47906 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2025-61727 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2025-61728 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2025-58186 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2025-58183 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2025-47912 - go/stdlib | aggregator_dev_parkwhiz |
+| 🟡 | CVE-2025-22870 - golang.org/x/net | aggregator_dev_extractor |
+| 🟡 | CVE-2025-22872 - golang.org/x/net | aggregator_dev_extractor |
+| 🟡 | CVE-2024-45338 - golang.org/x/net | aggregator_dev_extractor |
+| 🟡 | CVE-2020-8911 - github.com/aws/aws-sdk-go | aggregator_dev_extractor |
+| 🟡 | CVE-2025-58190 - golang.org/x/net | aggregator_dev_extractor |
+| 🟡 | CVE-2025-47911 - golang.org/x/net | aggregator_dev_extractor |
+| 🟡 | CVE-2025-61730 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2025-47906 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2025-22866 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2026-27142 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2025-58185 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2025-58183 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2025-58186 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2025-61724 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2025-58189 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2025-47912 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2025-4673 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2025-61727 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2025-0913 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2025-61728 - go/stdlib | aggregator_dev_extractor |
+| 🟡 | CVE-2025-58185 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2025-58183 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2025-4673 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2025-58186 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2025-47906 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2025-61728 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2025-61730 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2026-27142 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2025-22866 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2025-47912 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2025-58189 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2025-0913 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2025-61727 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2025-61724 - go/stdlib | aggregator_dev_spothero |
+| 🟡 | CVE-2025-47906 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2025-22866 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2025-61730 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2026-27142 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2025-58186 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2025-58185 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2025-61724 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2025-58183 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2025-4673 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2025-58189 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2025-47912 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2025-0913 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2025-61728 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2025-61727 - go/stdlib | aggregator_dev_processor |
+| 🟡 | CVE-2020-8911 - github.com/aws/aws-sdk-go | aggregator_dev_processor |
+| 🟡 | CVE-2025-61730 - go/stdlib | aggregator-dev-event-dedupe |
+| 🟡 | CVE-2026-27142 - go/stdlib | aggregator-dev-event-dedupe |
+| 🟡 | CVE-2025-61728 - go/stdlib | aggregator-dev-event-dedupe |
+| 🟡 | CVE-2026-27142 - go/stdlib | aggregator-dev-event-enrich |
+| 🟡 | CVE-2025-61730 - go/stdlib | aggregator-dev-event-enrich |
+| 🟡 | CVE-2025-61728 - go/stdlib | aggregator-dev-event-enrich |
+| 🟡 | CVE-2026-27142 - go/stdlib | aggregator-dev-spothero-events |
+| 🟡 | CVE-2025-61730 - go/stdlib | aggregator-dev-spothero-events |
+| 🟡 | CVE-2025-61728 - go/stdlib | aggregator-dev-spothero-events |
+| 🟡 | CVE-2026-27142 - go/stdlib | aggregator-dev-venue-normalize |
+| 🟡 | CVE-2025-61730 - go/stdlib | aggregator-dev-venue-normalize |
+| 🟡 | CVE-2025-61728 - go/stdlib | aggregator-dev-venue-normalize |
+| 🟡 | CVE-2026-27142 - go/stdlib | aggregator-dev-event-normalize |
+| 🟡 | CVE-2025-61730 - go/stdlib | aggregator-dev-event-normalize |
+| 🟡 | CVE-2025-61728 - go/stdlib | aggregator-dev-event-normalize |
+| 🟡 | CVE-2026-27142 - go/stdlib | token-rotator |
+| 🟡 | CVE-2025-61730 - go/stdlib | token-rotator |
+| 🟡 | CVE-2025-4673 - go/stdlib | token-rotator |
+| 🟡 | CVE-2025-0913 - go/stdlib | token-rotator |
+| 🟡 | CVE-2025-61728 - go/stdlib | token-rotator |
+| 🟡 | CVE-2025-61730 - go/stdlib | aggregator_dev_be |
+| 🟡 | CVE-2026-27142 - go/stdlib | aggregator_dev_be |
+| 🟡 | CVE-2025-4673 - go/stdlib | aggregator_dev_be |
+| 🟡 | CVE-2025-0913 - go/stdlib | aggregator_dev_be |
+| 🟡 | CVE-2025-61728 - go/stdlib | aggregator_dev_be |
+| 🟡 | CVE-2026-27142 - go/stdlib | aggregator_dev_apds_transformer |
+| 🟡 | CVE-2025-61730 - go/stdlib | aggregator_dev_apds_transformer |
+| 🟡 | CVE-2025-4673 - go/stdlib | aggregator_dev_apds_transformer |
+| 🟡 | CVE-2025-0913 - go/stdlib | aggregator_dev_apds_transformer |
+| 🟡 | CVE-2025-61728 - go/stdlib | aggregator_dev_apds_transformer |
+| 🟡 | CVE-2025-61727 - go/stdlib | aggregator-dev-venue-normalize |
+| 🟡 | CVE-2025-61727 - go/stdlib | aggregator-dev-event-enrich |
+| 🟡 | CVE-2025-61727 - go/stdlib | aggregator-dev-event-dedupe |
+| 🟡 | CVE-2025-61727 - go/stdlib | aggregator-dev-event-normalize |
+| 🟡 | CVE-2025-61727 - go/stdlib | aggregator-dev-spothero-events |
+| 🟡 | CVE-2025-22866 - go/stdlib | token-rotator |
+
+</details>
+
+**Summary of Findings**:
+🔴 0 Critical
+🟠 0 High
+🟡 100 Medium
+🔵 0 Low/Info
+
+*Last updated: 2026-04-13 18:05 UTC*

--- a/services/webhook/review_run_handler.py
+++ b/services/webhook/review_run_handler.py
@@ -142,8 +142,24 @@ async def handle_review_run(
         if summary_body and summary_body.strip():
             review_summary = summary_body
 
-    # For inline review comments, get thread context and check resolved status
+    # Get list of changed files in the PR (used for bot relevance check and later for file processing)
+    pr_files = get_pull_request_files(
+        owner=owner_name, repo=repo_name, pr_number=pr_number, token=token
+    )
+
+    # For PR-level comments (no file path), check bot relevance and loop prevention
     if not review_path:
+        if review_author_is_bot:
+            # Check if bot comment mentions any PR file paths (skip irrelevant bot comments like Security Hub scans)
+            pr_file_paths = [f["filename"] for f in pr_files]
+            mentions_pr_file = any(path in review_body for path in pr_file_paths)
+            if not mentions_pr_file:
+                logger.info(
+                    "Ignoring bot PR comment from %s - does not mention any PR file paths: %s",
+                    review_author["login"],
+                    pr_file_paths,
+                )
+                return
         review_comment = review_body
     else:
         # Get all comments in the review thread
@@ -331,10 +347,6 @@ async def handle_review_run(
             comment_body = create_progress_bar(p=p, msg="\n".join(log_messages))
             update_comment(body=comment_body, base_args=base_args)
 
-    # Get list of changed files in the PR (filenames only, not contents)
-    pr_files = get_pull_request_files(
-        owner=owner_name, repo=repo_name, pr_number=pr_number, token=token
-    )
     if not review_author_is_bot:
         p += 5
         add_log_message(f"Found {len(pr_files)} changed files in the PR.", log_messages)

--- a/services/webhook/test_review_run_handler.py
+++ b/services/webhook/test_review_run_handler.py
@@ -1,10 +1,13 @@
 # pylint: disable=unused-argument,too-many-lines
 # pyright: reportUnusedVariable=false
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from config import PRODUCT_ID
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 from services.agents.verify_task_is_complete import VerifyTaskIsCompleteResult
 from services.agents.verify_task_is_ready import VerifyTaskIsReadyResult
 from services.chat_with_agent import AgentResult
@@ -998,3 +1001,171 @@ async def test_question_comment_agent_replies_without_code_changes(
 
     # Empty commit NOT created (agent just replied, no code changes)
     mock_create_empty_commit.assert_not_called()
+
+
+@pytest.fixture
+def mock_bot_pr_comment_payload():
+    """Bot PR-level comment payload (no file path, from a bot like github-actions)."""
+    return {
+        "action": "created",
+        "comment": {
+            "id": 66666,
+            "node_id": "IC_66666",
+            "body": (FIXTURES_DIR / "security_hub_comment.txt").read_text(),
+            "user": {"login": "github-actions[bot]", "type": "Bot"},
+            "path": "",
+            "subject_type": "pr_comment",
+            "line": 0,
+            "side": "",
+        },
+        "pull_request": {
+            "number": 85,
+            "title": "Low Test Coverage: rates.go",
+            "body": "Adds tests for rates.go",
+            "url": "https://api.github.com/repos/test-owner/test-repo/pulls/85",
+            "user": {"login": "gitauto-ai[bot]"},
+            "head": {
+                "ref": f"{PRODUCT_ID}/coverage-20250101-Ab1C",
+                "sha": "aaa111bbb222",
+            },
+            "base": {"ref": "develop"},
+        },
+        "repository": {
+            "id": 98765,
+            "name": "test-repo",
+            "owner": {
+                "id": 11111,
+                "login": "test-owner",
+                "type": "Organization",
+            },
+            "clone_url": "https://github.com/test-owner/test-repo.git",
+            "fork": False,
+        },
+        "sender": {
+            "id": 55555,
+            "login": "github-actions[bot]",
+        },
+        "installation": {
+            "id": 33333,
+        },
+    }
+
+
+@patch("services.webhook.review_run_handler.set_npm_token_env")
+@patch("services.webhook.review_run_handler.get_installation_access_token")
+@patch("services.webhook.review_run_handler.get_user_public_info")
+@patch("services.webhook.review_run_handler.get_pull_request_files")
+@patch("services.webhook.review_run_handler.chat_with_agent")
+@patch("services.webhook.review_run_handler.GITHUB_APP_USER_NAME", "gitauto-ai[bot]")
+@pytest.mark.asyncio
+async def test_bot_pr_comment_irrelevant_to_pr_files_is_skipped(
+    mock_chat_with_agent,
+    mock_get_pr_files,
+    mock_get_user_public_info,
+    mock_get_token,
+    _mock_set_npm_token_env,
+    mock_bot_pr_comment_payload,
+):
+    """Bot PR-level comment that doesn't mention any PR file paths should be skipped."""
+    mock_get_token.return_value = "ghs_test_token"
+    mock_get_user_public_info.return_value = type(
+        "UserPublicInfo", (), {"email": "bot@test.com", "display_name": "GH Actions"}
+    )()
+    mock_get_pr_files.return_value = [
+        {"filename": "internal/models/core/rates_test.go", "status": "added"},
+    ]
+
+    await handle_review_run(mock_bot_pr_comment_payload, trigger="pr_comment")
+
+    mock_chat_with_agent.assert_not_called()
+
+
+@patch("services.webhook.review_run_handler.get_pull_request")
+@patch("services.webhook.review_run_handler.slack_notify")
+@patch("services.webhook.review_run_handler.get_local_file_tree", return_value=[])
+@patch("services.webhook.review_run_handler.set_npm_token_env")
+@patch("services.webhook.review_run_handler.get_installation_access_token")
+@patch("services.webhook.review_run_handler.get_user_public_info")
+@patch("services.webhook.review_run_handler.get_repository")
+@patch("services.webhook.review_run_handler.create_user_request")
+@patch("services.webhook.review_run_handler.get_review_thread_comments")
+@patch("services.webhook.review_run_handler.reply_to_comment")
+@patch("services.webhook.review_run_handler.create_comment")
+@patch("services.webhook.review_run_handler.get_local_file_content")
+@patch("services.webhook.review_run_handler.get_pull_request_files")
+@patch("services.webhook.review_run_handler.update_comment")
+@patch("services.webhook.review_run_handler.should_bail", return_value=False)
+@patch("services.webhook.review_run_handler.chat_with_agent")
+@patch("services.webhook.review_run_handler.create_empty_commit")
+@patch("services.webhook.review_run_handler.get_reference", return_value="changed_sha")
+@patch("services.webhook.review_run_handler.update_usage")
+@patch("services.webhook.review_run_handler.ensure_node_packages")
+@patch("services.webhook.review_run_handler.clone_repo_and_install_dependencies")
+@patch(
+    "services.webhook.review_run_handler.get_head_commit_count_behind_base",
+    return_value=0,
+)
+@patch("services.webhook.review_run_handler.git_merge_base_into_pr")
+@patch("services.webhook.review_run_handler.ensure_php_packages")
+@patch(
+    "services.webhook.review_run_handler.verify_task_is_ready", new_callable=AsyncMock
+)
+@patch("services.webhook.review_run_handler.GITHUB_APP_USER_NAME", "gitauto-ai[bot]")
+@pytest.mark.asyncio
+async def test_bot_pr_comment_mentioning_pr_file_is_processed(
+    _mock_verify_task_is_ready,
+    _mock_ensure_php,
+    _mock_get_behind,
+    _mock_merge_base,
+    _mock_prepare_repo,
+    _mock_ensure_node,
+    _mock_update_usage,
+    _mock_get_reference,
+    _mock_create_empty_commit,
+    mock_chat_with_agent,
+    _mock_should_bail,
+    _mock_update_comment,
+    mock_get_pr_files,
+    _mock_get_file_content,
+    mock_create_comment,
+    mock_reply_to_comment,
+    mock_get_thread_comments,
+    mock_create_user_request,
+    mock_get_repo,
+    mock_get_user_public_info,
+    mock_get_token,
+    _mock_set_npm_token_env,
+    _mock_get_local_file_tree,
+    _mock_slack_notify,
+    _mock_get_pull_request,
+    mock_bot_pr_comment_payload,
+):
+    """Bot PR-level comment that mentions a PR file path should be processed."""
+    mock_bot_pr_comment_payload["comment"][
+        "body"
+    ] = "Lint error in internal/models/core/rates_test.go"
+    mock_get_token.return_value = "ghs_test_token"
+    mock_get_user_public_info.return_value = type(
+        "UserPublicInfo", (), {"email": "bot@test.com", "display_name": "GH Actions"}
+    )()
+    mock_get_repo.return_value = {"id": 98765, "trigger_on_review_comment": True}
+    mock_create_user_request.return_value = 777
+    mock_create_comment.return_value = "http://new-comment-url"
+    mock_get_pr_files.return_value = [
+        {"filename": "internal/models/core/rates_test.go", "status": "added"},
+    ]
+    _mock_verify_task_is_ready.return_value = VerifyTaskIsReadyResult()
+
+    mock_chat_with_agent.return_value = AgentResult(
+        messages=[{"role": "user", "content": "review"}],
+        token_input=100,
+        token_output=50,
+        is_completed=True,
+        completion_reason="Addressed the lint error.",
+        p=40,
+        is_planned=False,
+    )
+
+    await handle_review_run(mock_bot_pr_comment_payload, trigger="pr_comment")
+
+    mock_chat_with_agent.assert_called_once()


### PR DESCRIPTION
## Summary

- For bot PR-level comments (e.g., Security Hub scans, dependabot alerts), check if the comment body mentions any file path from the PR's changed files before running the agent
- If the comment doesn't reference any PR file, skip it (e.g., a CVE scan listing Go stdlib vulnerabilities has nothing to do with a PR adding `rates_test.go`)
- Move `get_pull_request_files` call earlier so the same result is reused for both the relevance check and later file processing (no duplicate API call)

## Social Media Post (GitAuto)

A Security Hub bot posted CVE scan results on a PR that only added a Go test file. Our agent treated each comment as feedback, ran 47 times, made 70 API calls. Now before processing any bot comment, we check if it mentions a file the PR actually changed. No file overlap, no agent run.

## Social Media Post (Wes)

Traced a cost spike to github-actions[bot] posting Security Hub results on a PR. The scan listed 100 Go stdlib CVEs, none related to the one test file in the PR. Our agent ran 47 times trying to "fix" them. Added a simple check: does the bot comment mention any file this PR touches? String matching, nothing fancy. Would have saved us the entire 47-run loop.