### PR TITLE
Fix runner detection and rename run_jest_test to run_js_ts_test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GitAuto"
-version = "1.1.5"
+version = "1.1.7"
 requires-python = ">=3.14"
 dependencies = [
     "annotated-doc==0.0.4",

--- a/services/agents/test_verify_task_is_complete.py
+++ b/services/agents/test_verify_task_is_complete.py
@@ -7,7 +7,7 @@ import pytest
 
 from services.agents.verify_task_is_complete import verify_task_is_complete
 from services.eslint.run_eslint_fix import ESLintResult
-from services.jest.run_jest_test import JestResult
+from services.jest.run_js_ts_test import JsTsTestResult
 from services.phpunit.run_phpunit_test import PhpunitResult
 from services.prettier.run_prettier_fix import PrettierResult
 from services.pytest.run_pytest_test import PytestResult
@@ -36,11 +36,11 @@ def mock_create_tsc_issue():
 
 @pytest.fixture(autouse=True)
 def mock_jest_test():
-    """Auto-mock run_jest_test for all tests to prevent actual test execution."""
+    """Auto-mock run_js_ts_test for all tests to prevent actual test execution."""
     with patch(
-        "services.agents.verify_task_is_complete.run_jest_test",
+        "services.agents.verify_task_is_complete.run_js_ts_test",
         new_callable=AsyncMock,
-        return_value=JestResult(
+        return_value=JsTsTestResult(
             success=True,
             errors=[],
             error_files=set(),
@@ -518,7 +518,7 @@ async def test_verify_autofixes_ts_with_missing_braces_ignores_py(
 
 
 @pytest.mark.asyncio
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.read_local_file")
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
@@ -532,7 +532,7 @@ async def test_verify_fails_when_jest_tests_fail(
     ]
     mock_get_raw.return_value = "const x = 1;"
     mock_tsc.return_value = TscResult(success=True, errors=[], error_files=set())
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=False,
         errors=["FAIL src/index.test.js", "Expected true to be false"],
         error_files={"src/index.test.js"},
@@ -549,7 +549,7 @@ async def test_verify_fails_when_jest_tests_fail(
 
 
 @pytest.mark.asyncio
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_eslint_fix")
 @patch("services.agents.verify_task_is_complete.run_prettier_fix")
@@ -580,7 +580,7 @@ async def test_verify_error_files_collected_from_eslint_and_jest(
         coverage_errors=None,
     )
     mock_tsc.return_value = TscResult(success=True, errors=[], error_files=set())
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=False,
         errors=["FAIL src/index.test.js"],
         error_files={"src/index.test.js"},
@@ -597,7 +597,7 @@ async def test_verify_error_files_collected_from_eslint_and_jest(
 
 @pytest.mark.asyncio
 @patch("services.agents.verify_task_is_complete.create_tsc_issue")
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
 async def test_baseline_tsc_errors_filtered(
@@ -620,7 +620,7 @@ async def test_baseline_tsc_errors_filtered(
         errors=[pre_existing_error, new_error],
         error_files={"src/passport-oidc.ts", "src/index.ts"},
     )
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=True,
         errors=[],
         error_files=set(),
@@ -646,7 +646,7 @@ async def test_baseline_tsc_errors_filtered(
 
 @pytest.mark.asyncio
 @patch("services.agents.verify_task_is_complete.create_tsc_issue")
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
 async def test_all_tsc_errors_pre_existing_passes(
@@ -662,7 +662,7 @@ async def test_all_tsc_errors_pre_existing_passes(
         errors=[pre_existing],
         error_files={"src/old.ts"},
     )
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=True,
         errors=[],
         error_files=set(),
@@ -683,7 +683,7 @@ async def test_all_tsc_errors_pre_existing_passes(
 
 @pytest.mark.asyncio
 @patch("services.agents.verify_task_is_complete.create_tsc_issue")
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
 async def test_baseline_tsc_errors_in_pr_files_still_reported(
@@ -713,7 +713,7 @@ async def test_baseline_tsc_errors_in_pr_files_still_reported(
         errors=[pr_file_error],
         error_files={"src/models/InProgressPolicy.test.ts"},
     )
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=True,
         errors=[],
         error_files=set(),
@@ -739,7 +739,7 @@ async def test_baseline_tsc_errors_in_pr_files_still_reported(
     return_value="// snapshot content",
 )
 @patch("services.agents.verify_task_is_complete.write_and_commit_file")
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.read_local_file")
 @patch("services.agents.verify_task_is_complete.os.listdir", return_value=[])
@@ -759,7 +759,7 @@ async def test_verify_commits_updated_snapshots(
     ]
     mock_get_raw.return_value = "const x = 1;"
     mock_tsc.return_value = TscResult(success=True, errors=[], error_files=set())
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=True,
         errors=[],
         error_files=set(),
@@ -797,7 +797,7 @@ async def test_verify_commits_updated_snapshots(
 
 @pytest.mark.asyncio
 @patch("services.agents.verify_task_is_complete.create_tsc_issue")
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
 async def test_new_pr_handler_error_in_pr_file_reported(
@@ -818,7 +818,7 @@ async def test_new_pr_handler_error_in_pr_file_reported(
         errors=[pr_file_error],
         error_files={"src/utils.ts"},
     )
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=True,
         errors=[],
         error_files=set(),
@@ -838,7 +838,7 @@ async def test_new_pr_handler_error_in_pr_file_reported(
 
 @pytest.mark.asyncio
 @patch("services.agents.verify_task_is_complete.create_tsc_issue")
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
 async def test_new_pr_handler_preexisting_non_pr_file_error_skipped(
@@ -859,7 +859,7 @@ async def test_new_pr_handler_preexisting_non_pr_file_error_skipped(
         errors=[preexisting],
         error_files={"src/legacy.ts"},
     )
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=True,
         errors=[],
         error_files=set(),
@@ -880,7 +880,7 @@ async def test_new_pr_handler_preexisting_non_pr_file_error_skipped(
 
 @pytest.mark.asyncio
 @patch("services.agents.verify_task_is_complete.create_tsc_issue")
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
 async def test_new_pr_handler_new_non_pr_file_error_reported(
@@ -901,7 +901,7 @@ async def test_new_pr_handler_new_non_pr_file_error_reported(
         errors=[new_error],
         error_files={"src/consumer.ts"},
     )
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=True,
         errors=[],
         error_files=set(),
@@ -924,7 +924,7 @@ async def test_new_pr_handler_new_non_pr_file_error_reported(
 
 @pytest.mark.asyncio
 @patch("services.agents.verify_task_is_complete.create_tsc_issue")
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
 async def test_check_suite_error_in_pr_file_in_baseline_reported(
@@ -954,7 +954,7 @@ async def test_check_suite_error_in_pr_file_in_baseline_reported(
         errors=[pr_file_error],
         error_files={"src/models/Policy.test.ts"},
     )
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=True,
         errors=[],
         error_files=set(),
@@ -976,7 +976,7 @@ async def test_check_suite_error_in_pr_file_in_baseline_reported(
 
 @pytest.mark.asyncio
 @patch("services.agents.verify_task_is_complete.create_tsc_issue")
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
 async def test_check_suite_preexisting_non_pr_file_error_skipped(
@@ -1002,7 +1002,7 @@ async def test_check_suite_preexisting_non_pr_file_error_skipped(
         errors=[preexisting],
         error_files={"src/passport-oidc.ts"},
     )
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=True,
         errors=[],
         error_files=set(),
@@ -1024,7 +1024,7 @@ async def test_check_suite_preexisting_non_pr_file_error_skipped(
 
 @pytest.mark.asyncio
 @patch("services.agents.verify_task_is_complete.create_tsc_issue")
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
 async def test_check_suite_new_non_pr_file_error_reported(
@@ -1050,7 +1050,7 @@ async def test_check_suite_new_non_pr_file_error_reported(
         errors=[new_error],
         error_files={"src/auth.ts"},
     )
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=True,
         errors=[],
         error_files=set(),
@@ -1074,7 +1074,7 @@ async def test_check_suite_new_non_pr_file_error_reported(
 
 @pytest.mark.asyncio
 @patch("services.agents.verify_task_is_complete.create_tsc_issue")
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
 async def test_review_run_error_in_pr_file_in_baseline_reported(
@@ -1098,7 +1098,7 @@ async def test_review_run_error_in_pr_file_in_baseline_reported(
         errors=[pr_file_error],
         error_files={"src/components/Form.tsx"},
     )
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=True,
         errors=[],
         error_files=set(),
@@ -1118,7 +1118,7 @@ async def test_review_run_error_in_pr_file_in_baseline_reported(
 
 @pytest.mark.asyncio
 @patch("services.agents.verify_task_is_complete.create_tsc_issue")
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
 async def test_review_run_preexisting_non_pr_file_error_skipped(
@@ -1138,7 +1138,7 @@ async def test_review_run_preexisting_non_pr_file_error_skipped(
         errors=[preexisting],
         error_files={"src/legacy-auth.ts"},
     )
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=True,
         errors=[],
         error_files=set(),
@@ -1159,7 +1159,7 @@ async def test_review_run_preexisting_non_pr_file_error_skipped(
 
 @pytest.mark.asyncio
 @patch("services.agents.verify_task_is_complete.create_tsc_issue")
-@patch("services.agents.verify_task_is_complete.run_jest_test", new_callable=AsyncMock)
+@patch("services.agents.verify_task_is_complete.run_js_ts_test", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.run_tsc_check", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_complete.get_pull_request_files")
 async def test_review_run_new_non_pr_file_error_reported(
@@ -1179,7 +1179,7 @@ async def test_review_run_new_non_pr_file_error_reported(
         errors=[new_error],
         error_files={"src/validators.ts"},
     )
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=True,
         errors=[],
         error_files=set(),
@@ -1442,9 +1442,9 @@ async def test_quality_gate_runs_when_fail_count_below_3(
 
 @pytest.mark.asyncio
 @patch(
-    "services.agents.verify_task_is_complete.run_jest_test",
+    "services.agents.verify_task_is_complete.run_js_ts_test",
     new_callable=AsyncMock,
-    return_value=JestResult(
+    return_value=JsTsTestResult(
         success=False,
         errors=["Segmentation fault (core dumped)"],
         error_files={"src/test.test.ts"},

--- a/services/agents/test_verify_task_is_ready.py
+++ b/services/agents/test_verify_task_is_ready.py
@@ -6,7 +6,7 @@ import pytest
 
 from services.agents.verify_task_is_ready import verify_task_is_ready
 from services.eslint.run_eslint_fix import ESLintResult
-from services.jest.run_jest_test import JestResult
+from services.jest.run_js_ts_test import JsTsTestResult
 from services.prettier.run_prettier_fix import PrettierResult
 from services.tsc.run_tsc_check import TscResult
 
@@ -286,7 +286,7 @@ async def test_run_tsc_reports_type_errors(
 
 
 @pytest.mark.asyncio
-@patch("services.agents.verify_task_is_ready.run_jest_test")
+@patch("services.agents.verify_task_is_ready.run_js_ts_test")
 @patch("services.agents.verify_task_is_ready.git_commit_and_push")
 @patch("services.agents.verify_task_is_ready.run_eslint_fix", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_ready.run_prettier_fix", new_callable=AsyncMock)
@@ -306,7 +306,7 @@ async def test_run_jest_reports_test_failures(
     mock_eslint.return_value = ESLintResult(
         success=True, content=None, lint_errors=None, coverage_errors=None
     )
-    mock_jest.return_value = JestResult(
+    mock_jest.return_value = JsTsTestResult(
         success=False,
         errors=["FAIL src/index.test.ts", "Expected true to be false"],
         error_files={"src/index.test.ts"},
@@ -326,7 +326,7 @@ async def test_run_jest_reports_test_failures(
 
 
 @pytest.mark.asyncio
-@patch("services.agents.verify_task_is_ready.run_jest_test")
+@patch("services.agents.verify_task_is_ready.run_js_ts_test")
 @patch("services.agents.verify_task_is_ready.git_commit_and_push")
 @patch("services.agents.verify_task_is_ready.run_eslint_fix", new_callable=AsyncMock)
 @patch("services.agents.verify_task_is_ready.run_prettier_fix", new_callable=AsyncMock)
@@ -339,7 +339,7 @@ async def test_impl_files_excluded_from_jest(
     mock_jest,
     create_test_base_args,
 ):
-    """Impl files must NOT be passed to run_jest_test at all.
+    """Impl files must NOT be passed to run_js_ts_test at all.
 
     Previously all JS/TS files were passed as test_file_paths, causing
     jest --findRelatedTests on impl files which OOMed Lambda for MongoDB repos.
@@ -351,7 +351,7 @@ async def test_impl_files_excluded_from_jest(
     mock_eslint.return_value = ESLintResult(
         success=True, content=None, lint_errors=None, coverage_errors=None
     )
-    mock_jest.return_value = JestResult()
+    mock_jest.return_value = JsTsTestResult()
 
     base_args = create_test_base_args()
     await verify_task_is_ready(

--- a/services/agents/verify_task_is_complete.py
+++ b/services/agents/verify_task_is_complete.py
@@ -20,7 +20,7 @@ from services.eslint.get_eslint_config import get_eslint_config
 from services.github.pulls.get_pull_request_files import get_pull_request_files
 from services.types.base_args import BaseArgs
 from services.jest.format_coverage_comment import format_coverage_comment
-from services.jest.run_jest_test import run_jest_test
+from services.jest.run_js_ts_test import run_js_ts_test
 from services.node.detect_node_version import detect_node_version
 from services.node.ensure_jest_timeout_for_ci import ensure_jest_timeout_for_ci
 from services.node.ensure_jest_uses_tsconfig_for_tests import (
@@ -252,14 +252,14 @@ async def verify_task_is_complete(
             )
             create_tsc_issue(base_args=base_args, unrelated_errors=unrelated_tsc_errors)
 
-    # Set by new_pr_handler for schedule PRs so run_jest_test collects coverage using Istanbul instead of V8.
+    # Set by new_pr_handler for schedule PRs so run_js_ts_test collects coverage using Istanbul instead of V8.
     impl_file_to_collect_coverage_from = base_args.get(
         "impl_file_to_collect_coverage_from", ""
     )
 
     # Always pass source files so jest --findRelatedTests can discover dependent tests
     # (e.g., dead code removal from a source file may break tests not in the PR).
-    jest_result = await run_jest_test(
+    jest_result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=js_test_files,
         source_file_paths=[f for f in js_ts_files if is_source_file(f)],

--- a/services/agents/verify_task_is_ready.py
+++ b/services/agents/verify_task_is_ready.py
@@ -4,7 +4,7 @@ from constants.files import PHP_TEST_FILE_EXTENSIONS
 from services.eslint.run_eslint_fix import run_eslint_fix
 from services.git.git_commit_and_push import git_commit_and_push
 from services.types.base_args import BaseArgs
-from services.jest.run_jest_test import run_jest_test
+from services.jest.run_js_ts_test import run_js_ts_test
 from services.phpunit.run_phpunit_test import run_phpunit_test
 from services.prettier.run_prettier_fix import run_prettier_fix
 from services.pytest.run_pytest_test import run_pytest_test
@@ -112,7 +112,7 @@ async def verify_task_is_ready(
         files_with_errors.update(tsc_result.error_files)
 
     js_ts_test_files = [f for f in js_ts_files if is_test_file(f)]
-    jest_result = await run_jest_test(
+    jest_result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=js_ts_test_files,
         source_file_paths=[],

--- a/services/jest/run_js_ts_test.py
+++ b/services/jest/run_js_ts_test.py
@@ -22,7 +22,7 @@ from utils.process.kill_processes_by_name import kill_processes_by_name
 
 
 @dataclass
-class JestResult:
+class JsTsTestResult:
     success: bool = True
     errors: list[str] = field(default_factory=list)
     error_files: set[str] = field(default_factory=set)
@@ -32,10 +32,10 @@ class JestResult:
 
 
 @handle_exceptions(
-    default_return_value=JestResult(),
+    default_return_value=JsTsTestResult(),
     raise_on_error=False,
 )
-async def run_jest_test(
+async def run_js_ts_test(
     *,
     base_args: BaseArgs,
     test_file_paths: list[str],
@@ -44,31 +44,32 @@ async def run_jest_test(
 ):
     if not test_file_paths and not source_file_paths:
         logger.info("test: No test or source files to run")
-        return JestResult()
+        return JsTsTestResult()
 
     clone_dir = base_args.get("clone_dir", "")
     if not clone_dir:
         logger.warning("test: No clone_dir provided, skipping")
-        return JestResult()
+        return JsTsTestResult()
 
-    # Determine runner name for logging (jest vs vitest)
+    # Check which binaries exist
     jest_bin = os.path.join(clone_dir, "node_modules", ".bin", "jest")
     vitest_bin = os.path.join(clone_dir, "node_modules", ".bin", "vitest")
-    if os.path.exists(vitest_bin):
-        runner_name = "vitest"
-    elif os.path.exists(jest_bin):
-        runner_name = "jest"
-    else:
+    if not os.path.exists(vitest_bin) and not os.path.exists(jest_bin):
         logger.info("test: No test runner (jest/vitest) installed locally, skipping")
-        return JestResult()
+        return JsTsTestResult()
 
-    # Build base command
-    test_script_name = get_test_script_name(clone_dir)
+    # Build base command and determine actual runner name. The test script in package.json may invoke a different runner than the binary (e.g. vitest binary exists but "test" script runs jest). runner_name must match the actual runner because CLI flags differ (--related vs --findRelatedTests).
+    test_script_name, test_script_value = get_test_script_name(clone_dir)
     if test_script_name:
         pkg_manager, _, _ = detect_package_manager(clone_dir)
         base_cmd = [pkg_manager, "run", test_script_name, "--"]
+        runner_name = "vitest" if "vitest" in test_script_value else "jest"
+    elif os.path.exists(vitest_bin):
+        runner_name = "vitest"
+        base_cmd = [vitest_bin]
     else:
-        base_cmd = [vitest_bin if runner_name == "vitest" else jest_bin]
+        runner_name = "jest"
+        base_cmd = [jest_bin]
 
     # CI=true disables watch mode and interactive prompts for both jest and vitest
     env = os.environ.copy()
@@ -198,7 +199,7 @@ async def run_jest_test(
 
     if not error_files:
         logger.info("%s: All tests passed", runner_name)
-        return JestResult(
+        return JsTsTestResult(
             success=True,
             errors=[],
             error_files=set(),
@@ -207,7 +208,7 @@ async def run_jest_test(
             coverage=coverage,
         )
 
-    return JestResult(
+    return JsTsTestResult(
         success=False,
         errors=all_errors,
         error_files=error_files,

--- a/services/jest/test_run_js_ts_test.py
+++ b/services/jest/test_run_js_ts_test.py
@@ -4,13 +4,13 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from services.jest.run_jest_test import run_jest_test
+from services.jest.run_js_ts_test import run_js_ts_test
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_success(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_success(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     mock_exists.return_value = True
@@ -21,7 +21,7 @@ async def test_run_jest_test_success(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=[],
@@ -33,13 +33,13 @@ async def test_run_jest_test_success(
 
 
 @pytest.mark.asyncio
-async def test_run_jest_test_no_test_files(create_test_base_args):
+async def test_run_js_ts_test_no_test_files(create_test_base_args):
     base_args = create_test_base_args(
         owner="test",
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.ts", "README.md"],
         source_file_paths=[],
@@ -50,13 +50,13 @@ async def test_run_jest_test_no_test_files(create_test_base_args):
 
 
 @pytest.mark.asyncio
-async def test_run_jest_test_no_clone_dir(create_test_base_args):
+async def test_run_js_ts_test_no_clone_dir(create_test_base_args):
     base_args = create_test_base_args(
         owner="test",
         repo="test",
         clone_dir="",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=[],
@@ -67,8 +67,8 @@ async def test_run_jest_test_no_clone_dir(create_test_base_args):
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_no_runner(mock_exists, create_test_base_args):
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_no_runner(mock_exists, create_test_base_args):
     mock_exists.return_value = False
 
     base_args = create_test_base_args(
@@ -76,7 +76,7 @@ async def test_run_jest_test_no_runner(mock_exists, create_test_base_args):
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=[],
@@ -87,9 +87,9 @@ async def test_run_jest_test_no_runner(mock_exists, create_test_base_args):
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_with_failures(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_with_failures(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     mock_exists.return_value = True
@@ -104,7 +104,7 @@ async def test_run_jest_test_with_failures(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=[],
@@ -116,9 +116,9 @@ async def test_run_jest_test_with_failures(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_detects_updated_snapshots(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_detects_updated_snapshots(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     mock_exists.return_value = True
@@ -135,7 +135,7 @@ async def test_run_jest_test_detects_updated_snapshots(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=[],
@@ -149,9 +149,9 @@ async def test_run_jest_test_detects_updated_snapshots(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_no_snapshots_updated(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_no_snapshots_updated(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     mock_exists.return_value = True
@@ -165,7 +165,7 @@ async def test_run_jest_test_no_snapshots_updated(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=[],
@@ -176,9 +176,9 @@ async def test_run_jest_test_no_snapshots_updated(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_uses_vitest_when_no_jest(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_uses_vitest_when_no_jest(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     def exists_side_effect(path):
@@ -195,7 +195,7 @@ async def test_run_jest_test_uses_vitest_when_no_jest(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=[],
@@ -209,9 +209,9 @@ async def test_run_jest_test_uses_vitest_when_no_jest(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_spec_files(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_spec_files(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     mock_exists.return_value = True
@@ -222,7 +222,7 @@ async def test_run_jest_test_spec_files(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/utils.spec.ts", "src/helper.spec.jsx"],
         source_file_paths=[],
@@ -235,9 +235,9 @@ async def test_run_jest_test_spec_files(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_one_of_three_fails(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_one_of_three_fails(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     mock_exists.return_value = True
@@ -252,7 +252,7 @@ async def test_run_jest_test_one_of_three_fails(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/a.test.ts", "src/b.test.ts", "src/c.test.ts"],
         source_file_paths=[],
@@ -265,9 +265,9 @@ async def test_run_jest_test_one_of_three_fails(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_two_of_three_fail(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_two_of_three_fail(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     mock_exists.return_value = True
@@ -282,7 +282,7 @@ async def test_run_jest_test_two_of_three_fail(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/a.test.ts", "src/b.test.ts", "src/c.test.ts"],
         source_file_paths=[],
@@ -295,9 +295,9 @@ async def test_run_jest_test_two_of_three_fail(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_all_three_fail(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_all_three_fail(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     mock_exists.return_value = True
@@ -312,7 +312,7 @@ async def test_run_jest_test_all_three_fail(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/a.test.ts", "src/b.test.ts", "src/c.test.ts"],
         source_file_paths=[],
@@ -325,9 +325,9 @@ async def test_run_jest_test_all_three_fail(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_type_error_in_output(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_type_error_in_output(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     mock_exists.return_value = True
@@ -342,7 +342,7 @@ async def test_run_jest_test_type_error_in_output(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=[],
@@ -353,9 +353,9 @@ async def test_run_jest_test_type_error_in_output(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_sets_mongoms_download_dir(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_sets_mongoms_download_dir(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     """Verify MONGOMS_DOWNLOAD_DIR points to {clone_dir}/mongodb-binaries for S3 cache extraction."""
@@ -365,7 +365,7 @@ async def test_run_jest_test_sets_mongoms_download_dir(
     base_args = create_test_base_args(
         clone_dir="/tmp/clone",
     )
-    await run_jest_test(
+    await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=[],
@@ -380,7 +380,7 @@ async def test_run_jest_test_sets_mongoms_download_dir(
 
 # Real Jest output captured from foxden-rating-quoting-backend on 2026-03-23.
 # Jest writes PASS/FAIL to stderr, coverage tables to stdout.
-# This was the root cause of a bug where run_jest_test checked only result.stdout.
+# This was the root cause of a bug where run_js_ts_test checked only result.stdout.
 REAL_JEST_PASS_STDERR = (
     "PASS unit src/services/query/getQuote/fetchQuote.test.ts\n"
     "  fetchQuote\n"
@@ -475,10 +475,10 @@ Ran all test suites matching /tests\\/js\\/unit\\/annotation\\/print_dialog.kyud
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.get_test_script_name", return_value=None)
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_captures_full_esm_error(
+@patch("services.jest.run_js_ts_test.get_test_script_name", return_value=(None, ""))
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_captures_full_esm_error(
     mock_exists, mock_subprocess, _mock_get_test_script_name, create_test_base_args
 ):
     """Verify the full error output is kept, including the file path and stack trace."""
@@ -494,7 +494,7 @@ async def test_run_jest_test_captures_full_esm_error(
         repo="SPIDERPLUS-web",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["tests/js/unit/annotation/print_dialog.kyuden.test.js"],
         source_file_paths=[],
@@ -510,12 +510,15 @@ async def test_run_jest_test_captures_full_esm_error(
 
 @pytest.mark.asyncio
 @patch(
-    "services.jest.run_jest_test.detect_package_manager", return_value=("npm", "", "")
+    "services.jest.run_js_ts_test.detect_package_manager", return_value=("npm", "", "")
 )
-@patch("services.jest.run_jest_test.get_test_script_name", return_value="test:unit")
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_uses_test_unit_script(
+@patch(
+    "services.jest.run_js_ts_test.get_test_script_name",
+    return_value=("test:unit", "jest --selectProjects unit"),
+)
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_uses_test_unit_script(
     mock_exists,
     mock_subprocess,
     _mock_get_test_script_name,
@@ -534,7 +537,7 @@ async def test_run_jest_test_uses_test_unit_script(
         new_branch="feature",
         token="token",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["tests/js/unit/annotation/print_dialog.kyuden.test.js"],
         source_file_paths=[],
@@ -549,9 +552,9 @@ async def test_run_jest_test_uses_test_unit_script(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_exit_code_1_all_pass_in_stderr_treated_as_success(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_exit_code_1_all_pass_in_stderr_treated_as_success(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     """Real Jest output: PASS goes to stderr, not stdout (captured from
@@ -569,7 +572,7 @@ async def test_run_jest_test_exit_code_1_all_pass_in_stderr_treated_as_success(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/services/query/getQuote/fetchQuote.test.ts"],
         source_file_paths=[],
@@ -581,9 +584,9 @@ async def test_run_jest_test_exit_code_1_all_pass_in_stderr_treated_as_success(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_forcexit_pass_in_stderr_treated_as_success(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_forcexit_pass_in_stderr_treated_as_success(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     """Real Jest --forceExit output: tests pass but exit code 1 because of
@@ -601,7 +604,7 @@ async def test_run_jest_test_forcexit_pass_in_stderr_treated_as_success(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["test/testing/foxden_quoting/fetchQuote.test.ts"],
         source_file_paths=[],
@@ -613,9 +616,9 @@ async def test_run_jest_test_forcexit_pass_in_stderr_treated_as_success(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_real_fail_in_stderr_treated_as_failure(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_real_fail_in_stderr_treated_as_failure(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     """Real Jest FAIL output (captured 2026-03-23): FAIL goes to stderr.
@@ -632,7 +635,7 @@ async def test_run_jest_test_real_fail_in_stderr_treated_as_failure(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/fail_test.test.ts"],
         source_file_paths=[],
@@ -644,10 +647,10 @@ async def test_run_jest_test_real_fail_in_stderr_treated_as_failure(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.kill_processes_by_name")
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_kills_mongod_before_tests(
+@patch("services.jest.run_js_ts_test.kill_processes_by_name")
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_kills_mongod_before_tests(
     mock_exists, mock_subprocess, mock_kill, create_test_base_args
 ):
     """Verify kill_processes_by_name('mongod') is called before running tests."""
@@ -659,7 +662,7 @@ async def test_run_jest_test_kills_mongod_before_tests(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    await run_jest_test(
+    await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=[],
@@ -670,9 +673,9 @@ async def test_run_jest_test_kills_mongod_before_tests(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_includes_force_exit(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_includes_force_exit(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     """Verify --forceExit is in the jest command to prevent hangs from
@@ -685,7 +688,7 @@ async def test_run_jest_test_includes_force_exit(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    await run_jest_test(
+    await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=[],
@@ -698,9 +701,9 @@ async def test_run_jest_test_includes_force_exit(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_find_related_tests_with_only_test_files(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_find_related_tests_with_only_test_files(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     """--findRelatedTests with only test files (no source files) should work.
@@ -713,7 +716,7 @@ async def test_run_jest_test_find_related_tests_with_only_test_files(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=["src/index.test.ts"],
@@ -727,9 +730,9 @@ async def test_run_jest_test_find_related_tests_with_only_test_files(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_find_related_tests_with_both(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_find_related_tests_with_both(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     """When both test files and source files are provided, --findRelatedTests
@@ -743,7 +746,7 @@ async def test_run_jest_test_find_related_tests_with_both(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=["src/utils.ts"],
@@ -758,9 +761,9 @@ async def test_run_jest_test_find_related_tests_with_both(
 
 
 @pytest.mark.asyncio
-@patch("services.jest.run_jest_test.subprocess.run")
-@patch("services.jest.run_jest_test.os.path.exists")
-async def test_run_jest_test_always_uses_find_related_tests(
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_always_uses_find_related_tests(
     mock_exists, mock_subprocess, create_test_base_args
 ):
     """--findRelatedTests is always used, even when no source files are provided."""
@@ -772,7 +775,7 @@ async def test_run_jest_test_always_uses_find_related_tests(
         repo="test",
         clone_dir="/tmp/clone",
     )
-    result = await run_jest_test(
+    result = await run_js_ts_test(
         base_args=base_args,
         test_file_paths=["src/index.test.ts"],
         source_file_paths=[],
@@ -783,3 +786,87 @@ async def test_run_jest_test_always_uses_find_related_tests(
     cmd = mock_subprocess.call_args_list[0][0][0]
     assert "--findRelatedTests" in cmd
     assert "src/index.test.ts" in cmd
+
+
+@pytest.mark.asyncio
+@patch(
+    "services.jest.run_js_ts_test.detect_package_manager", return_value=("npm", "", "")
+)
+@patch(
+    "services.jest.run_js_ts_test.get_test_script_name",
+    return_value=("test", "jest"),
+)
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_vitest_binary_but_jest_script_uses_find_related_tests(
+    mock_exists,
+    mock_subprocess,
+    _mock_get_test_script_name,
+    _mock_detect_pm,
+    create_test_base_args,
+):
+    """Bug fix from gitautoai/website: "test": "jest" but both jest AND vitest
+    binaries exist in node_modules/.bin/. Runner detection must use the script
+    value, not binary existence. Should use --findRelatedTests (jest), not --related (vitest).
+    """
+    mock_exists.return_value = True
+    mock_subprocess.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    base_args = create_test_base_args(
+        owner="test",
+        repo="test",
+        clone_dir="/tmp/clone",
+    )
+    result = await run_js_ts_test(
+        base_args=base_args,
+        test_file_paths=["src/index.test.ts"],
+        source_file_paths=[],
+        impl_file_to_collect_coverage_from="",
+    )
+    assert result.success is True
+    assert result.runner_name == "jest"
+
+    cmd = mock_subprocess.call_args_list[0][0][0]
+    assert "--findRelatedTests" in cmd
+    assert "--related" not in cmd
+
+
+@pytest.mark.asyncio
+@patch(
+    "services.jest.run_js_ts_test.detect_package_manager", return_value=("npm", "", "")
+)
+@patch(
+    "services.jest.run_js_ts_test.get_test_script_name",
+    return_value=("test", "vitest run"),
+)
+@patch("services.jest.run_js_ts_test.subprocess.run")
+@patch("services.jest.run_js_ts_test.os.path.exists")
+async def test_run_js_ts_test_jest_binary_but_vitest_script_uses_related(
+    mock_exists,
+    mock_subprocess,
+    _mock_get_test_script_name,
+    _mock_detect_pm,
+    create_test_base_args,
+):
+    """Inverse case from ghostwriter: "test": "vitest run" but jest binary also
+    exists. Should use --related (vitest flag), not --findRelatedTests (jest flag)."""
+    mock_exists.return_value = True
+    mock_subprocess.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    base_args = create_test_base_args(
+        owner="test",
+        repo="test",
+        clone_dir="/tmp/clone",
+    )
+    result = await run_js_ts_test(
+        base_args=base_args,
+        test_file_paths=["src/index.test.ts"],
+        source_file_paths=[],
+        impl_file_to_collect_coverage_from="",
+    )
+    assert result.success is True
+    assert result.runner_name == "vitest"
+
+    cmd = mock_subprocess.call_args_list[0][0][0]
+    assert "--related" in cmd
+    assert "--findRelatedTests" not in cmd

--- a/services/node/get_test_script_name.py
+++ b/services/node/get_test_script_name.py
@@ -5,33 +5,36 @@ from config import UTF8
 from utils.error.handle_exceptions import handle_exceptions
 
 
-@handle_exceptions(default_return_value=None, raise_on_error=False)
+@handle_exceptions(default_return_value=(None, ""), raise_on_error=False)
 def get_test_script_name(clone_dir: str):
-    """Get the best test script name from package.json, or None if not found.
+    """Get the best test script name and value from package.json.
 
+    Returns (script_name, script_value) or (None, "") if not found.
     Prefers "test:unit" over "test" because we only run unit tests.
+    The script_value is needed to determine the actual runner (jest vs vitest)
+    because the installed binary may differ from what the script invokes.
     """
     package_json_path = os.path.join(clone_dir, "package.json")
     if not os.path.exists(package_json_path):
-        return None
+        return None, ""
 
     with open(package_json_path, encoding=UTF8) as f:
         package_json = json.load(f)
 
     if not isinstance(package_json, dict):
-        return None
+        return None, ""
 
     scripts = package_json.get("scripts", {})
     if not isinstance(scripts, dict):
-        return None
+        return None, ""
 
     # Prefer "test:unit" because we only run unit tests
     test_unit = scripts.get("test:unit")
     if isinstance(test_unit, str) and test_unit:
-        return "test:unit"
+        return "test:unit", test_unit
 
     test_script = scripts.get("test")
     if isinstance(test_script, str) and test_script:
-        return "test"
+        return "test", test_script
 
-    return None
+    return None, ""

--- a/services/node/test_get_test_script_name.py
+++ b/services/node/test_get_test_script_name.py
@@ -5,20 +5,95 @@ import tempfile
 from config import UTF8
 from services.node.get_test_script_name import get_test_script_name
 
+# Real scripts sections from customer/local repos, used as test fixtures.
+# gitautoai/website: "test" uses jest, but both jest AND vitest binaries exist (the bug scenario)
+WEBSITE_SCRIPTS = {
+    "dev": "npm run kill-port && npm run types:generate && (npm run stripe &) && next dev -p 4000",
+    "dev:ci": "next dev -p 4000 & npm run stripe",
+    "kill-port": "lsof -ti:4000 | xargs kill -9 2>/dev/null || true",
+    "stripe": "stripe listen --events payment_intent.succeeded --forward-to localhost:4000/api/stripe/webhook",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint .",
+    "types:generate": "supabase gen types typescript --project-id dkrxtcbaqzrodvsagwwn > types/supabase.ts && prettier --write types/supabase.ts",
+    "test": "jest",
+    "test:integration": "jest --config jest.integration.config.ts",
+    "test:watch": "jest --watch",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
+}
 
-def test_get_test_script_name_returns_script_name():
+# ghostwriter: vitest-based project
+GHOSTWRITER_SCRIPTS = {
+    "lint": "tsc --noEmit",
+    "build": "tsc",
+    "generate-drafts": "tsx src/lambda/generateDrafts.ts",
+    "dev": "tsx watch src/lambda/generateDrafts.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+}
+
+# posthog: has both "test" and "test:unit", prefers "test:unit"
+POSTHOG_SCRIPTS = {
+    "copy-scripts": "mkdir -p frontend/dist/ && ./bin/copy-posthog-js",
+    "test": "pnpm test:unit && pnpm test:visual",
+    "test:unit": "jest --testPathPattern=frontend/",
+    "jest": "jest",
+    "test:visual": "rm -rf frontend/__snapshots__/__failures__/ && docker compose -f docker-compose.playwright.yml run --rm -it --build playwright pnpm test:visual:update --url http://host.docker.internal:6006",
+    "start": 'concurrently -n ESBUILD,TYPEGEN -c yellow,green "pnpm start-http" "pnpm run typegen:watch"',
+    "build": "pnpm copy-scripts && pnpm build:esbuild",
+}
+
+# circle-ci-test: jest with NODE_OPTIONS for ESM support
+CIRCLE_CI_TEST_SCRIPTS = {
+    "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
+    "test:watch": "NODE_OPTIONS='--experimental-vm-modules' jest --watch",
+    "test:coverage": "NODE_OPTIONS='--experimental-vm-modules' jest --coverage",
+    "test:ci": "NODE_OPTIONS='--experimental-vm-modules' jest --ci --coverage --maxWorkers=2",
+    "test:report": "NODE_OPTIONS='--experimental-vm-modules' jest --reporters=jest-html-reporters --reporters=jest-junit",
+}
+
+
+def test_get_test_script_name_website_jest():
+    # gitautoai/website: "test": "jest" — the repo where the --related vs --findRelatedTests bug was found
     with tempfile.TemporaryDirectory() as tmpdir:
-        package_json = {"scripts": {"test": "jest"}}
         with open(os.path.join(tmpdir, "package.json"), "w", encoding=UTF8) as f:
-            json.dump(package_json, f)
+            json.dump({"scripts": WEBSITE_SCRIPTS}, f)
         result = get_test_script_name(tmpdir)
-        assert result == "test"
+        assert result == ("test", "jest")
+
+
+def test_get_test_script_name_ghostwriter_vitest():
+    # ghostwriter: "test": "vitest run"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "package.json"), "w", encoding=UTF8) as f:
+            json.dump({"scripts": GHOSTWRITER_SCRIPTS}, f)
+        result = get_test_script_name(tmpdir)
+        assert result == ("test", "vitest run")
+
+
+def test_get_test_script_name_posthog_prefers_test_unit():
+    # posthog: has both "test" and "test:unit", should prefer "test:unit"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "package.json"), "w", encoding=UTF8) as f:
+            json.dump({"scripts": POSTHOG_SCRIPTS}, f)
+        result = get_test_script_name(tmpdir)
+        assert result == ("test:unit", "jest --testPathPattern=frontend/")
+
+
+def test_get_test_script_name_circle_ci_test_jest_with_node_options():
+    # circle-ci-test: jest invoked with NODE_OPTIONS for ESM
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "package.json"), "w", encoding=UTF8) as f:
+            json.dump({"scripts": CIRCLE_CI_TEST_SCRIPTS}, f)
+        result = get_test_script_name(tmpdir)
+        assert result == ("test", "NODE_OPTIONS='--experimental-vm-modules' jest")
 
 
 def test_get_test_script_name_returns_none_when_no_package_json():
     with tempfile.TemporaryDirectory() as tmpdir:
         result = get_test_script_name(tmpdir)
-        assert result is None
+        assert result == (None, "")
 
 
 def test_get_test_script_name_returns_none_when_no_scripts():
@@ -27,7 +102,7 @@ def test_get_test_script_name_returns_none_when_no_scripts():
         with open(os.path.join(tmpdir, "package.json"), "w", encoding=UTF8) as f:
             json.dump(package_json, f)
         result = get_test_script_name(tmpdir)
-        assert result is None
+        assert result == (None, "")
 
 
 def test_get_test_script_name_returns_none_when_no_test_script():
@@ -36,7 +111,7 @@ def test_get_test_script_name_returns_none_when_no_test_script():
         with open(os.path.join(tmpdir, "package.json"), "w", encoding=UTF8) as f:
             json.dump(package_json, f)
         result = get_test_script_name(tmpdir)
-        assert result is None
+        assert result == (None, "")
 
 
 def test_get_test_script_name_returns_none_for_empty_test_script():
@@ -45,7 +120,7 @@ def test_get_test_script_name_returns_none_for_empty_test_script():
         with open(os.path.join(tmpdir, "package.json"), "w", encoding=UTF8) as f:
             json.dump(package_json, f)
         result = get_test_script_name(tmpdir)
-        assert result is None
+        assert result == (None, "")
 
 
 def test_get_test_script_name_returns_none_for_invalid_package_json():
@@ -54,7 +129,7 @@ def test_get_test_script_name_returns_none_for_invalid_package_json():
         with open(os.path.join(tmpdir, "package.json"), "w", encoding=UTF8) as f:
             json.dump(["invalid"], f)
         result = get_test_script_name(tmpdir)
-        assert result is None
+        assert result == (None, "")
 
 
 def test_get_test_script_name_returns_none_for_invalid_scripts():
@@ -64,7 +139,7 @@ def test_get_test_script_name_returns_none_for_invalid_scripts():
         with open(os.path.join(tmpdir, "package.json"), "w", encoding=UTF8) as f:
             json.dump(package_json, f)
         result = get_test_script_name(tmpdir)
-        assert result is None
+        assert result == (None, "")
 
 
 def test_get_test_script_name_returns_none_for_non_string_test():
@@ -74,30 +149,7 @@ def test_get_test_script_name_returns_none_for_non_string_test():
         with open(os.path.join(tmpdir, "package.json"), "w", encoding=UTF8) as f:
             json.dump(package_json, f)
         result = get_test_script_name(tmpdir)
-        assert result is None
-
-
-def test_get_test_script_name_prefers_test_unit_over_test():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        package_json = {
-            "scripts": {
-                "test": "jest",
-                "test:unit": "NODE_OPTIONS='--experimental-vm-modules' npx jest --selectProjects unit",
-            }
-        }
-        with open(os.path.join(tmpdir, "package.json"), "w", encoding=UTF8) as f:
-            json.dump(package_json, f)
-        result = get_test_script_name(tmpdir)
-        assert result == "test:unit"
-
-
-def test_get_test_script_name_falls_back_to_test_when_no_test_unit():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        package_json = {"scripts": {"test": "jest"}}
-        with open(os.path.join(tmpdir, "package.json"), "w", encoding=UTF8) as f:
-            json.dump(package_json, f)
-        result = get_test_script_name(tmpdir)
-        assert result == "test"
+        assert result == (None, "")
 
 
 def test_get_test_script_name_ignores_empty_test_unit():
@@ -106,4 +158,4 @@ def test_get_test_script_name_ignores_empty_test_unit():
         with open(os.path.join(tmpdir, "package.json"), "w", encoding=UTF8) as f:
             json.dump(package_json, f)
         result = get_test_script_name(tmpdir)
-        assert result == "test"
+        assert result == ("test", "jest")

--- a/utils/files/fixtures/gitauto.txt
+++ b/utils/files/fixtures/gitauto.txt
@@ -424,11 +424,11 @@ services/jest/fixtures/coverage-final.json
 services/jest/format_coverage_comment.py
 services/jest/get_mongoms_distro.py
 services/jest/parse_coverage_json.py
-services/jest/run_jest_test.py
+services/jest/run_js_ts_test.py
 services/jest/test_format_coverage_comment.py
 services/jest/test_get_mongoms_distro.py
 services/jest/test_parse_coverage_json.py
-services/jest/test_run_jest_test.py
+services/jest/test_run_js_ts_test.py
 services/jest/test_validate_istanbul_file_data.py
 services/jest/validate_istanbul_file_data.py
 services/model_selection.py

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "gitauto"
-version = "1.1.5"
+version = "1.1.7"
 source = { virtual = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## Summary

- **Bug fix**: Runner detection (jest vs vitest) was based on which binary existed in `node_modules/.bin/`. When both exist (e.g., gitautoai/website has `"test": "jest"` but vitest binary also installed), the wrong CLI flag was used (`--related` instead of `--findRelatedTests`). Now reads the script value from `get_test_script_name` to determine the actual runner.
- **Rename**: `run_jest_test` → `run_js_ts_test` and `JestResult` → `JsTsTestResult` since the function handles both jest and vitest for JS/TS files.
- **`get_test_script_name`** now returns `(name, value)` tuple so callers can inspect the script value to determine runner.
- **Test data** updated to use real `package.json` scripts from website, ghostwriter, posthog, and circle-ci-test repos.

## Social Media Post (GitAuto)

Our test runner had a silent bug. When both jest and vitest binaries existed in a repo, it picked vitest by default and passed `--related` instead of jest's `--findRelatedTests`. Tests ran fine locally but failed on repos like our own website where `package.json` says `"test": "jest"`. Now we read the actual script value instead of guessing from binaries.
