### PR TITLE
Fix SSM SecureString blocking deploys; add CI validation

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,7 +12,6 @@ on:
       - ".github/**"
       - ".gitignore"
       - "Dockerfile"
-      - "infrastructure/**"
       - "CODEOWNERS"
       - "LICENSE"
   # Run tests after merge and save coverage to Supabase as canonical source of truth
@@ -25,7 +24,6 @@ on:
       - ".github/**"
       - ".gitignore"
       - "Dockerfile"
-      - "infrastructure/**"
       - "CODEOWNERS"
       - "LICENSE"
   # Allow manual trigger for debugging
@@ -102,6 +100,11 @@ jobs:
 
           # Stripe credentials
           STRIPE_API_KEY: ${{ secrets.STAGE_STRIPE_API_KEY }}
+
+          # AWS credentials (SSM parameter validation in infrastructure tests)
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-west-1
 
           # Environment variables
           ENV: stage

--- a/infrastructure/test_deploy_lambda.py
+++ b/infrastructure/test_deploy_lambda.py
@@ -1,0 +1,48 @@
+"""Validate SSM parameter types match CloudFormation template expectations.
+
+CloudFormation's {{resolve:ssm:...}} only works with String parameters.
+SecureString parameters cause deployment failures with:
+  'Non-secure ssm prefix was used for secure parameter'
+"""
+
+import re
+from pathlib import Path
+
+import boto3
+import pytest
+
+INFRA_DIR = Path(__file__).parent
+CFN_TEMPLATE = INFRA_DIR / "deploy-lambda.yml"
+SSM_RESOLVE_PATTERN = re.compile(r"\{\{resolve:ssm:(/[^}]+)\}\}")
+AWS_REGION = "us-west-1"
+
+
+def _get_ssm_param_names_from_template():
+    """Extract all SSM parameter names referenced in the CloudFormation template."""
+    content = CFN_TEMPLATE.read_text()
+    return sorted(set(SSM_RESOLVE_PATTERN.findall(content)))
+
+
+@pytest.mark.integration
+def test_ssm_params_are_not_secure_string():
+    """Every {{resolve:ssm:...}} parameter must be String, not SecureString."""
+    param_names = _get_ssm_param_names_from_template()
+    assert param_names, f"No SSM parameters found in {CFN_TEMPLATE}"
+
+    ssm = boto3.client("ssm", region_name=AWS_REGION)
+    # DescribeParameters accepts max 10 filters, but we can paginate by name
+    secure_params: list[str] = []
+    for name in param_names:
+        response = ssm.describe_parameters(
+            ParameterFilters=[{"Key": "Name", "Values": [name]}]
+        )
+        params = response.get("Parameters", [])
+        if not params:
+            pytest.fail(f"SSM parameter {name} not found in {AWS_REGION}")
+        if params[0]["Type"] == "SecureString":
+            secure_params.append(name)
+
+    assert not secure_params, (
+        f"SecureString params can't be resolved by {{{{resolve:ssm:...}}}}. "
+        f"Re-create as String: {secure_params}"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GitAuto"
-version = "1.1.0"
+version = "1.1.1"
 requires-python = ">=3.13"
 dependencies = [
     "annotated-doc==0.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GitAuto"
-version = "1.0.5"
+version = "1.1.0"
 requires-python = ">=3.13"
 dependencies = [
     "annotated-doc==0.0.4",

--- a/scripts/git/pre_commit_hook.sh
+++ b/scripts/git/pre_commit_hook.sh
@@ -11,7 +11,8 @@ CURRENT=$(grep '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
 MAJOR=$(echo "$CURRENT" | cut -d. -f1)
 MINOR=$(echo "$CURRENT" | cut -d. -f2)
 PATCH=$(echo "$CURRENT" | cut -d. -f3)
-if git diff --cached --diff-filter=A --name-only | grep -q .; then
+# Minor bump only for new impl .py files (not tests, scripts, schemas, infra)
+if git diff --cached --diff-filter=A --name-only -- '*.py' | grep -Ev '(^|/)test_|conftest\.py$|^schemas/|^infrastructure/|^scripts/' | grep -q .; then
     NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
 else
     NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"

--- a/uv.lock
+++ b/uv.lock
@@ -578,7 +578,7 @@ wheels = [
 
 [[package]]
 name = "gitauto"
-version = "1.0.5"
+version = "1.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "annotated-doc" },

--- a/uv.lock
+++ b/uv.lock
@@ -578,7 +578,7 @@ wheels = [
 
 [[package]]
 name = "gitauto"
-version = "1.1.0"
+version = "1.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## Summary
- `GOOGLE_AI_API_KEY` was stored as SSM `SecureString`, but CloudFormation's `{{resolve:ssm:...}}` can't resolve `SecureString` into Lambda env vars — causing 3 consecutive deploy failures
- Re-created the parameter as `String` (matching all other params) and redeployed
- Added `infrastructure/test_deploy_lambda.py` to validate all SSM params referenced in the CFN template are `String` type
- Removed `infrastructure/**` from pytest.yml paths-ignore and added AWS creds so the test runs in CI

## Social Media Post (GitAuto)
Three deploys failed silently because one SSM parameter was SecureString instead of String. CloudFormation's resolve syntax doesn't support SecureString for Lambda env vars. Added a test that calls AWS SSM before every deploy to catch type mismatches early.

## Social Media Post (Wes)
Spent time debugging why our new model wasn't being used. Turned out the deploy had been failing for 3 runs because an API key was stored as SecureString in SSM. CloudFormation just rejects it silently. Wrote a 40-line test that checks every SSM param type against the template. Simple but would have saved hours.