### PR TITLE
Fix Python 3.14 event loop crash and tool dispatch for None args

### DIFF
--- a/.claude/hooks/no-skip-hooks.sh
+++ b/.claude/hooks/no-skip-hooks.sh
@@ -3,14 +3,18 @@
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 
-# Strip everything after -m to avoid matching flag text inside commit messages
-CMD_FLAGS=$(echo "$CMD" | sed 's/ -m .*//; s/ -m".*//; s/ -m$//')
-if echo "$CMD_FLAGS" | grep -qE "git commit.*--no-verify|--no-verify.*git commit"; then
-  jq -n '{
-    "decision": "block",
-    "reason": "BLOCKED: --no-verify is not allowed. Commit without it."
-  }'
-  exit 2
+# Extract only the git commit portion (before any && or ; chain), then strip the message
+COMMIT_CMD=$(echo "$CMD" | grep -oE '(^|&&|;)\s*git commit[^&;]*' | head -1)
+if [ -n "$COMMIT_CMD" ]; then
+  # Strip commit message to avoid false positives
+  FLAGS=$(echo "$COMMIT_CMD" | sed 's/ -m .*//; s/ -m".*//; s/ -m$//')
+  if echo "$FLAGS" | grep -q -- "--no-verify"; then
+    jq -n '{
+      "decision": "block",
+      "reason": "BLOCKED: --no-verify is not allowed. Commit without it."
+    }'
+    exit 2
+  fi
 fi
 
 exit 0

--- a/.claude/hooks/no-skip-hooks.sh
+++ b/.claude/hooks/no-skip-hooks.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Bash hook: Block --no-verify on git commit
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Strip everything after -m to avoid matching flag text inside commit messages
+CMD_FLAGS=$(echo "$CMD" | sed 's/ -m .*//; s/ -m".*//; s/ -m$//')
+if echo "$CMD_FLAGS" | grep -qE "git commit.*--no-verify|--no-verify.*git commit"; then
+  jq -n '{
+    "decision": "block",
+    "reason": "BLOCKED: --no-verify is not allowed. Commit without it."
+  }'
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Users/rwest/Repositories/gitauto/.claude/hooks/no-skip-hooks.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GitAuto"
-version = "1.1.11"
+version = "1.1.12"
 requires-python = ">=3.14"
 dependencies = [
     "annotated-doc==0.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GitAuto"
-version = "1.1.10"
+version = "1.1.11"
 requires-python = ">=3.14"
 dependencies = [
     "annotated-doc==0.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GitAuto"
-version = "1.1.9"
+version = "1.1.10"
 requires-python = ">=3.14"
 dependencies = [
     "annotated-doc==0.0.4",

--- a/scripts/lint/check_test_files.sh
+++ b/scripts/lint/check_test_files.sh
@@ -38,7 +38,6 @@ if [ -n "$STAGED_IMPL_NEW" ]; then
 fi
 
 # Check 2: Changed impl files with existing test files must have test also staged
-# Exception: if the test file has no unstaged changes (identical to HEAD), it's fine
 if [ -n "$STAGED_IMPL_MODIFIED" ]; then
     for file in $STAGED_IMPL_MODIFIED; do
         dir=$(dirname "$file")
@@ -46,11 +45,8 @@ if [ -n "$STAGED_IMPL_MODIFIED" ]; then
         test_file="$dir/test_$base"
         if [ -f "$test_file" ]; then
             if ! echo "$STAGED_ALL" | grep -qF "$test_file"; then
-                # Allow if test file is unchanged from HEAD (e.g. import-only refactors)
-                if ! git diff --quiet HEAD -- "$test_file" 2>/dev/null; then
-                    echo "TEST NOT UPDATED: $file changed but $test_file is not staged"
-                    FAIL=1
-                fi
+                echo "TEST NOT STAGED: $file changed but $test_file is not staged"
+                FAIL=1
             fi
         fi
     done

--- a/services/chat_with_agent.py
+++ b/services/chat_with_agent.py
@@ -246,6 +246,11 @@ async def chat_with_agent(
                 tool_result = tools_to_call[tool_name](
                     **tool_args, base_args=base_args, messages=messages
                 )
+            else:
+                # Model passed None or non-dict args (e.g. verify_task_is_complete with no args)
+                tool_result = tools_to_call[tool_name](
+                    base_args=base_args, messages=messages
+                )
             if inspect.iscoroutine(tool_result):
                 tool_result = await tool_result
 

--- a/services/test_chat_with_agent.py
+++ b/services/test_chat_with_agent.py
@@ -446,6 +446,56 @@ async def test_verify_task_is_complete_without_pr_changes_returns_is_completed_f
 
 @pytest.mark.asyncio
 @patch("services.chat_with_agent.chat_with_model")
+@patch("services.agents.verify_task_is_complete.get_pull_request_files")
+@patch("services.chat_with_agent.update_comment")
+async def test_verify_task_is_complete_with_none_args_still_executes(
+    _mock_update_comment, mock_get_pr_files, mock_chat_with_model, create_test_base_args
+):
+    """PR 786: Gemma 4 31B called verify_task_is_complete with args=None instead of {}.
+    isinstance(None, dict) is False, so the tool was silently skipped and returned None.
+    Gemma then entered a dead loop returning empty responses for 20 iterations."""
+    mock_get_pr_files.return_value = [{"filename": "test.py", "status": "modified"}]
+    mock_chat_with_model.return_value = (
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "test_id",
+                    "name": "verify_task_is_complete",
+                    "input": {},
+                }
+            ],
+        },
+        [ToolCall(id="test_id", name="verify_task_is_complete", args=None)],
+        15,
+        10,
+    )
+
+    base_args = create_test_base_args(
+        model_id=GoogleModelId.GEMMA_4_31B,
+        owner="test-owner",
+        repo="test-repo",
+        pr_number=123,
+        token="test-token",
+    )
+
+    result = await chat_with_agent(
+        messages=[{"role": "user", "content": "test"}],
+        system_message="test system message",
+        base_args=base_args,
+        tools=[],
+        usage_id=123,
+        model_id=GoogleModelId.GEMMA_4_31B,
+    )
+
+    # verify_task_is_complete was called (not skipped), so is_completed should be True
+    assert result.is_completed is True
+    mock_get_pr_files.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("services.chat_with_agent.chat_with_model")
 async def test_regular_tool_returns_is_completed_false(
     mock_chat_with_model, create_test_base_args
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "gitauto"
-version = "1.1.10"
+version = "1.1.11"
 source = { virtual = "." }
 dependencies = [
     { name = "annotated-doc" },

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "gitauto"
-version = "1.1.11"
+version = "1.1.12"
 source = { virtual = "." }
 dependencies = [
     { name = "annotated-doc" },

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "gitauto"
-version = "1.1.9"
+version = "1.1.10"
 source = { virtual = "." }
 dependencies = [
     { name = "annotated-doc" },


### PR DESCRIPTION
## Summary
- Fix Mangum crash on Python 3.14: `asyncio.get_event_loop()` no longer creates implicit event loops, causing every webhook invocation to fail with RuntimeError. Ensure one exists before calling mangum_handler.
- Fix tool dispatch silently skipping execution when model passes `None` args (e.g. `verify_task_is_complete`). Gemma called the tool with `args=None` instead of `args={}`, the dispatcher's `isinstance(tool_args, dict)` check skipped it entirely, and the model entered a dead loop returning empty responses for 20 iterations.
- Add Claude Code hook to block `--no-verify` on git commit

## Social Media Post (GitAuto)
Two silent failures in one deploy. Python 3.14 removed implicit event loop creation, crashing every webhook through our ASGI adapter. And when a model passed None instead of empty dict as tool args, the dispatcher skipped execution entirely. The model got a None result back, went blank, and burned 20 iterations doing nothing. Both were one-line-level fixes hidden behind hours of log reading.

## Social Media Post (Wes)
Spent an hour reading CloudWatch logs for a bug that was five lines to fix. Python 3.14 changed asyncio.get_event_loop() to raise instead of creating a loop. Our webhook adapter used the old pattern. Schedule triggers worked fine since they bypass the adapter. Then found a second bug: when the model passes None instead of {} as tool args, we silently skip the tool call. The model gets None back and gives up. Two invisible failures, two small fixes.