### PR TITLE
Add run_command tool with whitelisted shell commands

### DIFF
--- a/constants/shell.py
+++ b/constants/shell.py
@@ -1,0 +1,27 @@
+# Commands that access the file system — all path arguments must resolve under /tmp
+PATH_RESTRICTED_COMMANDS = ("cat", "ls")
+
+# Read-only commands safe to run on Lambda
+ALLOWED_PREFIXES = (
+    # File system (read-only, paths validated via PATH_RESTRICTED_COMMANDS)
+    *[cmd + " " for cmd in PATH_RESTRICTED_COMMANDS],
+    # Node/npm
+    "node -v",
+    "npm list",
+    "npm outdated",
+    "npm search",
+    "npm view",
+    # Yarn
+    "yarn info",
+    "yarn list",
+    "yarn why",
+    # PHP/Composer
+    "composer outdated",
+    "composer show",
+    "php -m",
+    "php -v",
+    # Python/pip
+    "pip index",
+    "pip list",
+    "pip show",
+)

--- a/services/claude/tools/tools.py
+++ b/services/claude/tools/tools.py
@@ -35,6 +35,7 @@ from services.github.comments.reply_to_comment import (
     REPLY_TO_REVIEW_COMMENT,
     reply_to_comment,
 )
+from services.shell.run_command import RUN_COMMAND, run_command
 from services.node.switch_node_version import (
     SWITCH_NODE_VERSION,
     switch_node_version,
@@ -73,6 +74,7 @@ _TOOLS_BASE: list[ToolUnionParam] = [
     GET_LOCAL_FILE_TREE,
     MOVE_FILE,
     QUERY_FILE,
+    RUN_COMMAND,
     SEARCH_AND_REPLACE,
     SEARCH_LOCAL_FILE_CONTENT,
     # SEARCH_WEB disabled: DDG CAPTCHAs bots. Use paid API (e.g. Brave Search) if needed.
@@ -126,6 +128,7 @@ tools_to_call: dict[str, Any] = {
     "move_file": move_file,
     "query_file": query_file,
     "reply_to_review_comment": reply_to_comment,
+    "run_command": run_command,
     "reset_pr_branch_to_new_base": reset_pr_branch_to_new_base,
     "search_and_replace": search_and_replace,
     "search_local_file_contents": search_local_file_contents,

--- a/services/shell/run_command.py
+++ b/services/shell/run_command.py
@@ -41,6 +41,8 @@ RUN_COMMAND: ToolUnionParam = {
 def run_command(base_args: BaseArgs, command: str, **_kwargs):
     if not any(command.startswith(prefix) for prefix in ALLOWED_PREFIXES):
         logger.info("Command blocked: %s", command)
+        thread_ts = base_args.get("slack_thread_ts")
+        slack_notify(f"⛔ Blocked command: `{command}`", thread_ts)
         return f"Command not allowed. Allowed prefixes: {', '.join(ALLOWED_PREFIXES)}"
 
     logger.info("Running command: %s", command)
@@ -54,6 +56,8 @@ def run_command(base_args: BaseArgs, command: str, **_kwargs):
             resolved = os.path.realpath(arg)
             if not resolved.startswith("/tmp"):
                 logger.info("Path blocked: %s resolves to %s", arg, resolved)
+                thread_ts = base_args.get("slack_thread_ts")
+                slack_notify(f"⛔ Blocked path: `{command}` (resolved to `{resolved}`)", thread_ts)
                 return f"Path not allowed: {arg}. File access is restricted to /tmp."
     try:
         result = run_subprocess(args=args, cwd="/tmp")

--- a/services/shell/run_command.py
+++ b/services/shell/run_command.py
@@ -1,0 +1,78 @@
+import os
+import shlex
+import uuid
+
+from anthropic.types import ToolUnionParam
+
+from constants.shell import ALLOWED_PREFIXES, PATH_RESTRICTED_COMMANDS
+from services.slack.slack_notify import slack_notify
+from services.types.base_args import BaseArgs
+from utils.command.run_subprocess import run_subprocess
+from utils.error.handle_exceptions import handle_exceptions
+from utils.logging.logging_config import logger
+
+# Output longer than this is saved to /tmp instead of returned inline
+INLINE_OUTPUT_LIMIT = 2_000
+
+RUN_COMMAND: ToolUnionParam = {
+    "name": "run_command",
+    "description": (
+        "Run a read-only shell command to look up package versions or dependencies. "
+        "Allowed: npm (view/list/outdated/search), yarn (info/list/why), "
+        "composer (show/outdated), pip (show/list/index), node -v, php -v/-m. "
+        "Use this instead of fetching HTML pages for package version lookups."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "command": {
+                "type": "string",
+                "description": "The shell command to run (e.g. 'npm view @circleci/node version').",
+            },
+        },
+        "required": ["command"],
+        "additionalProperties": False,
+    },
+    "strict": True,
+}
+
+
+@handle_exceptions(default_return_value=None, raise_on_error=False)
+def run_command(base_args: BaseArgs, command: str, **_kwargs):
+    if not any(command.startswith(prefix) for prefix in ALLOWED_PREFIXES):
+        logger.info("Command blocked: %s", command)
+        return f"Command not allowed. Allowed prefixes: {', '.join(ALLOWED_PREFIXES)}"
+
+    logger.info("Running command: %s", command)
+    args = shlex.split(command)
+
+    # For file-access commands, all path arguments must resolve under /tmp
+    if args[0] in PATH_RESTRICTED_COMMANDS:
+        for arg in args[1:]:
+            if arg.startswith("-"):
+                continue
+            resolved = os.path.realpath(arg)
+            if not resolved.startswith("/tmp"):
+                logger.info("Path blocked: %s resolves to %s", arg, resolved)
+                return f"Path not allowed: {arg}. File access is restricted to /tmp."
+    try:
+        result = run_subprocess(args=args, cwd="/tmp")
+    except ValueError as e:
+        logger.info("Command error: %s", e)
+        return str(e)
+
+    output = result.stdout
+    logger.info("Command completed: %s, len=%d", command, len(output))
+
+    if len(output) > INLINE_OUTPUT_LIMIT:
+        file_path = os.path.join("/tmp", f"cmd_{uuid.uuid4().hex[:8]}.txt")
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(output)
+        logger.info("Large output saved to %s (%d chars)", file_path, len(output))
+        thread_ts = base_args.get("slack_thread_ts")
+        slack_notify(f"🖥️ Command: `{command}` (saved to file)", thread_ts)
+        return f"Output too large for inline ({len(output):,} chars). Saved to: {file_path}\nUse get_local_file_content to read it."
+
+    thread_ts = base_args.get("slack_thread_ts")
+    slack_notify(f"🖥️ Command: `{command}`", thread_ts)
+    return output

--- a/services/shell/test_run_command.py
+++ b/services/shell/test_run_command.py
@@ -1,0 +1,90 @@
+# pylint: disable=unused-argument
+# pyright: reportUnusedVariable=false
+from unittest.mock import patch
+
+import pytest
+
+from constants.shell import ALLOWED_PREFIXES
+from services.shell.run_command import run_command
+
+
+class TestRunCommand:
+    @patch("services.shell.run_command.slack_notify")
+    def test_npm_view_returns_version(self, _mock_slack, create_test_base_args):
+        base_args = create_test_base_args()
+        result = run_command(base_args, "npm view express version")
+        assert result is not None
+        # express always has a version like "4.x.x" or "5.x.x"
+        assert result.strip()[0].isdigit()
+
+    @patch("services.shell.run_command.slack_notify")
+    def test_blocked_command(self, _mock_slack, create_test_base_args):
+        base_args = create_test_base_args()
+        result = run_command(base_args, "rm -rf /")
+        assert result is not None
+        assert "not allowed" in result.lower()
+
+    @patch("services.shell.run_command.slack_notify")
+    def test_ls_runs(self, _mock_slack, create_test_base_args):
+        base_args = create_test_base_args()
+        result = run_command(base_args, "ls /tmp")
+        assert result is not None
+
+    @patch("services.shell.run_command.slack_notify")
+    def test_npm_view_nonexistent_package(self, _mock_slack, create_test_base_args):
+        base_args = create_test_base_args()
+        result = run_command(
+            base_args, "npm view this-package-does-not-exist-xyz123 version"
+        )
+        assert result is not None
+        assert "404" in result
+
+    @patch("services.shell.run_command.slack_notify")
+    def test_yarn_info(self, _mock_slack, create_test_base_args):
+        base_args = create_test_base_args()
+        result = run_command(base_args, "yarn info express version")
+        assert result is not None
+
+    @patch("services.shell.run_command.slack_notify")
+    def test_large_output_saved_to_file(self, _mock_slack, create_test_base_args):
+        base_args = create_test_base_args()
+        # npm view express (no field) returns lots of metadata
+        result = run_command(base_args, "npm view express")
+        assert result is not None
+        if "Saved to:" in result:
+            assert "/tmp/cmd_" in result
+            assert "get_local_file_content" in result
+
+    @patch("services.shell.run_command.slack_notify")
+    def test_cat_blocked_outside_tmp(self, _mock_slack, create_test_base_args):
+        base_args = create_test_base_args()
+        result = run_command(base_args, "cat /etc/passwd")
+        assert result is not None
+        assert "not allowed" in result.lower()
+
+    @patch("services.shell.run_command.slack_notify")
+    def test_cat_blocked_proc_environ(self, _mock_slack, create_test_base_args):
+        base_args = create_test_base_args()
+        result = run_command(base_args, "cat /proc/self/environ")
+        assert result is not None
+        assert "not allowed" in result.lower()
+
+    @patch("services.shell.run_command.slack_notify")
+    def test_cat_blocked_traversal(self, _mock_slack, create_test_base_args):
+        base_args = create_test_base_args()
+        result = run_command(base_args, "cat /tmp/../../etc/passwd")
+        assert result is not None
+        assert "not allowed" in result.lower()
+
+    @patch("services.shell.run_command.slack_notify")
+    def test_ls_blocked_outside_tmp(self, _mock_slack, create_test_base_args):
+        base_args = create_test_base_args()
+        result = run_command(base_args, "ls /etc")
+        assert result is not None
+        assert "not allowed" in result.lower()
+
+    @pytest.mark.parametrize("prefix", ALLOWED_PREFIXES)
+    def test_all_allowed_prefixes_are_read_only(self, prefix):
+        # Verify no write commands snuck into the whitelist
+        dangerous = ("rm", "install", "uninstall", "add", "remove", "publish", "exec")
+        assert not any(d in prefix for d in dangerous)


### PR DESCRIPTION
## Summary

- New `run_command` tool gives the agent access to read-only shell commands: npm/yarn/pip/composer version lookups, `ls` and `cat` (restricted to `/tmp`)
- Prevents the agent from scraping HTML pages when CLI tools can provide the info directly (e.g. `npm view @circleci/node version` instead of fetching CircleCI's SPA page)
- Large output (>2K chars) saved to `/tmp` files to avoid bloating conversation history
- Blocked commands and paths are Slack-notified so we can see what the agent tries and decide whether to whitelist

## Social Media Post (GitAuto)

Our AI agent kept scraping web pages for package versions even though npm and yarn can answer in one line. Added a whitelisted shell command tool so the agent can run read-only CLI lookups directly. Commands outside the whitelist get blocked and we get notified.

## Social Media Post (Wes)

The agent was fetching CircleCI's SPA page to find an orb version. The page is client-side rendered so the fetch returned nothing useful. Now it can just run npm view instead. Added a whitelist of safe read-only commands and a Slack alert when something gets blocked.