### PR TITLE
Fix deploy: install gcc for pyiceberg C extension on Python 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM public.ecr.aws/lambda/python:3.14
 # Copy to Lambda root(which is specified in Lambda function, usually /var/task/ directory)
 COPY . ${LAMBDA_TASK_ROOT}
 
+# gcc: needed to build C extensions (e.g. pyiceberg) when no prebuilt 3.14 wheel exists
+# git, tar: needed at runtime for cloning repos and extracting archives
+RUN dnf install -y gcc git tar
+
 # Install uv (fast Python package manager) and prod-only dependencies
 # For Amazon Linux 2023-based images (Python 3.14): https://aws.amazon.com/blogs/compute/python-3-14-runtime-now-available-in-aws-lambda/
 # --frozen: use uv.lock exactly, no re-resolution
@@ -14,7 +18,6 @@ COPY . ${LAMBDA_TASK_ROOT}
 RUN pip install uv && \
     uv export --frozen --no-dev --no-hashes | \
     uv pip install --target "${LAMBDA_TASK_ROOT}" -r -
-RUN dnf install -y git tar
 
 # Install Node.js (including npm), n (version manager), and yarn
 # https://github.com/nodesource/distributions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GitAuto"
-version = "1.1.4"
+version = "1.1.5"
 requires-python = ">=3.14"
 dependencies = [
     "annotated-doc==0.0.4",

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "gitauto"
-version = "1.1.4"
+version = "1.1.5"
 source = { virtual = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## Summary
- Install gcc in Docker before pip install — pyiceberg has no prebuilt 3.14 wheel, needs C compilation
- Follows up on PR #2531 (Python 3.14 upgrade) which was merged but deploy failed due to missing gcc

## Social Media Post (GitAuto)
First deploy on Python 3.14 failed. pyiceberg ships a C extension with no prebuilt wheel for 3.14 yet. The Lambda base image dropped gcc. One line fix in the Dockerfile. Always check your deploy after a runtime upgrade.

## Social Media Post (Wes)
Upgraded Python to 3.14 and deploy broke. pyiceberg tried to compile its C extension but gcc wasn't in the Lambda 3.14 image. Added it to the Dockerfile. Lesson: prebuilt wheels lag behind new Python releases. Build tools need to be there as a fallback.