### PR TITLE
Honor DB preferred_model regardless of billing tier

### DIFF
--- a/.github/workflows/check-billing-consistency.yml
+++ b/.github/workflows/check-billing-consistency.yml
@@ -54,7 +54,7 @@ jobs:
           if [ -n "${{ github.event.inputs.owner }}" ]; then
             ARGS="$ARGS --owner ${{ github.event.inputs.owner }}"
           fi
-          python3 scripts/supabase/check_billing_consistency.py $ARGS
+          uv run python3 scripts/supabase/check_billing_consistency.py $ARGS
 
       - name: Notify Slack on failure
         if: failure()

--- a/.github/workflows/check-database-size.yml
+++ b/.github/workflows/check-database-size.yml
@@ -55,7 +55,7 @@ jobs:
             SIZE_BEFORE=$SIZE_MB
 
             echo "Clearing old content via Python..."
-            python3 << 'EOF'
+            uv run python3 << 'EOF'
           from services.supabase.llm_requests.clear_old_content import clear_old_content
           result = clear_old_content(retention_days=14)
           if result is None:
@@ -96,7 +96,7 @@ jobs:
             SIZE_BEFORE=$SIZE_MB
 
             echo "Clearing old error logs via Python..."
-            python3 << 'EOF'
+            uv run python3 << 'EOF'
           from services.supabase.usage.clear_old_error_logs import clear_old_error_logs
           result = clear_old_error_logs(retention_days=14)
           if result is None:

--- a/.github/workflows/daily-usage-report.yml
+++ b/.github/workflows/daily-usage-report.yml
@@ -34,4 +34,4 @@ jobs:
         run: uv sync --frozen
 
       - name: Generate and send report
-        run: python3 -m services.slack.daily_usage_report
+        run: uv run python3 -m services.slack.daily_usage_report

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -109,9 +109,9 @@ jobs:
 
         run: |
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            python -m pytest --cov-branch --cov=./ --cov-report=lcov:coverage/lcov.info
+            uv run pytest --cov-branch --cov=./ --cov-report=lcov:coverage/lcov.info
           else
-            python -m pytest
+            uv run pytest
           fi
 
       - name: Check resources on failure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GitAuto"
-version = "1.0.3"
+version = "1.0.4"
 requires-python = ">=3.13"
 dependencies = [
     "annotated-doc==0.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GitAuto"
-version = "1.0.4"
+version = "1.0.5"
 requires-python = ">=3.13"
 dependencies = [
     "annotated-doc==0.0.4",

--- a/services/webhook/utils/get_preferred_model.py
+++ b/services/webhook/utils/get_preferred_model.py
@@ -1,7 +1,6 @@
 from constants.models import (
     DEFAULT_FREE_MODEL,
     DEFAULT_PAID_MODEL,
-    FREE_TIER_MODELS,
     MODEL_ID_BY_VALUE,
     ModelId,
     USER_SELECTABLE_MODELS,
@@ -30,25 +29,15 @@ def get_preferred_model(
         logger.warning("Model %s is not user-selectable, ignoring", preferred)
         preferred = None
 
-    # 2. Free user logic
-    if not is_paid:
-        if not preferred or preferred not in FREE_TIER_MODELS:
-            if preferred:
-                logger.info(
-                    "Free user selected premium model %s, overriding to %s",
-                    preferred,
-                    DEFAULT_FREE_MODEL,
-                )
-            else:
-                logger.info("Free user, no preference, using %s", DEFAULT_FREE_MODEL)
-            return DEFAULT_FREE_MODEL
-        logger.info("Free user, using preferred model %s", preferred)
+    # 2. DB has a valid model set → use it regardless of billing tier
+    if preferred:
+        logger.info("Using DB preferred model %s", preferred)
         return preferred
 
-    # 3. Paid user logic
-    if not preferred:
+    # 3. No preference set → default based on billing tier
+    if is_paid:
         logger.info("Paid user, no preference, using %s", DEFAULT_PAID_MODEL)
         return DEFAULT_PAID_MODEL
 
-    logger.info("Paid user, using preferred model %s", preferred)
-    return preferred
+    logger.info("Free user, no preference, using %s", DEFAULT_FREE_MODEL)
+    return DEFAULT_FREE_MODEL

--- a/services/webhook/utils/test_get_preferred_model.py
+++ b/services/webhook/utils/test_get_preferred_model.py
@@ -151,13 +151,13 @@ def test_free_user_selects_sonnet_4_6():
     assert result == ClaudeModelId.SONNET_4_6
 
 
-# --- Free user with premium models (override to default free) ---
+# --- Free user with premium models (DB setting honored regardless of tier) ---
 
 
-def test_free_user_selects_opus_4_6_overridden():
+def test_free_user_selects_opus_4_6_honored():
     settings = cast(Repositories, {"preferred_model": ClaudeModelId.OPUS_4_6})
     result = get_preferred_model(repo_settings=settings, is_paid=False)
-    assert result == DEFAULT_FREE_MODEL
+    assert result == ClaudeModelId.OPUS_4_6
 
 
 # --- Paid user with each user-selectable model ---
@@ -207,22 +207,14 @@ def test_all_free_tier_models_honored_for_free():
         assert result == model, f"Free user selecting {model} got {result}"
 
 
-# --- Exhaustive: premium-only selectable models are overridden for free users ---
+# --- Exhaustive: all user-selectable models honored for free users (DB overrides tier) ---
 
 
-def test_premium_only_selectable_models_overridden_for_free():
-    premium_selectable = [
-        m for m in USER_SELECTABLE_MODELS if m not in FREE_TIER_MODELS
-    ]
-    assert (
-        len(premium_selectable) > 0
-    ), "Expected at least one premium-only selectable model"
-    for model in premium_selectable:
+def test_all_user_selectable_models_honored_for_free():
+    for model in USER_SELECTABLE_MODELS:
         settings = cast(Repositories, {"preferred_model": model.value})
         result = get_preferred_model(repo_settings=settings, is_paid=False)
-        assert (
-            result == DEFAULT_FREE_MODEL
-        ), f"Free user selecting premium {model} should get {DEFAULT_FREE_MODEL}, got {result}"
+        assert result == model, f"Free user selecting {model} got {result}"
 
 
 # --- Exhaustive: every non-selectable model falls back for both tiers ---

--- a/uv.lock
+++ b/uv.lock
@@ -578,7 +578,7 @@ wheels = [
 
 [[package]]
 name = "gitauto"
-version = "1.0.3"
+version = "1.0.4"
 source = { virtual = "." }
 dependencies = [
     { name = "annotated-doc" },

--- a/uv.lock
+++ b/uv.lock
@@ -578,7 +578,7 @@ wheels = [
 
 [[package]]
 name = "gitauto"
-version = "1.0.4"
+version = "1.0.5"
 source = { virtual = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## Summary
- If `preferred_model` is set in DB for a repository, use it regardless of whether the user is free or paid
- Previously, free users with a premium model set would get overridden to the default free model
- This enables setting specific models per-org (e.g., Opus 4.6 for SpiderPlus) via DB without tier gating
- Removed unused `FREE_TIER_MODELS` import from `get_preferred_model.py`
- Updated all 34 tests to match new behavior

## Social Media Post (GitAuto)

Our model selection was overriding explicit admin choices. If you set Claude Opus for a repo but the org was on free tier, it silently downgraded to Gemma. Now DB settings are respected regardless of billing tier. Admin intent wins.

## Social Media Post (Wes)

Spent time debugging why a repo we explicitly set to Opus kept using Gemma. Turned out our own tier-gating logic was overriding the DB setting. The fix was removing 15 lines of code. Sometimes the best feature work is deletion.