### PR TITLE
Fix verify_task_is_ready OOM from passing impl files to Jest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-doc==0.0.4
 annotated-types==0.7.0
 anthropic==0.77.0
-anyio==4.4.0
+anyio==4.13.0
 astroid==3.2.4
 attrs==26.1.0
 autoflake==2.3.1
@@ -42,6 +42,8 @@ Faker==24.14.1
 fastapi==0.128.0
 fastapi-cli==0.0.5
 filelock==3.20.3
+google-auth==2.49.2
+google-genai==1.73.0
 gotrue==2.6.1
 gql==3.5.0
 graphql-core==3.2.6
@@ -52,7 +54,7 @@ hpack==4.1.0
 html2text==2025.4.15
 httpcore==1.0.9
 httptools==0.6.4
-httpx==0.27.0
+httpx==0.28.1
 hyperframe==6.1.0
 identify==2.6.0
 idna==3.7
@@ -97,10 +99,14 @@ primp==1.1.3
 propcache==0.2.1
 psutil==7.0.0
 psycopg2-binary==2.9.10
+pyasn1==0.6.3
+pyasn1_modules==0.4.2
+pycodestyle==2.14.0
 pycparser==2.22
 pydantic==2.12.5
 pydantic_core==2.41.5
 pyee==12.1.1
+pyflakes==3.4.0
 PyGithub==2.3.0
 Pygments==2.18.0
 PyJWT==2.9.0
@@ -138,6 +144,7 @@ stripe==14.1.0
 supabase==2.6.0
 supafunc==0.5.1
 sympy==1.14.0
+tenacity==9.1.4
 tiktoken==0.11.0
 toml==0.10.2
 tomlkit==0.13.0
@@ -157,6 +164,6 @@ uvicorn==0.34.0
 uvloop==0.21.0
 virtualenv==20.36.1
 watchfiles==0.23.0
-websockets==12.0
+websockets==16.0
 wrapt==1.16.0
 yarl==1.18.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-doc==0.0.4
 annotated-types==0.7.0
 anthropic==0.77.0
-anyio==4.13.0
+anyio==4.4.0
 astroid==3.2.4
 attrs==26.1.0
 autoflake==2.3.1
@@ -42,8 +42,6 @@ Faker==24.14.1
 fastapi==0.128.0
 fastapi-cli==0.0.5
 filelock==3.20.3
-google-auth==2.49.2
-google-genai==1.73.0
 gotrue==2.6.1
 gql==3.5.0
 graphql-core==3.2.6
@@ -54,7 +52,7 @@ hpack==4.1.0
 html2text==2025.4.15
 httpcore==1.0.9
 httptools==0.6.4
-httpx==0.28.1
+httpx==0.27.0
 hyperframe==6.1.0
 identify==2.6.0
 idna==3.7
@@ -99,14 +97,10 @@ primp==1.1.3
 propcache==0.2.1
 psutil==7.0.0
 psycopg2-binary==2.9.10
-pyasn1==0.6.3
-pyasn1_modules==0.4.2
-pycodestyle==2.14.0
 pycparser==2.22
 pydantic==2.12.5
 pydantic_core==2.41.5
 pyee==12.1.1
-pyflakes==3.4.0
 PyGithub==2.3.0
 Pygments==2.18.0
 PyJWT==2.9.0
@@ -144,7 +138,6 @@ stripe==14.1.0
 supabase==2.6.0
 supafunc==0.5.1
 sympy==1.14.0
-tenacity==9.1.4
 tiktoken==0.11.0
 toml==0.10.2
 tomlkit==0.13.0
@@ -164,6 +157,6 @@ uvicorn==0.34.0
 uvloop==0.21.0
 virtualenv==20.36.1
 watchfiles==0.23.0
-websockets==16.0
+websockets==12.0
 wrapt==1.16.0
 yarl==1.18.3

--- a/services/agents/test_verify_task_is_ready.py
+++ b/services/agents/test_verify_task_is_ready.py
@@ -411,3 +411,47 @@ async def test_run_jest_reports_test_failures(
     assert len(result.errors) == 2
     assert "jest:" in result.errors[0]
     assert result.files_with_errors == {"src/index.test.ts"}
+
+
+@pytest.mark.asyncio
+@patch("services.agents.verify_task_is_ready.run_jest_test")
+@patch("services.agents.verify_task_is_ready.git_commit_and_push")
+@patch("services.agents.verify_task_is_ready.run_eslint_fix", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_ready.run_prettier_fix", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_ready.read_local_file")
+async def test_impl_files_excluded_from_jest(
+    mock_read_local_file, mock_prettier, mock_eslint, mock_commit, mock_jest
+):
+    """Impl files must NOT be passed to run_jest_test at all.
+
+    Previously all JS/TS files were passed as test_file_paths, causing
+    jest --findRelatedTests on impl files which OOMed Lambda for MongoDB repos.
+    verify_task_is_ready only validates existing test files; running related
+    tests for impl files is verify_task_is_complete's job.
+    """
+    mock_read_local_file.return_value = "export function foo() { return 1; }"
+    mock_prettier.return_value = PrettierResult(success=True, content=None, error=None)
+    mock_eslint.return_value = ESLintResult(
+        success=True, content=None, lint_errors=None, coverage_errors=None
+    )
+    mock_jest.return_value = JestResult()
+
+    base_args = cast(
+        BaseArgs,
+        {
+            "owner": "test",
+            "repo": "test",
+            "token": "test",
+            "base_branch": "main",
+            "clone_dir": "/tmp/clone",
+        },
+    )
+    await verify_task_is_ready(
+        base_args=base_args,
+        run_phpunit=False,
+        file_paths=["src/models/Foo.ts", "src/models/Foo.test.ts"],
+    )
+    mock_jest.assert_called_once()
+    call_kwargs = mock_jest.call_args[1]
+    assert call_kwargs["test_file_paths"] == ["src/models/Foo.test.ts"]
+    assert call_kwargs["source_file_paths"] == []

--- a/services/agents/verify_task_is_ready.py
+++ b/services/agents/verify_task_is_ready.py
@@ -12,6 +12,7 @@ from services.tsc.run_tsc_check import run_tsc_check
 from utils.error.handle_exceptions import handle_exceptions
 from utils.files.filter_js_ts_files import filter_js_ts_files
 from utils.files.is_python_test_file import is_python_test_file
+from utils.files.is_test_file import is_test_file
 from utils.files.read_local_file import read_local_file
 from utils.logging.logging_config import logger
 
@@ -110,9 +111,10 @@ async def verify_task_is_ready(
             errors.append(f"- tsc: {err}")
         files_with_errors.update(tsc_result.error_files)
 
+    js_ts_test_files = [f for f in js_ts_files if is_test_file(f)]
     jest_result = await run_jest_test(
         base_args=base_args,
-        test_file_paths=js_ts_files,
+        test_file_paths=js_ts_test_files,
         source_file_paths=[],
         impl_file_to_collect_coverage_from="",
     )


### PR DESCRIPTION
## Summary
- `verify_task_is_ready` passed all JS/TS files (including impl files) as `test_file_paths` to `run_jest_test`, triggering `jest --findRelatedTests` on impl files
- For MongoDB repos this fans out to all dependent test suites, spawning multiple `mongod` processes via `mongodb-memory-server`, exceeding Lambda's 3072MB limit
- Fix: filter through `is_test_file()` so only actual test files go to `test_file_paths`; impl files excluded from Jest entirely — regression detection is `verify_task_is_complete`'s job

## Root cause (Foxquilt/foxcom-payment-backend PR #1702)
1. `new_pr_handler` passed `src/models/mongodb/InProgressPolicy.ts` (impl) to `verify_task_is_ready`
2. `verify_task_is_ready` passed it as `test_file_paths` to `run_jest_test`
3. `run_jest_test` ran `jest --findRelatedTests InProgressPolicy.ts`
4. Jest discovered all related test suites → started multiple `mongod` processes → OOM at 3072/3072 MB after 653s
5. Agent never started. 0 files changed.

## Social Media Post (GitAuto)
Our agent was dying before it even started writing tests. It ran jest --findRelatedTests on the implementation file during pre-validation, which fanned out to every test that touched a MongoDB model. Multiple mongod instances ate all 3GB of Lambda memory. The fix: only run existing test files during pre-validation. Save the regression check for after.

## Social Media Post (Wes)
Found why some test coverage PRs died with zero changes. The pre-validation step was running Jest on implementation files, not test files. For MongoDB repos that meant spinning up multiple mongod processes in parallel. Three-line fix, but took real log diving to find.