### PR TITLE
Add specs to TEST_DIR_NAMES, fix billing script to query PROD

### DIFF
--- a/constants/files.py
+++ b/constants/files.py
@@ -118,6 +118,7 @@ TEST_DIR_NAMES = {
     "tests",  # Python, PHP, general
     "test",  # Java/Maven, Go
     "spec",  # RSpec (Ruby), Jasmine
+    "specs",  # Jasmine/Mocha plural convention
     "e2e",  # End-to-end tests
     "unit",  # PHPUnit/Laravel Unit tests
     "feature",  # PHPUnit/Laravel Feature tests

--- a/scripts/supabase/check_billing_consistency.py
+++ b/scripts/supabase/check_billing_consistency.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # pylint: disable=wrong-import-position
+# ruff: noqa: E402
 """Check billing consistency between GitHub PRs, usage table, and credits table.
 
 Source of truth: GitHub PRs created by gitauto-ai[bot].
@@ -14,13 +15,23 @@ Usage:
 
 import argparse
 from datetime import datetime, timedelta, timezone
+import os
 from pathlib import Path
 import sys
 
+from dotenv import load_dotenv
 import requests
 
 # Add repo root to Python path so imports work
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+load_dotenv()
+
+# Billing checks must always run against PROD Supabase
+os.environ["SUPABASE_URL"] = os.environ.get("SUPABASE_URL_PRD", "")
+os.environ["SUPABASE_SERVICE_ROLE_KEY"] = os.environ.get(
+    "SUPABASE_SERVICE_ROLE_KEY_PRD", ""
+)
 
 from scripts.github.get_installation_token import get_installation_token
 from scripts.supabase.compare_billing_records import compare_billing_records


### PR DESCRIPTION
## Summary
- Add `"specs"` to `TEST_DIR_NAMES` alongside existing `"spec"` (singular/plural pattern like `test`/`tests`). Fixes `find_test_files` failing to match `test/specs/` directories in mirror matching.
- Fix `check_billing_consistency.py` to query PROD Supabase (`SUPABASE_URL_PRD`) instead of DEV. Script was returning 0 usage/credit records.
- Also set `test_dir_prefixes` to `{test/specs}` in PROD DB for `foxden-shared-lib` and `foxden-tools`.

## GitAuto Post
We weren't detecting test files inside `test/specs/` directories. The plural "specs" was missing from our known test directory names, and a billing diagnostic script was silently querying dev instead of prod. Two small fixes, both caught by investigating why a scheduled PR shipped empty.

## Wes Post
Investigated why a scheduled PR had zero file changes. Traced it through CloudWatch logs to a credit check failure, then found `find_test_files` returned 0 matches because we had "spec" but not "specs" in our directory name list. Also discovered our billing check script was querying dev, showing phantom discrepancies. Both one-line root causes.