### PR TITLE
Upgrade GitHub Actions to v6 for Node.js 24

### DIFF
--- a/.github/workflows/check-billing-consistency.yml
+++ b/.github/workflows/check-billing-consistency.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/check-database-size.yml
+++ b/.github/workflows/check-database-size.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/daily-usage-report.yml
+++ b/.github/workflows/daily-usage-report.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -28,10 +28,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4 # https://github.com/actions/checkout
+        uses: actions/checkout@v6 # https://github.com/actions/checkout
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4 # https://github.com/aws-actions/configure-aws-credentials
+        uses: aws-actions/configure-aws-credentials@v6 # https://github.com/aws-actions/configure-aws-credentials
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -49,10 +49,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 

--- a/services/github/workflows/templates/pytest.yml
+++ b/services/github/workflows/templates/pytest.yml
@@ -33,10 +33,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           # Match your project's Python version
           python-version: '3.14'


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout` v4 → v6, `actions/setup-python` v5 → v6, `actions/setup-node` v4 → v6, `aws-actions/configure-aws-credentials` v4 → v6
- Node.js 20 actions deprecated June 2, 2026; removed September 16, 2026
- 8 workflow files updated

## Social Media Post (GitAuto)

GitHub is deprecating Node.js 20 actions in June 2026. Updated all our workflows to v6 across both repos before the deadline hits. Small maintenance task that prevents surprises later.

## Social Media Post (Wes)

GitHub Actions deprecating Node.js 20 this June. Updated checkout, setup-python, setup-node, and configure-aws-credentials to v6 across both repos. The kind of thing you want to do before the deadline emails start.