### PR TITLE
Fix Google AI 400 error: FunctionResponse.name must be function name, not tool_use_id

### DIFF
--- a/services/google_ai/convert_messages.py
+++ b/services/google_ai/convert_messages.py
@@ -17,6 +17,9 @@ def convert_messages_to_google(messages: list[MessageParam]):
     Anthropic tool_result -> Google FunctionResponse."""
     contents: list[types.Content] = []
 
+    # Map tool_use_id -> function name for FunctionResponse.name (must match FunctionDeclaration.name)
+    tool_id_to_name: dict[str, str] = {}
+
     for msg in messages:
         role = msg["role"]
         raw_content = msg["content"]
@@ -41,6 +44,7 @@ def convert_messages_to_google(messages: list[MessageParam]):
                     args = block["input"]
                     if not isinstance(args, dict):
                         args = {}
+                    tool_id_to_name[block["id"]] = block["name"]
                     parts.append(
                         types.Part(
                             function_call=types.FunctionCall(
@@ -58,12 +62,14 @@ def convert_messages_to_google(messages: list[MessageParam]):
                         content_val = json.dumps(content_val)
                     elif not isinstance(content_val, str):
                         content_val = ""
+                    tool_use_id = block["tool_use_id"]
+                    func_name = tool_id_to_name.get(tool_use_id, tool_use_id)
                     parts.append(
                         types.Part(
                             function_response=types.FunctionResponse(
-                                name=block["tool_use_id"],
+                                name=func_name,
                                 response={"result": content_val},
-                                id=block["tool_use_id"],
+                                id=tool_use_id,
                             )
                         )
                     )

--- a/services/google_ai/test_convert_messages.py
+++ b/services/google_ai/test_convert_messages.py
@@ -69,7 +69,8 @@ def test_convert_real_messages_tool_result():
     assert msg.role == "user"
     assert len(msg.parts) == 1
     fr = msg.parts[0].function_response
-    assert fr.name == "toolu_01UqpdeuMtRAfShXJjZnM1xr"
+    # name must be function name (matching FunctionDeclaration), not tool_use_id
+    assert fr.name == "get_remote_file_content"
     assert fr.id == "toolu_01UqpdeuMtRAfShXJjZnM1xr"
     assert fr.response == {
         "result": "Opened file: 'services/anthropic/test_client.py' with line numbers for your information.\n\n```services/anthropic/test_client.py\n 1:import pytest\n```"
@@ -97,7 +98,7 @@ def test_convert_real_messages_all_tool_use_ids():
 
 
 def test_convert_real_messages_all_tool_result_ids():
-    """All 4 tool_result blocks reference the correct tool_use_ids."""
+    """All 4 tool_result blocks have correct IDs."""
     messages = _load_real_messages()
     result = convert_messages_to_google(messages)
     expected_tool_result_ids = [
@@ -110,8 +111,31 @@ def test_convert_real_messages_all_tool_result_ids():
     for content in result:
         for part in content.parts:
             if part.function_response:
-                actual_ids.append(part.function_response.name)
+                actual_ids.append(part.function_response.id)
     assert actual_ids == expected_tool_result_ids
+
+
+def test_function_response_name_matches_function_declaration_name():
+    """FunctionResponse.name must be the function name, not tool_use_id.
+    Google AI requires FunctionResponse.name to match FunctionDeclaration.name.
+    Using tool_use_id as the name causes 400 INVALID_ARGUMENT on the second API call.
+    Bug: PR 782 failed because FunctionResponse.name was 'vpfs0f3y' instead of
+    'get_local_file_content'."""
+    messages = _load_real_messages()
+    result = convert_messages_to_google(messages)
+    # Expected: function names from the preceding tool_use blocks
+    expected_function_names = [
+        "get_remote_file_content",
+        "get_remote_file_content",
+        "get_remote_file_content",
+        "write_and_commit_file",
+    ]
+    actual_names = []
+    for content in result:
+        for part in content.parts:
+            if part.function_response:
+                actual_names.append(part.function_response.name)
+    assert actual_names == expected_function_names
 
 
 def test_convert_real_messages_write_and_commit_args():


### PR DESCRIPTION
## Summary
- `convert_messages_to_google` was setting `FunctionResponse.name` to `tool_use_id` (e.g., `"vpfs0f3y"`) instead of the function name (e.g., `"get_local_file_content"`)
- Google AI requires `FunctionResponse.name` to match `FunctionDeclaration.name`. First call works (no tool results), second call always fails with `400 INVALID_ARGUMENT`
- Root cause of PR 782 (gitautoai/website) Gemma failure — confirmed via AWS CloudWatch logs

## Fix
Build `tool_id_to_name` mapping as we process `tool_use` blocks, look up function name when converting `tool_result` to `FunctionResponse`

## Test
- Added `test_function_response_name_matches_function_declaration_name` — verified fails before fix, passes after
- Updated existing tests to assert correct `FunctionResponse.name` (function name) and `.id` (tool_use_id) separately

## Social Media Post (GitAuto)
Gemma was failing on every second API call with a 400 error. Turned out we were passing the tool call ID as the function name in Google AI responses. First call worked fine since there were no tool results yet. One-line mapping fix, caught by a test that asserts function names match declarations.

## Social Media Post (Wes)
Spent time tracing why Gemma died mid-conversation. CloudWatch showed 400 INVALID_ARGUMENT on the second call only. The message converter was using the tool call ID where Google expects the function name. Wrote a test using real fixture data that fails on the old code and passes on the fix. Always test with real payloads.