### PR TITLE
Fix Python 3.14 asyncio event loop crash in Mangum webhook handler

### DIFF
--- a/main.py
+++ b/main.py
@@ -113,6 +113,7 @@ def handler(event, context):
     try:
         asyncio.get_event_loop()
     except RuntimeError:
+        logger.info("No event loop found, creating one for Mangum")
         asyncio.set_event_loop(asyncio.new_event_loop())
 
     # mangum_handler converts requests from API Gateway to FastAPI routing system

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 # Standard imports
+import asyncio
 import json
 from typing import Any, cast
 import urllib.parse
@@ -107,6 +108,12 @@ def handler(event, context):
                 thread_ts,
             )
         return None
+
+    # Python 3.14 removed implicit event loop creation in asyncio.get_event_loop(), which Mangum's HTTPCycle.__call__ still uses. Ensure one exists before each request.
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
 
     # mangum_handler converts requests from API Gateway to FastAPI routing system
     return mangum_handler(event=event, context=context)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GitAuto"
-version = "1.1.7"
+version = "1.1.8"
 requires-python = ">=3.14"
 dependencies = [
     "annotated-doc==0.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GitAuto"
-version = "1.1.8"
+version = "1.1.9"
 requires-python = ">=3.14"
 dependencies = [
     "annotated-doc==0.0.4",

--- a/test_main.py
+++ b/test_main.py
@@ -819,6 +819,30 @@ class TestLogStatements:
         assert str(call_args[0][1]) == "JSON parsing error"
 
 
+class TestEventLoopSetup:
+    @patch("main.mangum_handler")
+    def test_handler_creates_event_loop_when_missing(self, mock_mangum_handler):
+        """Python 3.14 removed implicit event loop creation in asyncio.get_event_loop().
+        Verify handler creates one before calling mangum_handler."""
+        event = {"key": "value"}
+        context = {"context": "data"}
+        mock_mangum_handler.return_value = {"status": "success"}
+
+        # Remove the current event loop to simulate Python 3.14 behavior
+        policy = asyncio.get_event_loop_policy()
+        policy.set_event_loop(None)  # type: ignore[arg-type]
+
+        # handler() should NOT raise RuntimeError — it ensures a loop exists
+        result = handler(event=event, context=context)
+
+        mock_mangum_handler.assert_called_with(event=event, context=context)
+        assert result == {"status": "success"}
+
+        # Verify an event loop now exists
+        loop = asyncio.get_event_loop()
+        assert loop is not None
+
+
 class TestModuleImports:
     def test_required_imports_available(self):
         """Test that all required modules and functions are properly imported."""

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "gitauto"
-version = "1.1.7"
+version = "1.1.8"
 source = { virtual = "." }
 dependencies = [
     { name = "annotated-doc" },

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "gitauto"
-version = "1.1.8"
+version = "1.1.9"
 source = { virtual = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## Summary
- Python 3.14 removed implicit event loop creation in `asyncio.get_event_loop()`, causing Mangum's `HTTPCycle.__call__` to crash with `RuntimeError` on every webhook invocation
- 3027 out of 6462 CloudWatch log events in the last 2 hours were this crash — all webhook processing was broken
- Schedule triggers (EventBridge) worked because they bypass Mangum; webhook events (GitHub PR opened, push, etc.) go through Mangum and crashed
- Fix: ensure an event loop exists in `handler()` before calling `mangum_handler()`, same pattern Mangum uses at init time but executed at request time
- Even Mangum 0.21.0 (latest) has the same bug — upgrading won't help
